### PR TITLE
Use workflow artifacts for the docker archive

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -141,9 +141,6 @@ jobs:
         with:
           name: ${{ needs.build-docker-image.outputs.image-archive }}
           path: dist
-      - name: find dist
-        run:
-          find dist
       - name: Create K8s Kind Cluster
         uses: helm/kind-action@v1.4.0
         with:


### PR DESCRIPTION
Previously we were using the GH cache share the docker image archive with between jobs. Since these files almost always guaranteed to be unique, there is no reason to cache them.