### PR TITLE
samples: add missing step in readme and use nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ make setup-integration-test
 ./config/samples/setup.sh
 
 # Build and deploy the operator
-make build deploy-kind
+make build docker-build deploy-kind
 
 # Deploy the sample K8s resources
 kubectl apply -k config/samples

--- a/config/samples/secrets_v1alpha1_vaultpkisecret_pods.yaml
+++ b/config/samples/secrets_v1alpha1_vaultpkisecret_pods.yaml
@@ -9,11 +9,8 @@ metadata:
   namespace: tenant-1
 spec:
   containers:
-    - name: busybox
-      image: busybox:1.28
-      args:
-        - sleep
-        - "1000000"
+    - name: nginx
+      image: nginx
       volumeMounts:
         - name: secrets
           mountPath: "/etc/secrets"
@@ -46,11 +43,8 @@ spec:
 #  namespace: tenant-2
 #spec:
 #  containers:
-#    - name: busybox
-#      image: busybox:1.28
-#      args:
-#        - sleep
-#        - "1000000"
+#    - name: nginx
+#      image: nginx
 #      volumeMounts:
 #        - name: secrets
 #          mountPath: "/etc/secrets"

--- a/config/samples/secrets_v1alpha1_vaultstaticsecret.yaml
+++ b/config/samples/secrets_v1alpha1_vaultstaticsecret.yaml
@@ -51,11 +51,8 @@ metadata:
   namespace: tenant-1
 spec:
   containers:
-  - name: busybox
-    image: busybox:1.28
-    args:
-    - sleep
-    - "1000000"
+  - name: nginx
+    image: nginx
     volumeMounts:
     - name: secrets
       mountPath: "/etc/secrets"
@@ -73,11 +70,8 @@ metadata:
   namespace: tenant-2
 spec:
   containers:
-  - name: busybox
-    image: busybox:1.28
-    args:
-    - sleep
-    - "1000000"
+  - name: nginx
+    image: nginx
     volumeMounts:
     - name: secrets
       mountPath: "/etc/secrets"


### PR DESCRIPTION
The readme was missing the `docker-build` step in the samples instructions. Also switched the Pods used in the samples to nginx since it responds to kill signals faster than busybox.