### PR TITLE
Add integration-test-helm-ent and make it the default for matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -237,6 +237,8 @@ jobs:
         run: |
           make integration-test-ent SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: ENT tests using Helm
+        # TODO: When the VDS integration test supports Helm swap the matrix filter so this test runs the full matrix.
+        if: ${{ matrix.vault-version == '1.13.1' }}
         env:
           INTEGRATION_TESTS: true
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -228,8 +228,8 @@ jobs:
         run: |
           make integration-test SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: ENT tests using Kustomize
-        # Ideally we only need to test the latest release of OSS Vault.
-        if: ${{ matrix.vault-version == '1.13.1' }}
+        # TODO: When the VDS integration test supports Helm we test against one version of (ENT) Vault like the other tests.
+        # if: ${{ matrix.vault-version == '1.13.1' }}
         env:
           INTEGRATION_TESTS: true
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -227,6 +227,15 @@ jobs:
           VAULT_IMAGE_TAG: ${{ matrix.vault-version }}
         run: |
           make integration-test SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
+      - name: ENT tests using Kustomize
+        # Ideally we only need to test the latest release of OSS Vault.
+        if: ${{ matrix.vault-version == '1.13.1' }}
+        env:
+          INTEGRATION_TESTS: true
+          VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}
+          VAULT_IMAGE_TAG: ${{ matrix.vault-version }}-ent
+        run: |
+          make integration-test-ent SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: ENT tests using Helm
         env:
           INTEGRATION_TESTS: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -227,13 +227,13 @@ jobs:
           VAULT_IMAGE_TAG: ${{ matrix.vault-version }}
         run: |
           make integration-test SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
-      - name: ENT tests using Kustomize
+      - name: ENT tests using Helm
         env:
           INTEGRATION_TESTS: true
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}
           VAULT_IMAGE_TAG: ${{ matrix.vault-version }}-ent
         run: |
-          make integration-test-ent SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
+          make integration-test-helm-ent SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: Store kind cluster logs
         if: success()
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,10 @@ integration-test:  setup-vault ## Run integration tests for Vault OSS
 integration-test-helm: setup-integration-test ## Run integration tests for Vault OSS
 	$(MAKE) integration-test TEST_WITH_HELM=true
 
+.PHONY: integration-test-helm-ent
+integration-test-ent: ## Run integration tests for Vault Enterprise
+	$(MAKE) integration-test TEST_WITH_HELM=true VAULT_ENTERPRISE=true ENT_TESTS=$(VAULT_ENTERPRISE)
+
 .PHONY: integration-test-ent
 integration-test-ent: ## Run integration tests for Vault Enterprise
 	$(MAKE) integration-test VAULT_ENTERPRISE=true ENT_TESTS=$(VAULT_ENTERPRISE)

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ integration-test-helm: setup-integration-test ## Run integration tests for Vault
 	$(MAKE) integration-test TEST_WITH_HELM=true
 
 .PHONY: integration-test-helm-ent
-integration-test-ent: ## Run integration tests for Vault Enterprise
+integration-test-helm-ent: ## Run integration tests for Vault Enterprise
 	$(MAKE) integration-test TEST_WITH_HELM=true VAULT_ENTERPRISE=true ENT_TESTS=$(VAULT_ENTERPRISE)
 
 .PHONY: integration-test-ent


### PR DESCRIPTION
We currently restrict the scope of our testing matrix to the latest release of Vault OSS (1.13.1) for the majority of our test environments, with the exception of the `ENT tests using Kustomize` which run against the full test matrix of Vault versions and Kubernetes versions.
This PR changes this so that we deploy using Helm instead of Kustomize for our most expansive test and only run the existing `ENT tests using Kustomize` against `1.13.1`.

* Adds a new Makefile target `integration-test-helm-ent` which runs the integration test with Helm and Vault ENT
* Use this test as the basis for our more expansive tests by introducing and running `ENT tests using Helm` instead of `ENT tests using Kustomize` across all versions of Kubernetes and Vault.
