### PR TITLE
Fix "make test"

### DIFF
--- a/hack/install_copywrite.sh
+++ b/hack/install_copywrite.sh
@@ -41,6 +41,7 @@ pushd $tempdir > /dev/null
 popd > /dev/null
 
 rm -f "${dest_file%/*}"/copywrite*
+mkdir bin/
 mv "${tempdir}/copywrite" "${dest_file}"
 ln -sf "${dest_filename}" "${dest_file%/*}/copywrite"
 

--- a/hack/install_copywrite.sh
+++ b/hack/install_copywrite.sh
@@ -41,7 +41,7 @@ pushd $tempdir > /dev/null
 popd > /dev/null
 
 rm -f "${dest_file%/*}"/copywrite*
-mkdir bin/
+mkdir -p bin/
 mv "${tempdir}/copywrite" "${dest_file}"
 ln -sf "${dest_filename}" "${dest_file%/*}/copywrite"
 


### PR DESCRIPTION
It previously failed with this error:
```
$ make test
Fetching https://github.com/hashicorp/copywrite/releases/download/v0.16.3/SHA256SUMS
Fetching https://github.com/hashicorp/copywrite/releases/download/v0.16.3/copywrite_0.16.3_darwin_x86_64.tar.gz
copywrite_0.16.3_darwin_x86_64.tar.gz: OK
mv: rename /var/folders/kv/rdx7k58x5fj0wb03vgdh6zqh0000gp/T/tmp.wU0r4D42/copywrite to bin/copywrite-0.16.3: No such file or directory
make: *** [copywrite] Error 1
```

It seems like the destination "bin" direcory doesn't exist and needs creating.