### PR TITLE
Extend Client.Init() tests

### DIFF
--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -522,6 +522,13 @@ func (c *defaultClient) init(ctx context.Context, client ctrlclient.Client,
 	authObj *secretsv1alpha1.VaultAuth, connObj *secretsv1alpha1.VaultConnection,
 	providerNamespace string, opts *ClientOptions,
 ) error {
+	if connObj == nil {
+		return errors.New("VaultConnection was nil")
+	}
+	if authObj == nil {
+		return errors.New("VaultAuth was nil")
+	}
+
 	cfg := &ClientConfig{
 		Address:         connObj.Spec.Address,
 		SkipTLSVerify:   connObj.Spec.SkipTLSVerify,

--- a/internal/vault/client_test.go
+++ b/internal/vault/client_test.go
@@ -173,226 +173,226 @@ func Test_defaultClient_Init(t *testing.T) {
 	ca, err := generateCA()
 	require.NoError(t, err)
 
+	defaultAuthObj := &secretsv1alpha1.VaultAuth{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "vso",
+		},
+		Spec: secretsv1alpha1.VaultAuthSpec{
+			VaultConnectionRef: "default",
+			Method:             credentials.ProviderMethodKubernetes,
+			Mount:              "kubernetes",
+			Kubernetes: &secretsv1alpha1.VaultAuthConfigKubernetes{
+				ServiceAccount: "default",
+			},
+		},
+	}
+
+	defaultConnObj := &secretsv1alpha1.VaultConnection{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "vso",
+		},
+		Spec: secretsv1alpha1.VaultConnectionSpec{
+			CACertSecretRef: "baz",
+			SkipTLSVerify:   false,
+		},
+	}
+
+	connObjSkipTLSVerify := &secretsv1alpha1.VaultConnection{
+		ObjectMeta: defaultConnObj.ObjectMeta,
+		Spec: secretsv1alpha1.VaultConnectionSpec{
+			CACertSecretRef: "baz",
+			SkipTLSVerify:   true,
+		},
+	}
+
 	tests := []struct {
-		name              string
-		client            ctrlclient.Client
-		authObj           *secretsv1alpha1.VaultAuth
-		connObj           *secretsv1alpha1.VaultConnection
-		createNamespaces  bool
-		createCASecret    bool
-		caSecretData      map[string][]byte
-		providerNamespace string
-		opts              *ClientOptions
-		wantErr           assert.ErrorAssertionFunc
+		name                  string
+		client                ctrlclient.Client
+		authObj               *secretsv1alpha1.VaultAuth
+		connObj               *secretsv1alpha1.VaultConnection
+		withoutCASecret       bool
+		withoutServiceAccount bool
+		caSecretData          map[string][]byte
+		providerNamespace     string
+		opts                  *ClientOptions
+		wantErr               assert.ErrorAssertionFunc
 	}{
 		{
-			name:             "valid-secret-ca-cert",
-			createNamespaces: true,
-			createCASecret:   true,
+			name: "valid-secret-ca-cert",
 			caSecretData: map[string][]byte{
 				consts.TLSSecretCAKey: ca,
 			},
-			client: fake.NewClientBuilder().Build(),
-			authObj: &secretsv1alpha1.VaultAuth{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default",
-					Namespace: "vso",
-				},
-				Spec: secretsv1alpha1.VaultAuthSpec{
-					VaultConnectionRef: "default",
-					Method:             credentials.ProviderMethodKubernetes,
-					Mount:              "kubernetes",
-					Kubernetes: &secretsv1alpha1.VaultAuthConfigKubernetes{
-						ServiceAccount: "default",
-					},
-				},
-			},
-			connObj: &secretsv1alpha1.VaultConnection{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default",
-					Namespace: "vso",
-				},
-				Spec: secretsv1alpha1.VaultConnectionSpec{
-					CACertSecretRef: "baz",
-					SkipTLSVerify:   false,
-				},
-			},
-			providerNamespace: "vso",
+			client:            fake.NewClientBuilder().Build(),
+			authObj:           defaultAuthObj,
+			connObj:           defaultConnObj,
+			providerNamespace: defaultConnObj.Namespace,
 			wantErr:           assert.NoError,
 		},
 		{
-			name:             "invalid-secret-missing-ca-cert",
-			createNamespaces: true,
-			createCASecret:   true,
-			client:           fake.NewClientBuilder().Build(),
-			authObj: &secretsv1alpha1.VaultAuth{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default",
-					Namespace: "vso",
-				},
-				Spec: secretsv1alpha1.VaultAuthSpec{
-					VaultConnectionRef: "default",
-					Method:             credentials.ProviderMethodKubernetes,
-					Mount:              "kubernetes",
-					Kubernetes: &secretsv1alpha1.VaultAuthConfigKubernetes{
-						ServiceAccount: "default",
-					},
-				},
+			name: "valid-secret-ca-cert-other-provider-ns",
+			caSecretData: map[string][]byte{
+				consts.TLSSecretCAKey: ca,
 			},
-			connObj: &secretsv1alpha1.VaultConnection{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default",
-					Namespace: "vso",
-				},
-				Spec: secretsv1alpha1.VaultConnectionSpec{
-					CACertSecretRef: "baz",
-				},
-			},
-			providerNamespace: "vso",
+			client:            fake.NewClientBuilder().Build(),
+			authObj:           defaultAuthObj,
+			connObj:           defaultConnObj,
+			providerNamespace: "vso-provider-ns",
+			wantErr:           assert.NoError,
+		},
+		{
+			name:    "error-secret-missing-ca-cert",
+			client:  fake.NewClientBuilder().Build(),
+			authObj: defaultAuthObj,
+			connObj: defaultConnObj,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.EqualError(t, err, fmt.Sprintf(
 					`%q not present in the CA secret "%s/%s"`, consts.TLSSecretCAKey, "vso", "baz"), i...)
 			},
 		},
 		{
-			name:             "invalid-empty-ca-cert",
-			createNamespaces: true,
-			createCASecret:   true,
+			name: "valid-empty-ca-cert-without-tls-verify",
 			caSecretData: map[string][]byte{
 				consts.TLSSecretCAKey: {},
 			},
-			client: fake.NewClientBuilder().Build(),
-			authObj: &secretsv1alpha1.VaultAuth{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default",
-					Namespace: "vso",
-				},
-				Spec: secretsv1alpha1.VaultAuthSpec{
-					VaultConnectionRef: "default",
-					Method:             credentials.ProviderMethodKubernetes,
-					Mount:              "kubernetes",
-					Kubernetes: &secretsv1alpha1.VaultAuthConfigKubernetes{
-						ServiceAccount: "default",
-					},
-				},
+			client:            fake.NewClientBuilder().Build(),
+			authObj:           defaultAuthObj,
+			connObj:           connObjSkipTLSVerify,
+			providerNamespace: "provider-vso",
+			wantErr:           assert.NoError,
+		},
+		{
+			name: "invalid-empty-ca-cert-with-tls-verify",
+			caSecretData: map[string][]byte{
+				consts.TLSSecretCAKey: {},
 			},
-			connObj: &secretsv1alpha1.VaultConnection{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default",
-					Namespace: "vso",
-				},
-				Spec: secretsv1alpha1.VaultConnectionSpec{
-					CACertSecretRef: "baz",
-					SkipTLSVerify:   false,
-				},
-			},
-			providerNamespace: "vso",
+			client:  fake.NewClientBuilder().Build(),
+			authObj: defaultAuthObj,
+			connObj: defaultConnObj,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.EqualError(t, err, fmt.Sprintf(
 					`no valid certificates found for key %q in CA secret "%s/%s"`, consts.TLSSecretCAKey, "vso", "baz"))
 			},
 		},
 		{
-			name:             "valid-empty-ca-cert-skip-tls-verify",
-			createNamespaces: true,
-			createCASecret:   true,
+			name:                  "invalid-service-account-not-found",
+			withoutServiceAccount: true,
 			caSecretData: map[string][]byte{
 				consts.TLSSecretCAKey: {},
 			},
-			client: fake.NewClientBuilder().Build(),
-			authObj: &secretsv1alpha1.VaultAuth{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default",
-					Namespace: "vso",
-				},
-				Spec: secretsv1alpha1.VaultAuthSpec{
-					VaultConnectionRef: "default",
-					Method:             credentials.ProviderMethodKubernetes,
-					Mount:              "kubernetes",
-					Kubernetes: &secretsv1alpha1.VaultAuthConfigKubernetes{
-						ServiceAccount: "default",
-					},
-				},
+			client:  fake.NewClientBuilder().Build(),
+			authObj: defaultAuthObj,
+			connObj: connObjSkipTLSVerify,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err, fmt.Sprintf(
+					"serviceaccounts %q not found", "default"))
 			},
