### PR TITLE
VSS: ensure an out-of-band Secret deletion is properly remediated

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,4 +16,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: hashicorp/vault-secrets-operator
-  newTag: 0.1.0-beta
+  newTag: 0.0.0-dev

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,4 +16,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: hashicorp/vault-secrets-operator
-  newTag: 0.0.0-dev
+  newTag: 0.1.0-beta

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -230,6 +230,8 @@ func (r *VaultStaticSecretReconciler) handleSecretHMAC(ctx context.Context, o *s
 			}
 
 			macsEqual = valid
+		} else {
+			macsEqual = false
 		}
 	}
 

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -231,6 +231,7 @@ func (r *VaultStaticSecretReconciler) handleSecretHMAC(ctx context.Context, o *s
 
 			macsEqual = valid
 		} else {
+			// assume MACs are not equal if the secret does not exist or an error (ignored) has occurred
 			macsEqual = false
 		}
 	}

--- a/test/integration/vaultstaticsecret_integration_test.go
+++ b/test/integration/vaultstaticsecret_integration_test.go
@@ -370,7 +370,7 @@ func TestVaultStaticSecret_kv(t *testing.T) {
 			if obj.Spec.Destination.Create {
 				sec, _, err := helpers.GetSecret(ctx, crdClient, obj)
 				if assert.NoError(t, err) {
-					// ensure that a Secret deleted ouf of band is properly restored
+					// ensure that a Secret deleted out-of-band is properly restored
 					if assert.NoError(t, crdClient.Delete(ctx, sec)) {
 						_, err := waitForSecretData(t, ctx, crdClient, 30, 1*time.Second, obj.Spec.Destination.Name,
 							obj.ObjectMeta.Namespace, data)

--- a/test/integration/vaultstaticsecret_integration_test.go
+++ b/test/integration/vaultstaticsecret_integration_test.go
@@ -30,6 +30,7 @@ import (
 
 	secretsv1alpha1 "github.com/hashicorp/vault-secrets-operator/api/v1alpha1"
 	"github.com/hashicorp/vault-secrets-operator/internal/consts"
+	"github.com/hashicorp/vault-secrets-operator/internal/helpers"
 	"github.com/hashicorp/vault-secrets-operator/internal/vault"
 )
 
@@ -356,9 +357,7 @@ func TestVaultStaticSecret_kv(t *testing.T) {
 
 		secret, err := waitForSecretData(t, ctx, crdClient, 30, 1*time.Second, obj.Spec.Destination.Name,
 			obj.ObjectMeta.Namespace, data)
-		assert.NoError(t, err)
-
-		if err == nil {
+		if assert.NoError(t, err) {
 			assertSyncableSecret(t, obj,
 				"secrets.hashicorp.com/v1alpha1",
 				"VaultStaticSecret", secret)
@@ -367,6 +366,19 @@ func TestVaultStaticSecret_kv(t *testing.T) {
 			} else {
 				assertNoHMAC(t, obj)
 			}
+
+			if obj.Spec.Destination.Create {
+				sec, _, err := helpers.GetSecret(ctx, crdClient, obj)
+				if assert.NoError(t, err) {
+					// ensure that a Secret deleted ouf of band is properly restored
+					if assert.NoError(t, crdClient.Delete(ctx, sec)) {
+						_, err := waitForSecretData(t, ctx, crdClient, 30, 1*time.Second, obj.Spec.Destination.Name,
+							obj.ObjectMeta.Namespace, data)
+						assert.NoError(t, err)
+					}
+				}
+			}
+
 			if !expectInitial && len(obj.Spec.RolloutRestartTargets) > 0 {
 				// TODO(tech-debt): add method waiting for rollout-restart, for now we
 				//  can provide an artificial grace period.
@@ -384,9 +396,11 @@ func TestVaultStaticSecret_kv(t *testing.T) {
 			for idx, vssObj := range tt.existing {
 				count++
 				t.Run(fmt.Sprintf("%s-existing-%d", tt.name, idx), func(t *testing.T) {
-					t.Cleanup(func() {
-						assert.NoError(t, crdClient.Delete(ctx, vssObj))
-					})
+					if !skipCleanup {
+						t.Cleanup(func() {
+							assert.NoError(t, crdClient.Delete(ctx, vssObj))
+						})
+					}
 					assertSync(t, vssObj, tt.expectedExisting[idx], true)
 					assertSync(t, vssObj, tt.expectedExisting[idx], false)
 				})
@@ -429,10 +443,12 @@ func TestVaultStaticSecret_kv(t *testing.T) {
 							},
 						}
 
-						t.Cleanup(func() {
-							assert.NoError(t, crdClient.Delete(ctx, vssObj))
-							deleteKV(t, vssObj)
-						})
+						if !skipCleanup {
+							t.Cleanup(func() {
+								assert.NoError(t, crdClient.Delete(ctx, vssObj))
+								deleteKV(t, vssObj)
+							})
+						}
 
 						assertSync(t, vssObj, expected, true)
 						assertSync(t, vssObj, expected, false)


### PR DESCRIPTION
The Operator now detects whenever the owned Destination Secret is deleted. Whenever this situation is encountered, the Operator will recreate/repopulate the Secret.

RefreshAfter must be set and Destination.Create must be set to true for the remediation to take place.

Closes #124 