### PR TITLE
VPS: make commonName optional

### DIFF
--- a/api/v1alpha1/vaultpkisecret_types.go
+++ b/api/v1alpha1/vaultpkisecret_types.go
@@ -60,7 +60,7 @@ type VaultPKISecretSpec struct {
 	Destination Destination `json:"destination"`
 
 	// CommonName to include in the request.
-	CommonName string `json:"commonName"`
+	CommonName string `json:"commonName,omitempty"`
 
 	// AltNames to include in the request
 	// May contain both DNS names and email addresses.

--- a/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -186,7 +186,6 @@ spec:
                   configured in its own Kubernetes namespace.
                 type: string
             required:
-            - commonName
             - destination
             - mount
             - name


### PR DESCRIPTION
The Vault PKI role should have require_cn  to set false if commonName is not provided.

Closes #150 