### PR TITLE
[wip] sets the controller templates to pass restricted:v1.25 PodSecurityStandards

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -34,6 +34,13 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
     spec:
+      securityContext:
+        runAsUser: 10000
+        runAsGroup: 30000
+        fsGroup: 20000
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
       containers:
       - name: kube-rbac-proxy
         args:
@@ -51,7 +58,11 @@ spec:
           protocol: TCP
         resources: {{- toYaml .Values.controller.kubeRbacProxy.resources | nindent 10 }}
         securityContext:
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       - name: manager
         args:
         - --health-probe-bind-address=:8081
@@ -95,12 +106,16 @@ spec:
           periodSeconds: 10
         resources: {{- toYaml .Values.controller.manager.resources | nindent 10 }}
         securityContext:
+          capabilities:
+            drop:
+              - ALL
           allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /var/run/podinfo
           name: podinfo
-      securityContext:
-        runAsNonRoot: true
       serviceAccountName: {{ include "chart.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
@@ -131,12 +146,26 @@ spec:
     metadata:
       name: {{ include "chart.fullname" . }}-pre-delete-controller-cleanup
     spec:
+      securityContext:
+        runAsUser: 10000
+        runAsGroup: 30000
+        fsGroup: 20000
       serviceAccountName: {{ include "chart.fullname" . }}-controller-manager
       containers:
       - name: pre-delete-controller-cleanup
+        resources: {{- toYaml .Values.controller.manager.resources | nindent 10 }}
         image: {{ .Values.controller.manager.image.repository }}:{{ .Values.controller.manager.image.tag }}
         args:
         - --finalizer-cleanup=true
         command:
         - /vault-secrets-operator
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
       restartPolicy: Never

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -37,7 +37,6 @@ spec:
       securityContext:
         runAsUser: 10000
         runAsGroup: 30000
-        fsGroup: 20000
         seccompProfile:
           type: RuntimeDefault
         runAsNonRoot: true
@@ -149,7 +148,6 @@ spec:
       securityContext:
         runAsUser: 10000
         runAsGroup: 30000
-        fsGroup: 20000
       serviceAccountName: {{ include "chart.fullname" . }}-controller-manager
       containers:
       - name: pre-delete-controller-cleanup


### PR DESCRIPTION
Adds a minimum subset of `securityContext` settings to the VSO deployment to comply with `restricted:v1.25` mode of the PSS subsystem which is the first GA version of PSS in Kubernetes.

This is in advance of compliance efforts and potential OpenShift support which tend to have configurations that support the [PodSecurityAdmission](https://kubernetes.io/blog/2022/08/25/pod-security-admission-stable/) system and default it to `restricted` mode, which is the most restricted.
If we are able to run in the most restricted mode, this should cover the other modes.

If you apply the following [labels](https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/) on a Kube-1.25+ config to the vso namespace which results in enforcing PSA policies on the vso namespace:
```
kubectl label --overwrite ns vault-secrets-operator-system pod-security.kubernetes.io/enforce=restricted pod-security.kubernetes.io/enforce-version=v1.25
```
This will result in various failures to deploy which can be seen in `kubectl get events -A`, one example is:
```
11m         Warning   FailedCreate        job/test-vault-secrets-operator-pre-delete-controller-cleanup          Error creating: pods "test-vault-secrets-operator-pre-delete-controller-cleanup-slkj2" is forbidden: violates PodSecurity "restricted:v1.25": allowPrivilegeEscalation != false (container "pre-delete-controller-cleanup" must set securityContext.allowPrivilegeEscalation=false)
```

The changes to the `deployment.yaml` enable the operator to be deployed in a `restricted:v1.25` namespace and run without problem.

This fixes some failures noted by the `checkov` tool as well.
