### PR TITLE
Test with k8s 1.26 and latest Vault versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: .go-version
+          cache: true
       - name: go fmt
         run: |
           make check-fmt
@@ -89,6 +90,7 @@ jobs:
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: .go-version
+          cache: true
       - name: Build
         env:
           GOOS: "linux"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: .go-version
+          cache: true
       - run: |
           make check-fmt
   tf-fmtcheck:
@@ -19,6 +20,7 @@ jobs:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: .go-version
+          cache: true
       - run: |
           make check-tffmt
 
@@ -29,14 +31,7 @@ jobs:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: .go-version
-      - uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
       - run: make ci-test
 
   unitTest:
@@ -47,14 +42,7 @@ jobs:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: .go-version
-      - uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version: '16'
@@ -76,14 +64,7 @@ jobs:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: .go-version
-      - uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
       - name: Build operator binary and image
         id: build-docker-image
         run: |
@@ -107,27 +88,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.22.15, 1.23.13, 1.24.7, 1.25.3]
-        vault-version: [1.11.8, 1.12.4, 1.13.0]
+        kind-k8s-version: [1.22.17, 1.23.17, 1.24.12, 1.25.8, 1.26.3]
+        vault-version: [1.11.9, 1.12.5, 1.13.1]
         # Note: The below exclude and includes are a bit awkward, but they
         # allow us to exclude the combos we don't really need. We want to test
         # the operator with the different k8s versions, and with the different
         # vault versions, but we don't care about testing all the k8s versions
         # against all the vault versions.
         # Combos to exclude:
-        #   kind-k8s-version: [1.22.15, 1.23.13, 1.24.7]
-        #   vault-version: [1.11.8, 1.12.4]
+        #   kind-k8s-version: [1.22.17, 1.23.17, 1.24.12, 1.25.8]
+        #   vault-version: [1.11.9, 1.12.5]
         exclude:
-          - kind-k8s-version: 1.24.7
-          - kind-k8s-version: 1.23.13
-          - kind-k8s-version: 1.22.15
+          - kind-k8s-version: 1.25.8
+          - kind-k8s-version: 1.24.12
+          - kind-k8s-version: 1.23.17
+          - kind-k8s-version: 1.22.17
         include:
+          - kind-k8s-version: 1.25.8
+            vault-version: 1.13.1
           - kind-k8s-version: 1.24.7
-            vault-version: 1.13.0
+            vault-version: 1.13.1
           - kind-k8s-version: 1.23.13
-            vault-version: 1.13.0
+            vault-version: 1.13.1
           - kind-k8s-version: 1.22.15
-            vault-version: 1.13.0
+            vault-version: 1.13.1
 
     name: Integration vault:${{ matrix.vault-version }} kind ${{ matrix.kind-k8s-version }}
     steps:
@@ -157,14 +141,7 @@ jobs:
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: .go-version
-      - uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
       - name: OSS tests using Helm
         env:
           INTEGRATION_TESTS: true


### PR DESCRIPTION
Also remove the extra go caching steps in favor of setup-go@v3's [built-in caching support](https://github.com/actions/setup-go/tree/v3.5.0#caching-dependency-files-and-build-outputs).