### PR TITLE
Support setting kv-v2 version for VaultStaticSecret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Features:
 Improvements:
 * VaultDynamicSecrets (VDS): Generate new credentials if lease renewal TTL is truncated [GH-170](https://github.com/hashicorp/vault-secrets-operator/pull/170)
 * VaultDynamicSecrets (VDS): Replace `Spec.Role` with `Spec.Path` (**breaking change**) [GH-172](https://github.com/hashicorp/vault-secrets-operator/pull/172)
+* VaultStaticSecrets (VSS): Add `Spec.Version` field to support fetching a specific kv-v2 secret version [GH-200](https://github.com/hashicorp/vault-secrets-operator/pull/200)
 
 ## 0.1.0-beta (March 29th, 2023)
 

--- a/api/v1alpha1/vaultstaticsecret_types.go
+++ b/api/v1alpha1/vaultstaticsecret_types.go
@@ -22,6 +22,10 @@ type VaultStaticSecretSpec struct {
 	Mount string `json:"mount"`
 	// Name of the secret in Vault
 	Name string `json:"name"`
+	// Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:
+	// https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version
+	// +kubebuilder:validation:Minimum=0
+	Version int `json:"version,omitempty"`
 	// Type of the Vault static secret
 	// +kubebuilder:validation:Enum={kv-v1,kv-v2}
 	Type string `json:"type"`

--- a/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -131,6 +131,11 @@ spec:
                   specified the Operator will default to the `default` VaultAuth,
                   configured in its own Kubernetes namespace.
                 type: string
+              version:
+                description: 'Version of the secret to fetch. Only valid for type
+                  kv-v2. Corresponds to version query parameter: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version'
+                minimum: 0
+                type: integer
             required:
             - destination
             - mount

--- a/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -131,6 +131,11 @@ spec:
                   specified the Operator will default to the `default` VaultAuth,
                   configured in its own Kubernetes namespace.
                 type: string
+              version:
+                description: 'Version of the secret to fetch. Only valid for type
+                  kv-v2. Corresponds to version query parameter: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version'
+                minimum: 0
+                type: integer
             required:
             - destination
             - mount

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -93,7 +93,11 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		resp, err = w.Get(ctx, o.Spec.Name)
+		if o.Spec.Version == 0 {
+			resp, err = w.Get(ctx, o.Spec.Name)
+		} else {
+			resp, err = w.GetVersion(ctx, o.Spec.Name, o.Spec.Version)
+		}
 	default:
 		err = fmt.Errorf("unsupported secret type %q", o.Spec.Type)
 		logger.Error(err, "")

--- a/test/integration/vaultstaticsecret_integration_test.go
+++ b/test/integration/vaultstaticsecret_integration_test.go
@@ -429,7 +429,7 @@ func TestVaultStaticSecret_kv(t *testing.T) {
 						t.Parallel()
 
 						mount := kvType + testID
-						dest := fmt.Sprintf("create-%s-%d", kvType, idx)
+						dest := fmt.Sprintf("%s-%s-%d", tt.name, kvType, idx)
 						expected := expectedData{
 							initial: map[string]interface{}{"dest-initial": dest},
 							update:  map[string]interface{}{"dest-updated": dest},

--- a/test/integration/vaultstaticsecret_integration_test.go
+++ b/test/integration/vaultstaticsecret_integration_test.go
@@ -275,6 +275,7 @@ func TestVaultStaticSecret_kv(t *testing.T) {
 		expectedExisting []expectedData
 		create           int
 		createTypes      []string
+		version          int
 	}{
 		{
 			name: "existing",
@@ -299,6 +300,12 @@ func TestVaultStaticSecret_kv(t *testing.T) {
 			name:        "create-kv-v2",
 			create:      2,
 			createTypes: []string{consts.KVSecretTypeV2},
+		},
+		{
+			name:        "create-kv-v2-fixed-version",
+			create:      2,
+			createTypes: []string{consts.KVSecretTypeV2},
+			version:     1,
 		},
 		{
 			name:        "create-both",
@@ -355,7 +362,11 @@ func TestVaultStaticSecret_kv(t *testing.T) {
 		} else {
 			putKV(t, obj, expected.update)
 
-			data = expected.update
+			if obj.Spec.Version == 1 {
+				data = expected.initial
+			} else {
+				data = expected.update
+			}
 		}
 
 		secret, err := waitForSecretData(t, ctx, crdClient, 30, 1*time.Second, obj.Spec.Destination.Name,
@@ -441,6 +452,9 @@ func TestVaultStaticSecret_kv(t *testing.T) {
 								RefreshAfter:   "5s",
 								HMACSecretData: true,
 							},
+						}
+						if tt.version != 0 {
+							vssObj.Spec.Version = tt.version
 						}
 
 						if !skipCleanup {


### PR DESCRIPTION
Adds support for specifying the [version](https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version) of a kv-v2 secret, so that when there are different personas managing the secret contents and the consuming application, they can more easily coordinate rollout and rollback.