### PR TITLE
shorten the metrics service object name

### DIFF
--- a/chart/templates/metrics-service.yaml
+++ b/chart/templates/metrics-service.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "chart.fullname" . }}-controller-manager-metrics-service
+  name: {{ include "chart.fullname" . }}-metrics-service
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: controller-manager


### PR DESCRIPTION
Shortens the metrics Service object name so that we dont hit the 63 character limit with helm release names longer than 4 characters.