### PR TITLE
bats tests cleanup and fix copywrite in templates

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,5 +1,7 @@
+{{/*
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
+*/}}
 
 {{/*
 Expand the name of the chart.

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,5 +1,7 @@
+{{/*
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
+*/}}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/chart/templates/leader-election-rbac.yaml
+++ b/chart/templates/leader-election-rbac.yaml
@@ -1,5 +1,7 @@
+{{/*
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/chart/templates/manager-config.yaml
+++ b/chart/templates/manager-config.yaml
@@ -1,5 +1,7 @@
+{{/*
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
+*/}}
 
 apiVersion: v1
 kind: ConfigMap

--- a/chart/templates/manager-rbac.yaml
+++ b/chart/templates/manager-rbac.yaml
@@ -1,5 +1,7 @@
+{{/*
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/chart/templates/metrics-reader-rbac.yaml
+++ b/chart/templates/metrics-reader-rbac.yaml
@@ -1,5 +1,7 @@
+{{/*
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/chart/templates/metrics-service.yaml
+++ b/chart/templates/metrics-service.yaml
@@ -1,5 +1,7 @@
+{{/*
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
+*/}}
 
 apiVersion: v1
 kind: Service

--- a/chart/templates/proxy-rbac.yaml
+++ b/chart/templates/proxy-rbac.yaml
@@ -1,5 +1,7 @@
+{{/*
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/chart/templates/tests/test-runner.yaml
+++ b/chart/templates/tests/test-runner.yaml
@@ -1,5 +1,7 @@
+{{/*
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
+*/}}
 {{- if .Values.tests.enabled }}
 apiVersion: v1
 kind: Pod

--- a/test/unit/deployment.bats
+++ b/test/unit/deployment.bats
@@ -36,11 +36,11 @@ load _helpers
 
    local actual=$(echo "$object" | yq '.requests.cpu' | tee /dev/stderr)
     [ "${actual}" = "5m" ]
