### PR TITLE
Fix deployment templating so that kubernetesClusterDomain can be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 Bugs:
-* Controller Deployment: Fix such that setting `controller.kubernetesClusterDomain` works as defined in values.yaml.
+* Helm Chart: fix deployment templating so setting `controller.kubernetesClusterDomain` works as defined in values.yaml. [GH-183](https://github.com/hashicorp/vault-secrets-operator/pull/183)
 
 Features:
 * VaultDynamicSecrets: CRD is extended with `Revoke` field which will result in the dynamic secret lease being revoked on rotation and CR deletion. Note: The VaultAuthMethod referenced by the VDS Secret must have a policy which provides `["update"]` on `sys/leases/revoke`. [GH-143](https://github.com/hashicorp/vault-secrets-operator/pull/143)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Bugs:
+* Controller Deployment: Fix such that setting `controller.kubernetesClusterDomain` works as defined in values.yaml.
+
 Features:
 * VaultDynamicSecrets: CRD is extended with `Revoke` field which will result in the dynamic secret lease being revoked on rotation and CR deletion. Note: The VaultAuthMethod referenced by the VDS Secret must have a policy which provides `["update"]` on `sys/leases/revoke`. [GH-143](https://github.com/hashicorp/vault-secrets-operator/pull/143)
 * VaultAuth: Adds support for the JWT authentication method which either uses the JWT token from the provided secret reference, or a service account JWT token that VSO will generate using the provided service account. [GH-131](https://github.com/hashicorp/vault-secrets-operator/pull/131)

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - --v=0
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
-          value: {{ .Values.kubernetesClusterDomain }}
+          value: {{ .Values.controller.kubernetesClusterDomain }}
         image: {{ .Values.controller.kubeRbacProxy.image.repository }}:{{ .Values.controller.kubeRbacProxy.image.tag }}
         ports:
         - containerPort: 8443
@@ -78,7 +78,7 @@ spec:
             fieldRef:
               fieldPath: metadata.uid
         - name: KUBERNETES_CLUSTER_DOMAIN
-          value: {{ .Values.kubernetesClusterDomain }}
+          value: {{ .Values.controller.kubernetesClusterDomain }}
         image: {{ .Values.controller.manager.image.repository }}:{{ .Values.controller.manager.image.tag }}
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/test/unit/deployment.bats
+++ b/test/unit/deployment.bats
@@ -156,4 +156,34 @@ load _helpers
     [ "${actual}" = "true" ]
 }
 
+#--------------------------------------------------------------------
+# kubernetesClusterDomain
 
+@test "controller/Deployment: controller.kubernetesClusterDomain not set by default" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/deployment.yaml  \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec | select(documentIndex == 1)' | tee /dev/stderr)
+
+   local actual=$(echo "$object" | yq '.containers[0].env | map(select(.name == "KUBERNETES_CLUSTER_DOMAIN")) | .[] .value' | tee /dev/stderr)
+    [ "${actual}" = "cluster.local" ]
+
+   actual=$(echo "$object" | yq '.containers[1].env | map(select(.name == "KUBERNETES_CLUSTER_DOMAIN")) | .[] .value' | tee /dev/stderr)
+    [ "${actual}" = "cluster.local" ]
+}
+
+@test "controller/Deployment: controller.kubernetesClusterDomain can be set" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/deployment.yaml  \
+      --set 'controller.kubernetesClusterDomain=foo.bar' \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec | select(documentIndex == 1)' | tee /dev/stderr)
+
+   local actual=$(echo "$object" | yq '.containers[0].env | map(select(.name == "KUBERNETES_CLUSTER_DOMAIN")) | .[] .value' | tee /dev/stderr)
+    [ "${actual}" = "foo.bar" ]
+
+   actual=$(echo "$object" | yq '.containers[1].env | map(select(.name == "KUBERNETES_CLUSTER_DOMAIN")) | .[] .value' | tee /dev/stderr)
+    [ "${actual}" = "foo.bar" ]
+}


### PR DESCRIPTION
Previously setting `controller.kubernetesClusterDomain` in `values.yaml` did not do anything as the templating was incorrect. This PR fixes the deployment templating so that it can be set according to the values.yaml definition.

Fixes #181 