### PR TITLE
VDS: sync CRD config to Helm chart

### DIFF
--- a/chart/crds/vaultdynamicsecret-crd.yaml
+++ b/chart/crds/vaultdynamicsecret-crd.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -74,6 +75,11 @@ spec:
               namespace:
                 description: Namespace where the secrets engine is mounted in Vault.
                 type: string
+              path:
+                description: Path in Vault to get the credentials for, and is relative
+                  to Mount. Please consult https://developer.hashicorp.com/vault/docs/secrets
+                  if one is uncertain about what 'path' should be set to.
+                type: string
               renewalPercent:
                 default: 67
                 description: RenewalPercent is the percent out of 100 of the lease
@@ -86,9 +92,6 @@ spec:
                 description: Revoke the existing lease when a lease is rotated or
                   on VDS resource deletion.
                 type: boolean
-              role:
-                description: Role in Vault to get the credentials for.
-                type: string
               rolloutRestartTargets:
                 description: RolloutRestartTargets should be configured whenever the
                   application(s) consuming the Vault secret does not support dynamically
@@ -127,7 +130,7 @@ spec:
             required:
             - destination
             - mount
-            - role
+            - path
             type: object
           status:
             description: VaultDynamicSecretStatus defines the observed state of VaultDynamicSecret


### PR DESCRIPTION
When working on #172 we missed updating the Helm chart to reflect the new CRD schema.