### PR TITLE
VDS: allow for specifying an arbitrary secrets path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ Bugs:
 * Helm Chart: fix deployment templating so setting `controller.kubernetesClusterDomain` works as defined in values.yaml. [GH-183](https://github.com/hashicorp/vault-secrets-operator/pull/183)
 
 Features:
-* VaultDynamicSecrets: CRD is extended with `Revoke` field which will result in the dynamic secret lease being revoked on rotation and CR deletion. Note: The VaultAuthMethod referenced by the VDS Secret must have a policy which provides `["update"]` on `sys/leases/revoke`. [GH-143](https://github.com/hashicorp/vault-secrets-operator/pull/143)
+* VaultDynamicSecrets (VDS): CRD is extended with `Revoke` field which will result in the dynamic secret lease being revoked on rotation and CR deletion. Note: The VaultAuthMethod referenced by the VDS Secret must have a policy which provides `["update"]` on `sys/leases/revoke`. [GH-143](https://github.com/hashicorp/vault-secrets-operator/pull/143)
 * VaultAuth: Adds support for the JWT authentication method which either uses the JWT token from the provided secret reference, or a service account JWT token that VSO will generate using the provided service account. [GH-131](https://github.com/hashicorp/vault-secrets-operator/pull/131)
-* VaultDynamicSecrets: New `RenewalPercent` field to control when a lease is renewed [GH-170](https://github.com/hashicorp/vault-secrets-operator/pull/170)
+* VaultDynamicSecrets (VDS): New `RenewalPercent` field to control when a lease is renewed [GH-170](https://github.com/hashicorp/vault-secrets-operator/pull/170)
 
 Improvements:
-* VaultDynamicSecrets: Generate new credentials if lease renewal TTL is truncated [GH-170](https://github.com/hashicorp/vault-secrets-operator/pull/170)
+* VaultDynamicSecrets (VDS): Generate new credentials if lease renewal TTL is truncated [GH-170](https://github.com/hashicorp/vault-secrets-operator/pull/170)
+* VaultDynamicSecrets (VDS): Replace `Spec.Role` with `Spec.Path` (**breaking change**) [GH-172](https://github.com/hashicorp/vault-secrets-operator/pull/172)
 
 ## 0.1.0-beta (March 29th, 2023)
 
-    * Initial Beta Release
+* Initial Beta Release

--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,7 @@ deploy: manifests kustomize set-image ## Deploy controller to the K8s cluster sp
 	$(KUSTOMIZE) build $(KUSTOMIZE_BUILD_DIR) | kubectl apply -f -
 
 .PHONY: undeploy
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+undeploy: set-image ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build $(KUSTOMIZE_BUILD_DIR) | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy-kind

--- a/api/v1alpha1/vaultdynamicsecret_types.go
+++ b/api/v1alpha1/vaultdynamicsecret_types.go
@@ -18,8 +18,10 @@ type VaultDynamicSecretSpec struct {
 	Namespace string `json:"namespace,omitempty"`
 	// Mount path of the secret's engine in Vault.
 	Mount string `json:"mount"`
-	// Role in Vault to get the credentials for.
-	Role string `json:"role"`
+	// Path in Vault to get the credentials for, and is relative to Mount.
+	// Please consult https://developer.hashicorp.com/vault/docs/secrets if one is
+	// uncertain about what 'path' should be set to.
+	Path string `json:"path"`
 	// Revoke the existing lease when a lease is rotated or on VDS resource deletion.
 	Revoke bool `json:"revoke,omitempty"`
 	// RolloutRestartTargets should be configured whenever the application(s) consuming the Vault secret does

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -75,13 +75,15 @@ spec:
               namespace:
                 description: Namespace where the secrets engine is mounted in Vault.
                 type: string
+              path:
+                description: Path in Vault to get the credentials for, and is relative
+                  to Mount. Please consult https://developer.hashicorp.com/vault/docs/secrets
+                  if one is uncertain about what 'path' should be set to.
+                type: string
               revoke:
                 description: Revoke the existing lease when a lease is rotated or
                   on VDS resource deletion.
                 type: boolean
-              role:
-                description: Role in Vault to get the credentials for.
-                type: string
               rolloutRestartTargets:
                 description: RolloutRestartTargets should be configured whenever the
                   application(s) consuming the Vault secret does not support dynamically
@@ -120,7 +122,7 @@ spec:
             required:
             - destination
             - mount
-            - role
+            - path
             type: object
           status:
             description: VaultDynamicSecretStatus defines the observed state of VaultDynamicSecret

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -222,7 +222,7 @@ func (r *VaultDynamicSecretReconciler) isRenewableLease(resp *secretsv1alpha1.Va
 }
 
 func (r *VaultDynamicSecretReconciler) syncSecret(ctx context.Context, vClient vault.Client, o *secretsv1alpha1.VaultDynamicSecret) (*secretsv1alpha1.VaultSecretLease, error) {
-	path := fmt.Sprintf("%s/creds/%s", o.Spec.Mount, o.Spec.Role)
+	path := fmt.Sprintf("%s/%s", o.Spec.Mount, o.Spec.Path)
 	resp, err := vClient.Read(ctx, path)
 	if err != nil {
 		return nil, err

--- a/demo.mk
+++ b/demo.mk
@@ -57,7 +57,7 @@ demo-infra-app: demo-setup-kind ## Deploy Postgres for the demo
 demo-deploy: demo-setup-kind ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	$(MAKE) deploy-kind \
 		KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
-		KUSTOMIZE_BUILD_DIR=config/persistence-encrypted
+		KUSTOMIZATION=persistence-encrypted
 
 .PHONY: demo
 demo: demo-deploy demo-infra-vault demo-infra-app ## Deploy the demo

--- a/demo/infra/app/app.tf
+++ b/demo/infra/app/app.tf
@@ -65,7 +65,7 @@ resource "kubernetes_manifest" "vault-dynamic-secret" {
     spec = {
       namespace = vault_auth_backend.default.namespace
       mount     = vault_database_secrets_mount.db.path
-      role      = local.db_role
+      path      = local.db_creds_path
       destination = {
         create : false
         name : kubernetes_secret.db.metadata[0].name
@@ -92,7 +92,7 @@ resource "kubernetes_manifest" "vault-dynamic-secret-create" {
     spec = {
       namespace = vault_auth_backend.default.namespace
       mount     = vault_database_secrets_mount.db.path
-      role      = local.db_role
+      path      = local.db_creds_path
       destination = {
         create : true
         name : "vso-db-demo-created"

--- a/demo/infra/app/locals.tf
+++ b/demo/infra/app/locals.tf
@@ -18,4 +18,5 @@ locals {
   # db locals
   postgres_host = "${data.kubernetes_service.postgres.metadata[0].name}.${helm_release.postgres.namespace}.svc.cluster.local:${data.kubernetes_service.postgres.spec[0].port[0].port}"
   db_role       = "dev-postgres"
+  db_creds_path = "creds/${var.db_role}"
 }

--- a/demo/infra/app/locals.tf
+++ b/demo/infra/app/locals.tf
@@ -17,6 +17,5 @@ locals {
 
   # db locals
   postgres_host = "${data.kubernetes_service.postgres.metadata[0].name}.${helm_release.postgres.namespace}.svc.cluster.local:${data.kubernetes_service.postgres.spec[0].port[0].port}"
-  db_role       = "dev-postgres"
   db_creds_path = "creds/${var.db_role}"
 }

--- a/demo/infra/app/outputs.tf
+++ b/demo/infra/app/outputs.tf
@@ -17,7 +17,7 @@ output "auth_role" {
   value = local.auth_role
 }
 output "db_role" {
-  value = local.db_role
+  value = var.db_role
 }
 output "db_path" {
   value = vault_database_secrets_mount.db.path

--- a/demo/infra/app/postgres.tf
+++ b/demo/infra/app/postgres.tf
@@ -54,7 +54,7 @@ resource "vault_database_secrets_mount" "db" {
     connection_url    = "postgresql://{{username}}:{{password}}@${local.postgres_host}/postgres?sslmode=disable"
     verify_connection = false
     allowed_roles = [
-      local.db_role,
+      var.db_role,
     ]
   }
 }
@@ -62,7 +62,7 @@ resource "vault_database_secrets_mount" "db" {
 resource "vault_database_secret_backend_role" "postgres" {
   namespace = local.namespace
   backend   = vault_database_secrets_mount.db.path
-  name      = local.db_role
+  name      = var.db_role
   db_name   = vault_database_secrets_mount.db.postgresql[0].name
   creation_statements = [
     "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';",

--- a/demo/infra/app/variables.tf
+++ b/demo/infra/app/variables.tf
@@ -30,5 +30,9 @@ variable "k8s_db_secret_count" {
   default = 50
 }
 
+variable "db_role" {
+  default = "dev-postgres"
+}
+
 variable "vault_address" {}
 variable "vault_token" {}

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -239,7 +239,7 @@ func TestVaultDynamicSecret(t *testing.T) {
 						Namespace: outputs.Namespace,
 						Mount:     outputs.DBPath,
 						Path:      "creds/" + outputs.DBRole,
-						Revoke:    false,
+						Revoke:    true,
 						Destination: secretsv1alpha1.Destination{
 							Name:   dest,
 							Create: false,
@@ -271,7 +271,7 @@ func TestVaultDynamicSecret(t *testing.T) {
 						Namespace: outputs.Namespace,
 						Mount:     outputs.DBPath,
 						Path:      "creds/" + outputs.DBRole,
-						Revoke:    false,
+						Revoke:    true,
 						Destination: secretsv1alpha1.Destination{
 							Name:   dest,
 							Create: true,

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -238,8 +238,8 @@ func TestVaultDynamicSecret(t *testing.T) {
 					Spec: secretsv1alpha1.VaultDynamicSecretSpec{
 						Namespace: outputs.Namespace,
 						Mount:     outputs.DBPath,
-						Role:      outputs.DBRole,
-						Revoke:    true,
+						Path:      "creds/" + outputs.DBRole,
+						Revoke:    false,
 						Destination: secretsv1alpha1.Destination{
 							Name:   dest,
 							Create: false,
@@ -270,8 +270,8 @@ func TestVaultDynamicSecret(t *testing.T) {
 					Spec: secretsv1alpha1.VaultDynamicSecretSpec{
 						Namespace: outputs.Namespace,
 						Mount:     outputs.DBPath,
-						Role:      outputs.DBRole,
-						Revoke:    true,
+						Path:      "creds/" + outputs.DBRole,
+						Revoke:    false,
 						Destination: secretsv1alpha1.Destination{
 							Name:   dest,
 							Create: true,


### PR DESCRIPTION
This PR ensure that VDS can support any Vault secret engine path.

- drops hard coded `creds` path component.

Example of an updated VDS CR:
```yaml
apiVersion: secrets.hashicorp.com/v1alpha1
kind: VaultDynamicSecret
metadata:
  name: vso-db-demo-create
  namespace: demo-ns
spec:
  destination:
    create: true
    name: vso-db-demo-created
  mount: demo-db
  path: creds/dev-postgres
  rolloutRestartTargets:
  - kind: Deployment
    name: vso-db-demo
```

**Breaking change:**
- Spec.Role is now Spec.Path

Close #108 #107 