-			connObj: &secretsv1alpha1.VaultConnection{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default",
-					Namespace: "vso",
-				},
-				Spec: secretsv1alpha1.VaultConnectionSpec{
-					CACertSecretRef: "baz",
-					SkipTLSVerify:   true,
-				},
+		},
+		{
+			name:            "invalid-missing-secret",
+			withoutCASecret: true,
+			authObj:         defaultAuthObj,
+			connObj:         defaultConnObj,
+			client:          fake.NewClientBuilder().Build(),
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err, fmt.Sprintf(
+					`secrets %q not found`, "baz"))
 			},
-			providerNamespace: "vso",
-			wantErr:           assert.NoError,
+		},
+		{
+			name:            "invalid-nil-VaultConnection",
+			authObj:         defaultAuthObj,
+			connObj:         nil,
+			client:          fake.NewClientBuilder().Build(),
+			withoutCASecret: true,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err, "VaultConnection was nil")
+			},
+		},
+		{
+			name:                  "invalid-nil-VaultAuth",
+			authObj:               nil,
+			connObj:               defaultConnObj,
+			withoutServiceAccount: true,
+			client:                fake.NewClientBuilder().Build(),
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err, "VaultAuth was nil")
+			},
+		},
+		{
+			name:                  "invalid-nil-ctrl-client",
+			withoutCASecret:       true,
+			withoutServiceAccount: true,
+			authObj:               defaultAuthObj,
+			connObj:               defaultConnObj,
+			client:                nil,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err, "ctrl-runtime Client was nil")
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.createNamespaces {
-				ns := &corev1.Namespace{
+			if !tt.withoutCASecret {
+				require.NotNil(t, tt.client)
+				require.NotNil(t, tt.connObj)
+
+				require.NoError(t, tt.client.Create(ctx, &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: tt.connObj.Namespace,
+						Namespace: tt.connObj.Namespace,
+						Name:      tt.connObj.Spec.CACertSecretRef,
 					},
-				}
-
-				require.NoError(t, tt.client.Create(ctx, ns))
-
-				if tt.authObj.Spec.Kubernetes.ServiceAccount != "" {
-					sa := &corev1.ServiceAccount{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      tt.authObj.Spec.Kubernetes.ServiceAccount,
-							Namespace: tt.authObj.Namespace,
-						},
-					}
-
-					require.NoError(t, tt.client.Create(ctx, sa))
-				}
-
-				if tt.createCASecret {
-					secret := &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: tt.connObj.Namespace,
-							Name:      tt.connObj.Spec.CACertSecretRef,
-						},
-						Data: tt.caSecretData,
-						Type: "kubernetes.io/tls",
-					}
-
-					require.NoError(t, tt.client.Create(ctx, secret))
-				}
-
-				c := &defaultClient{}
-
-				err := c.Init(ctx, tt.client, tt.authObj, tt.connObj, tt.providerNamespace, tt.opts)
-				tt.wantErr(t, err,
-					fmt.Sprintf("Init(%v, %v, %v, %v, %v, %v)",
-						ctx, tt.client, tt.authObj, tt.connObj, tt.providerNamespace, tt.opts))
-
-				opts := tt.opts
-				if opts == nil {
-					opts = defaultClientOptions()
-				}
-				assert.Equal(t, opts.SkipRenewal, c.skipRenewal)
-
-				if err != nil {
-					assert.Nil(t, c.authObj)
-					assert.Nil(t, c.connObj)
-					return
-				}
-
-				assert.Equal(t, tt.connObj, c.connObj)
-				assert.Equal(t, tt.authObj, c.authObj)
-
-				if assert.NotNil(t, c.client, "vault client not set from Init()") {
-					return
-				}
-
-				actualPool := c.client.CloneConfig().TLSConfig().RootCAs
-				expectedPool := getTestCertPool(t, tt.caSecretData[consts.TLSSecretCAKey])
-				assert.True(t, expectedPool.Equal(actualPool))
+					Data: tt.caSecretData,
+					Type: "kubernetes.io/tls",
+				}))
 			}
