### PR TITLE
remove vds kubebuilder fields which are unnecessary

### DIFF
--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -55,9 +55,6 @@ type VaultDynamicSecretReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;patch
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;patch
-//
-// needed for managing cached Clients, duplicated in vaultconnection_controller.go
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;delete;update;patch
 
 // Reconcile ensures that the VaultDynamicSecret Custom Resource is synced from Vault to its
 // configured Kubernetes secret. The resource will periodically be reconciled to renew the


### PR DESCRIPTION
Removing unnecessary kubebuilder fields from the vds controller:
* All of the verbs are duplicated on line 52 except for `delete` which we aren't using.
