### PR TITLE
Update .copywrite.hcl to include year

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -2,14 +2,14 @@ schema_version = 1
 
 project {
   license        = "MPL-2.0"
-  copyright_year = 2017
+  copyright_year = 2022
 
   # (OPTIONAL) A list of globs that should not have copyright or license headers.
   # Supports doublestar glob patterns for more flexibility in defining which
   # files or folders should be ignored
   # Default: []
   header_ignore = [
-    # "vendors/**",
+    # "vendor/**",
     # "**autogen**",
   ]
 }


### PR DESCRIPTION
Hey all!

I was reviewing the `.copywrite.hcl` config added for this project (thank you for adding it!) and noticed the `copyright_year` attribute was commented out. The attribute is optional in most cases, but I figured I'd fill it out here since it can speed up runs of the `copywrite` command locally, as the CLI tool won't have to reach out to GitHub's API to infer the year.

As an aside - was this project started in 2017 and copied from elsewhere, or is `2022` the proper year? It seems like the project was imported from elsewhere, so I figured I'd use this forum to clarify.

Thanks!