-   local actual=$(echo "$object" | yq '.requests.memory' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.requests.memory' | tee /dev/stderr)
     [ "${actual}" = "64Mi" ]
-   local actual=$(echo "$object" | yq '.limits.cpu' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.limits.cpu' | tee /dev/stderr)
     [ "${actual}" = "500m" ]
-   local actual=$(echo "$object" | yq '.limits.memory' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.limits.memory' | tee /dev/stderr)
     [ "${actual}" = "128Mi" ]
 }
 
@@ -57,11 +57,11 @@ load _helpers
 
    local actual=$(echo "$object" | yq '.requests.cpu' | tee /dev/stderr)
     [ "${actual}" = "100m" ]
-   local actual=$(echo "$object" | yq '.requests.memory' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.requests.memory' | tee /dev/stderr)
     [ "${actual}" = "100Mi" ]
-   local actual=$(echo "$object" | yq '.limits.cpu' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.limits.cpu' | tee /dev/stderr)
     [ "${actual}" = "200m" ]
-   local actual=$(echo "$object" | yq '.limits.memory' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.limits.memory' | tee /dev/stderr)
     [ "${actual}" = "200Mi" ]
 }
 
@@ -74,11 +74,11 @@ load _helpers
 
    local actual=$(echo "$object" | yq '.requests.cpu' | tee /dev/stderr)
     [ "${actual}" = "10m" ]
-   local actual=$(echo "$object" | yq '.requests.memory' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.requests.memory' | tee /dev/stderr)
     [ "${actual}" = "64Mi" ]
-   local actual=$(echo "$object" | yq '.limits.cpu' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.limits.cpu' | tee /dev/stderr)
     [ "${actual}" = "500m" ]
-   local actual=$(echo "$object" | yq '.limits.memory' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.limits.memory' | tee /dev/stderr)
     [ "${actual}" = "128Mi" ]
 }
 
@@ -95,13 +95,10 @@ load _helpers
 
    local actual=$(echo "$object" | yq '.requests.cpu' | tee /dev/stderr)
     [ "${actual}" = "100m" ]
-   local actual=$(echo "$object" | yq '.requests.memory' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.requests.memory' | tee /dev/stderr)
     [ "${actual}" = "100Mi" ]
-   local actual=$(echo "$object" | yq '.limits.cpu' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.limits.cpu' | tee /dev/stderr)
     [ "${actual}" = "200m" ]
-   local actual=$(echo "$object" | yq '.limits.memory' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.limits.memory' | tee /dev/stderr)
     [ "${actual}" = "200Mi" ]
 }
-
-
-

--- a/test/unit/manager-config.bats
+++ b/test/unit/manager-config.bats
@@ -14,13 +14,13 @@ load _helpers
 
    local actual=$(echo "$object" | yq  '.health.healthProbeBindAddress' | tee /dev/stderr)
     [ "${actual}" = ":8081" ]
-   local actual=$(echo "$object" | yq  '.leaderElection.leaderElect' | tee /dev/stderr)
+   actual=$(echo "$object" | yq  '.leaderElection.leaderElect' | tee /dev/stderr)
     [ "${actual}" = "true" ]
-   local actual=$(echo "$object" | yq  '.leaderElection.resourceName' | tee /dev/stderr)
+   actual=$(echo "$object" | yq  '.leaderElection.resourceName' | tee /dev/stderr)
     [ "${actual}" = "b0d477c0.hashicorp.com" ]
-   local actual=$(echo "$object" | yq  '.metrics.bindAddress' | tee /dev/stderr)
+   actual=$(echo "$object" | yq  '.metrics.bindAddress' | tee /dev/stderr)
     [ "${actual}" = "127.0.0.1:8080" ]
-   local actual=$(echo "$object" | yq  '.webhook.port' | tee /dev/stderr)
+   actual=$(echo "$object" | yq  '.webhook.port' | tee /dev/stderr)
     [ "${actual}" = "9443" ]
 }
 
@@ -38,13 +38,12 @@ load _helpers
 
    local actual=$(echo "$object" | yq  '.health.healthProbeBindAddress' | tee /dev/stderr)
     [ "${actual}" = ":9091" ]
-   local actual=$(echo "$object" | yq  '.leaderElection.leaderElect' | tee /dev/stderr)
+   actual=$(echo "$object" | yq  '.leaderElection.leaderElect' | tee /dev/stderr)
     [ "${actual}" = "false" ]
-   local actual=$(echo "$object" | yq  '.leaderElection.resourceName' | tee /dev/stderr)
+   actual=$(echo "$object" | yq  '.leaderElection.resourceName' | tee /dev/stderr)
     [ "${actual}" = "foo.bar" ]
-   local actual=$(echo "$object" | yq  '.metrics.bindAddress' | tee /dev/stderr)
+   actual=$(echo "$object" | yq  '.metrics.bindAddress' | tee /dev/stderr)
     [ "${actual}" = "127.0.0.1:10091" ]
-   local actual=$(echo "$object" | yq  '.webhook.port' | tee /dev/stderr)
+   actual=$(echo "$object" | yq  '.webhook.port' | tee /dev/stderr)
     [ "${actual}" = "9091" ]
 }
-

--- a/test/unit/metrics-service.bats
+++ b/test/unit/metrics-service.bats
@@ -36,11 +36,11 @@ load _helpers
 
    local actual=$(echo "$object" | yq '.name' | tee /dev/stderr)
     [ "${actual}" = "https" ]
-   local actual=$(echo "$object" | yq '.port' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.port' | tee /dev/stderr)
     [ "${actual}" = "8443" ]
-   local actual=$(echo "$object" | yq '.protocol' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.protocol' | tee /dev/stderr)
     [ "${actual}" = "TCP" ]
-   local actual=$(echo "$object" | yq '.targetPort' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.targetPort' | tee /dev/stderr)
     [ "${actual}" = "https" ]
 }
 
@@ -57,11 +57,11 @@ load _helpers
 
    local actual=$(echo "$object" | yq '.name' | tee /dev/stderr)
     [ "${actual}" = "foo" ]
-   local actual=$(echo "$object" | yq '.port' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.port' | tee /dev/stderr)
     [ "${actual}" = "8080" ]
-   local actual=$(echo "$object" | yq '.protocol' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.protocol' | tee /dev/stderr)
     [ "${actual}" = "UDP" ]
-   local actual=$(echo "$object" | yq '.targetPort' | tee /dev/stderr)
+   actual=$(echo "$object" | yq '.targetPort' | tee /dev/stderr)
     [ "${actual}" = "http" ]
 }
 


### PR DESCRIPTION
Followup PR to #36 : 
* Cleanup bats tests to skip unnecessary redeclaration of `local`variable
* Add comment blocks around copywrite header in templates so they don't render when templating.