+
+			if !tt.withoutServiceAccount {
+				require.NotNil(t, tt.client)
+				require.NotNil(t, tt.authObj)
+
+				ns := tt.authObj.Namespace
+				if tt.providerNamespace != "" {
+					ns = tt.providerNamespace
+				}
+				require.NoError(t, tt.client.Create(ctx, &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tt.authObj.Spec.Kubernetes.ServiceAccount,
+						Namespace: ns,
+					},
+				}))
+			}
+
+			c := &defaultClient{}
+
+			err := c.Init(ctx, tt.client, tt.authObj, tt.connObj, tt.providerNamespace, tt.opts)
+			tt.wantErr(t, err,
+				fmt.Sprintf("Init(%v, %v, %v, %v, %v, %v)",
+					ctx, tt.client, tt.authObj, tt.connObj, tt.providerNamespace, tt.opts))
+
+			opts := tt.opts
+			if opts == nil {
+				opts = defaultClientOptions()
+			}
+			assert.Equal(t, opts.SkipRenewal, c.skipRenewal)
+
+			if err != nil {
+				assert.Nil(t, c.authObj)
+				assert.Nil(t, c.connObj)
+				return
+			}
+
+			assert.Equal(t, tt.connObj, c.connObj)
+			assert.Equal(t, tt.authObj, c.authObj)
+
+			if assert.NotNil(t, c.client, "vault client not set from Init()") {
+				return
+			}
+
+			actualPool := c.client.CloneConfig().TLSConfig().RootCAs
+			expectedPool := getTestCertPool(t, tt.caSecretData[consts.TLSSecretCAKey])
+			assert.True(t, expectedPool.Equal(actualPool))
 		})
 	}
 }

--- a/internal/vault/config.go
+++ b/internal/vault/config.go
@@ -44,6 +44,10 @@ func MakeVaultClient(ctx context.Context, cfg *ClientConfig, client ctrlclient.C
 		return nil, fmt.Errorf("ClientConfig was nil")
 	}
 
+	if client == nil {
+		return nil, fmt.Errorf("ctrl-runtime Client was nil")
+	}
+
 	var b []byte
 	if cfg.CACertSecretRef != "" {
 		objKey := ctrlclient.ObjectKey{


### PR DESCRIPTION
The Client.Init() tests now provide more coverage and cover the original regression.