### PR TITLE
Include the test status in the kind export log dir name

### DIFF
--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -388,6 +388,12 @@ func exportKindLogs(t *testing.T) {
 			exportDir += "-oss"
 		}
 
+		if t.Failed() {
+			exportDir += "-failed"
+		} else {
+			exportDir += "-passed"
+		}
+
 		st, err := os.Stat(exportDir)
 		if err != nil && !os.IsNotExist(err) {
 			assert.NoError(t, err)


### PR DESCRIPTION
Make it easier to know which kind export logs contained failed tests, by including the test result passed/failed in the export log dir name.