### PR TITLE
Drop TokenGenerateName from Vaultauth.Spec

### DIFF
--- a/api/v1alpha1/vaultauth_types.go
+++ b/api/v1alpha1/vaultauth_types.go
@@ -23,10 +23,6 @@ type VaultAuthConfigKubernetes struct {
 	// +kubebuilder:default=600
 	// +kubebuilder:validation:Minimum=600
 	TokenExpirationSeconds int64 `json:"tokenExpirationSeconds,omitempty"`
-	// TokenGenerateName is an optional prefix, to be used when generating unique
-	// ServiceAccount tokens.
-	// +kubebuilder:default=vault-secrets-operator
-	TokenGenerateName string `json:"tokenGenerateName,omitempty"`
 }
 
 // VaultAuthSpec defines the desired state of VaultAuth

--- a/config/crd/bases/secrets.hashicorp.com_vaultauths.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultauths.yaml
@@ -66,11 +66,6 @@ spec:
                     format: int64
                     minimum: 600
                     type: integer
-                  tokenGenerateName:
-                    default: vault-secrets-operator
-                    description: TokenGenerateName is an optional prefix, to be used
-                      when generating unique ServiceAccount tokens.
-                    type: string
                 required:
                 - role
                 - serviceAccount

--- a/internal/vault/auth_kubernetes.go
+++ b/internal/vault/auth_kubernetes.go
@@ -20,6 +20,8 @@ import (
 	"github.com/hashicorp/vault-secrets-operator/api/v1alpha1"
 )
 
+const tokenGenerateName = "vault-secrets-operator"
+
 var _ AuthLogin = (*KubernetesAuth)(nil)
 
 // KubernetesAuth implements the AuthLogin interface to log in to Vault.
@@ -71,7 +73,7 @@ func (l *KubernetesAuth) Login(ctx context.Context, client *api.Client) (*api.Se
 func (l *KubernetesAuth) getSATokenRequest() (*authv1.TokenRequest, error) {
 	return &authv1.TokenRequest{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: l.vaultAuth.Spec.Kubernetes.TokenGenerateName,
+			GenerateName: tokenGenerateName,
 		},
 		Spec: authv1.TokenRequestSpec{
 			ExpirationSeconds: pointer.Int64(l.vaultAuth.Spec.Kubernetes.TokenExpirationSeconds),

--- a/internal/vault/auth_kubernetes_test.go
+++ b/internal/vault/auth_kubernetes_test.go
@@ -75,13 +75,12 @@ func TestKubernetesAuth_getSATokenRequest(t *testing.T) {
 					Kubernetes: &secretsv1alpha1.VaultAuthConfigKubernetes{
 						TokenAudiences:         []string{"buz", "qux"},
 						TokenExpirationSeconds: 1200,
-						TokenGenerateName:      "baz",
 					},
 				},
 			},
 			want: &authv1.TokenRequest{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "baz",
+					GenerateName: tokenGenerateName,
 				},
 				Spec: authv1.TokenRequestSpec{
 					ExpirationSeconds: pointer.Int64(1200),


### PR DESCRIPTION
There is not much value in exposing this parameter to the user since the name it is neither stored in the generated JWT, nor available to the user via the control-plane logs.