### PR TITLE
Set the correct version in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,15 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.1.0-beta
+VERSION ?= 0.0.0-dev
 
 GO_VERSION = $(shell cat .go-version)
 
-CONFIG_MANAGER_DIR ?= config/manager
-KUSTOMIZE_BUILD_DIR ?= config/default
+CONFIG_SRC_DIR ?= config
+CONFIG_BUILD_DIR ?= build/config
+CONFIG_MANAGER_DIR ?= $(CONFIG_BUILD_DIR)/manager
+KUSTOMIZATION ?= default
+KUSTOMIZE_BUILD_DIR ?= $(CONFIG_BUILD_DIR)/$(KUSTOMIZATION)
 
 VAULT_IMAGE_TAG ?= latest
 VAULT_IMAGE_REPO ?=
@@ -246,9 +249,17 @@ ci-docker-build: ## Build docker image with the operator (without generating ass
 ci-test: vet envtest ## Run tests in CI (without generating assets)
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... $(TESTARGS) -coverprofile cover.out
 
-.PHONY: integration-test
-integration-test:  setup-vault ## Run integration tests for Vault OSS
+.PHONY: copy-config
+copy-config: ## Copy kustomize config to CONFIG_BUILD_DIR
+	@rm -rf $(CONFIG_BUILD_DIR)
+	@cp -a $(CONFIG_SRC_DIR) $(CONFIG_BUILD_DIR)
+
+.PHONY: set-image
+set-image: kustomize copy-config ## Set the controller image in CONFIG_MANAGER_DIR
 	cd $(CONFIG_MANAGER_DIR) && $(KUSTOMIZE) edit set image controller=$(IMG)
+
+.PHONY: set-image integration-test
+integration-test: set-image setup-vault ## Run integration tests for Vault OSS
 	SUPPRESS_TF_OUTPUT=$(SUPPRESS_TF_OUTPUT) SKIP_CLEANUP=$(SKIP_CLEANUP) OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE) \
 	OPERATOR_IMAGE_REPO=$(IMAGE_TAG_BASE) OPERATOR_IMAGE_TAG=$(VERSION) \
     INTEGRATION_TESTS=true KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND_CLUSTER_CONTEXT=$(KIND_CLUSTER_CONTEXT) CGO_ENABLED=0 \
@@ -342,8 +353,7 @@ endif
 endif
 
 .PHONY: ci-deploy
-ci-deploy: kustomize ## Deploy controller to the K8s cluster (without generating assets)
-	cd $(CONFIG_MANAGER_DIR) && $(KUSTOMIZE) edit set image controller=$(IMG)
+ci-deploy: kustomize set-image ## Deploy controller to the K8s cluster (without generating assets)
 	$(KUSTOMIZE) build $(KUSTOMIZE_BUILD_DIR) | kubectl apply -f -
 
 .PHONY: ci-deploy-kind
@@ -432,8 +442,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd $(CONFIG_MANAGER_DIR) && $(KUSTOMIZE) edit set image controller=$(IMG)
+deploy: manifests kustomize set-image ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build $(KUSTOMIZE_BUILD_DIR) | kubectl apply -f -
 
 .PHONY: undeploy
@@ -488,10 +497,9 @@ $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: bundle
-bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
+bundle: manifests kustomize set-image ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
-	cd $(CONFIG_MANAGER_DIR) && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
+	$(KUSTOMIZE) build $(KUSTOMIZE_BUILD_DIR)/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
 	operator-sdk bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/Makefile
+++ b/Makefile
@@ -252,6 +252,7 @@ ci-test: vet envtest ## Run tests in CI (without generating assets)
 .PHONY: copy-config
 copy-config: ## Copy kustomize config to CONFIG_BUILD_DIR
 	@rm -rf $(CONFIG_BUILD_DIR)
+	@mkdir -p $(dir $(CONFIG_BUILD_DIR))
 	@cp -a $(CONFIG_SRC_DIR) $(CONFIG_BUILD_DIR)
 
 .PHONY: set-image

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.0-dev
+VERSION ?= 0.1.0-beta
 
 GO_VERSION = $(shell cat .go-version)
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,11 +11,9 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 images:
 - name: controller
   newName: hashicorp/vault-secrets-operator
   newTag: 0.1.0-beta
-
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,9 +11,11 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
+
 images:
 - name: controller
   newName: hashicorp/vault-secrets-operator
   newTag: 0.1.0-beta
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -79,7 +79,7 @@ func init() {
 		panic(err)
 	}
 
-	kustomizeConfigRoot, err = filepath.Abs(filepath.Join(testRoot, "..", "..", "config"))
+	kustomizeConfigRoot, err = filepath.Abs(filepath.Join(testRoot, "..", "..", "build", "config"))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Move the images block up to prevent 'kustomize edit' from stripping the end of file newline which resulted in a perpetual diff.