### PR TITLE
RequeueAfter only functions with returning nil error

### DIFF
--- a/controllers/vaultpkisecret_controller.go
+++ b/controllers/vaultpkisecret_controller.go
@@ -104,7 +104,6 @@ func (r *VaultPKISecretReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err != nil {
 		logger.Info("Kubernetes secret does not exist yet", "path", s.Name)
 		return ctrl.Result{
-			Requeue:      true,
 			RequeueAfter: time.Second * 10,
 		}, nil
 	}
@@ -128,7 +127,6 @@ func (r *VaultPKISecretReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if resp == nil {
 		logger.Error(err, "Empty Vault secret", "path", path)
 		return ctrl.Result{
-			Requeue:      true,
 			RequeueAfter: time.Second * 30,
 		}, nil
 	}

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -109,7 +109,6 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if err != nil {
 		l.Error(err, "error reading secret %q")
 		return ctrl.Result{
-			Requeue:      true,
 			RequeueAfter: refAfter,
 		}, nil
 	}
@@ -117,7 +116,6 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if resp == nil {
 		l.Error(err, "empty Vault secret", "path", path)
 		return ctrl.Result{
-			Requeue:      true,
 			RequeueAfter: refAfter,
 		}, nil
 	}
@@ -142,7 +140,6 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// set ctrl.Result.Requeue to true with RequeueAfter being the credential (expiry TTL - some offset)
 	return ctrl.Result{
-		Requeue:      true,
 		RequeueAfter: refAfter,
 	}, nil
 }


### PR DESCRIPTION
Minor fix.

According to https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/internal/controller/controller.go#L321-L325, `RequeueAfter` will only work the way it is expected when not returning an error, otherwise it just requeues right away.