### PR TITLE
VDS: suppress lease not found errors

### DIFF
--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -150,8 +151,10 @@ func (r *VaultDynamicSecretReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{RequeueAfter: horizon}, nil
 		} else {
 			doRolloutRestart = true
-			r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonSecretLeaseRenewalError,
-				"Could not renew lease, lease_id=%s, err=%s", leaseID, err)
+			if !isLeaseNotfoundError(err) {
+				r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonSecretLeaseRenewalError,
+					"Could not renew lease, lease_id=%s, err=%s", leaseID, err)
+			}
 		}
 	}
 
@@ -281,4 +284,13 @@ func (r *VaultDynamicSecretReconciler) SetupWithManager(mgr ctrl.Manager, opts c
 		WithOptions(opts).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
+}
+
+func isLeaseNotfoundError(err error) bool {
+	if respErr, ok := err.(*api.ResponseError); ok && respErr != nil {
+		if respErr.StatusCode == http.StatusBadRequest {
+			return len(respErr.Errors) == 1 && respErr.Errors[0] == "lease not found"
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Lease not found errors are expected when a dynamic secret lease has expired. This type of error should not be emitted.