### PR TITLE
Remove hardcoded "creds" from path

### DIFF
--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -206,7 +206,7 @@ func (r *VaultDynamicSecretReconciler) isRenewableLease(resp *secretsv1alpha1.Va
 }
 
 func (r *VaultDynamicSecretReconciler) syncSecret(ctx context.Context, vClient vault.Client, o *secretsv1alpha1.VaultDynamicSecret) (*secretsv1alpha1.VaultSecretLease, error) {
-	path := fmt.Sprintf("%s/creds/%s", o.Spec.Mount, o.Spec.Role)
+	path := fmt.Sprintf("%s/%s", o.Spec.Mount, o.Spec.Role)
 	resp, err := vClient.Read(ctx, path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Related issue: https://github.com/hashicorp/vault-secrets-operator/issues/107

Not all secrets engines have "creds" in their path.

I honestly don't know if the approach is the correct one.

I assume another approach would be to detect the engine, and then dynamically figure out which path is needed.
I don't know how possible that is.