### PR TITLE
Store kind cluster logs as GH artifacts

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -149,6 +149,14 @@ jobs:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           config: test/integration/kind/config.yaml
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
+      - name: Create kind export log root
+        id: create_kind_export_log_root
+        run: |
+          log_artifact_name="kind-${{ env.KIND_CLUSTER_NAME}}-$(git rev-parse --short ${{ github.sha }})-${{ matrix.kind-k8s-version }}-${{ matrix.vault-version }}-logs"
+          log_root="/tmp/${log_artifact_name}"
+          mkdir -p "${log_root}"
+          echo "log_root=${log_root}" >> $GITHUB_OUTPUT
+          echo "log_artifact_name=${log_artifact_name}" >> $GITHUB_OUTPUT
       - name: Load Docker image
         run:
           make docker-image-load load-docker-image IMAGE_ARCHIVE_FILE=${{ needs.build-docker-image.outputs.image-archive-file }}
@@ -170,7 +178,7 @@ jobs:
       #    VAULT_IMAGE_TAG: ${{ matrix.vault-version }}
       #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #  run: |
-      #    make integration-test-helm SUPPRESS_TF_OUTPUT=true
+      #    make integration-test-helm SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: OSS tests using Kustomize
         # Ideally we only need to test the latest release of OSS Vault.
         if: ${{ matrix.vault-version == '1.13.0' }}
@@ -179,27 +187,17 @@ jobs:
           VAULT_IMAGE_TAG: ${{ matrix.vault-version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          make integration-test SUPPRESS_TF_OUTPUT=true
+          make integration-test SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: ENT tests using Kustomize
         env:
           INTEGRATION_TESTS: true
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}
           VAULT_IMAGE_TAG: ${{ matrix.vault-version }}-ent
         run: |
-          make integration-test-ent SUPPRESS_TF_OUTPUT=true
-      - name: Export cluster logs
-        if: success() || failure()
-        id: export_cluster_logs
-        run: |
-          log_artifact_name="kind-${{ env.KIND_CLUSTER_NAME}}-$(git rev-parse --short ${{ github.sha }})-${{ matrix.kind-k8s-version }}-${{ matrix.vault-version }}-logs"
-          log_dir="/tmp/${log_artifact_name}"
-          mkdir -p "${log_dir}"
-          kind export logs -n ${{ env.KIND_CLUSTER_NAME}} ${log_dir}
-          echo "log_dir=${log_dir}" >> $GITHUB_OUTPUT
-          echo "log_artifact_name=${log_artifact_name}" >> $GITHUB_OUTPUT
+          make integration-test-ent SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: Store kind cluster logs
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ steps.export_cluster_logs.outputs.log_artifact_name }}
-          path: ${{ steps.export_cluster_logs.outputs.log_dir }}
+          name: ${{ steps.create_kind_export_log_root.outputs.log_artifact_name }}
+          path: ${{ steps.create_kind_export_log_root.outputs.log_root }}

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ VAULT_IMAGE_REPO ?=
 K8S_VAULT_NAMESPACE ?= vault
 KIND_K8S_VERSION ?= v1.25.3
 VAULT_HELM_VERSION ?= 0.23.0
+# Root directory to export kind cluster logs after each test run.
+EXPORT_KIND_LOGS_ROOT ?=
 
 TERRAFORM_VERSION ?= 1.3.7
 GOFUMPT_VERSION ?= v0.4.0
@@ -24,7 +26,7 @@ TESTCOUNT ?= 1
 TESTARGS ?= -test.v -count=$(TESTCOUNT)
 
 # Run integration tests against a Helm installed Operator
-DEPLOY_OPERATOR_WITH_HELM ?=
+TEST_WITH_HELM ?=
 
 # Suppress the output from terraform when running the integration tests.
 SUPPRESS_TF_OUTPUT ?=
@@ -89,7 +91,7 @@ KIND_CLUSTER_NAME ?= vault-secrets-operator
 # Kind cluster context
 KIND_CLUSTER_CONTEXT ?= kind-$(KIND_CLUSTER_NAME)
 # Kind config file
-KIND_CONFIG ?= $(INTEGRATION_TEST_ROOT)/kind/config.yaml
+KIND_CONFIG_FILE ?= $(INTEGRATION_TEST_ROOT)/kind/config.yaml
 
 # Operator namespace as configured in $(KUSTOMIZE_BUILD_DIR)/kustomization.yaml
 OPERATOR_NAMESPACE ?= vault-secrets-operator-system
@@ -239,7 +241,7 @@ integration-test:  setup-vault ## Run integration tests for Vault OSS
 
 .PHONY: integration-test-helm
 integration-test-helm: setup-integration-test ## Run integration tests for Vault OSS
-	$(MAKE) integration-test DEPLOY_OPERATOR_WITH_HELM=true
+	$(MAKE) integration-test TEST_WITH_HELM=true
 
 .PHONY: integration-test-ent
 integration-test-ent: ## Run integration tests for Vault Enterprise

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestVaultDynamicSecret(t *testing.T) {
-	if os.Getenv("DEPLOY_OPERATOR_WITH_HELM") != "" {
+	if testWithHelm {
 		t.Skipf("Test is not compatiable with Helm")
 	}
 	testID := fmt.Sprintf("vds")
@@ -85,7 +85,7 @@ func TestVaultDynamicSecret(t *testing.T) {
 			"vault_db_default_lease_ttl": 60,
 		},
 	}
-	if entTests := os.Getenv("ENT_TESTS"); entTests != "" {
+	if entTests {
 		tfOptions.Vars["vault_enterprise"] = true
 	}
 	tfOptions = setCommonTFOptions(t, tfOptions)
@@ -98,6 +98,9 @@ func TestVaultDynamicSecret(t *testing.T) {
 				// removes the k8s namespace
 				assert.Nil(t, crdClient.Delete(ctx, c))
 			}
+
+			exportKindLogs(t)
+
 			// Clean up resources with "terraform destroy" at the end of the test.
 			terraform.Destroy(t, tfOptions)
 			os.RemoveAll(tempDir)


### PR DESCRIPTION
This PR adds steps for storing the exported kind cluster logs to the GH artifact store. Logs will be stored for each kind cluster created, and regardless of the jobs final status.