### PR TITLE
Expose prometheus port in deployment and service

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
       - name: manager
         args:
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+        - --metrics-bind-address=:8080
         - --leader-elect
         {{- if .Values.controller.manager.clientCache.persistenceModel }}
         - --client-cache-persistence-model={{ .Values.controller.manager.clientCache.persistenceModel }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -134,7 +134,7 @@ controller:
       leaderElect: true
       resourceName: b0d477c0.hashicorp.com
     metrics:
-      bindAddress: 127.0.0.1:8080
+      bindAddress: :8080
     webhook:
       port: 9443
 
@@ -148,7 +148,7 @@ controller:
 # @recurse: true
 # @type: map
 metricsService:
-  # Set the port settings for the metrics service.
+  # Set the port settings for the metrics service and prometheus metrics
   # For more information on configuring resources, see the K8s documentation:
   # https://kubernetes.io/docs/concepts/services-networking/service/
   # @type: map
@@ -157,6 +157,10 @@ metricsService:
     port: 8443
     protocol: TCP
     targetPort: https
+  - name: prometheus
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
   type: ClusterIP
 
 # Configures the default VaultConnection CR which will be used by resources

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -39,5 +39,5 @@ spec:
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--metrics-bind-address=:8080"
         - "--leader-elect"


### PR DESCRIPTION
Prometheus port is not exposed through the service clusterIP and is only listening from 127.0.0.1. Allow to expose the port 8080 for prometheus scraping