### PR TITLE
fix the `depends` for promote-production-helm

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -164,7 +164,7 @@ event "promote-production-docker" {
 }
 
 event "promote-production-helm" {
-  depends = ["promote-production-packaging"]
+  depends = ["promote-production-docker"]
   action "promote-production-helm" {
     organization = "hashicorp"
     repository = "crt-workflows-common"


### PR DESCRIPTION
Since we aren't using the `promote-production-packaging` step.