### PR TITLE
update helm gen to directly modify files in vault repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -643,9 +643,9 @@ clean:
 
 
 # Generate Helm reference docs from values.yaml and update Vault website.
-# Usage: make gen-helm-docs vault=<path-to-vault-repo>.
-# If not options are given, the local copy of docs/helm.mdx will be updated, which can
-# be used to submit a PR to vault docs.
+# Usage: make gen-helm-docs
+# If no options are given, helm.mdx from a local copy of the vault repository will be used.
 # Adapted from https://github.com/hashicorp/consul-k8s/tree/main/hack/helm-reference-gen
+VAULT_DOCS_PATH ?= $(GOPATH)/src/github.com/hashicorp/vault/website/content/docs/platform/k8s/vso/helm.mdx
 gen-helm-docs:
-	@cd hack/helm-reference-gen; go run ./... --vault=$(vault)
+	@cd hack/helm-reference-gen; go run ./... --vault=$(VAULT_DOCS_PATH)

--- a/Makefile
+++ b/Makefile
@@ -646,6 +646,6 @@ clean:
 # Usage: make gen-helm-docs
 # If no options are given, helm.mdx from a local copy of the vault repository will be used.
 # Adapted from https://github.com/hashicorp/consul-k8s/tree/main/hack/helm-reference-gen
-VAULT_DOCS_PATH ?= $(GOPATH)/src/github.com/hashicorp/vault/website/content/docs/platform/k8s/vso/helm.mdx
+VAULT_DOCS_PATH ?= ../vault/website/content/docs/platform/k8s/vso/helm.mdx
 gen-helm-docs:
 	@cd hack/helm-reference-gen; go run ./... --vault=$(VAULT_DOCS_PATH)

--- a/hack/helm-reference-gen/main.go
+++ b/hack/helm-reference-gen/main.go
@@ -76,9 +76,10 @@ var (
 func main() {
 	validateFlag := flag.Bool("validate", false, "only validate that the markdown can be generated, don't actually generate anything")
 	vaultMdxFlag := flag.String("vault", "", "path to the helm reference documentation file")
-	chartDocsPath := "../../"
+	chartDocsPath := ""
 	flag.Parse()
 
+	// Fallback to the local copy of docs/helm.mdx, should not really be used anymore.
 	if *vaultMdxFlag == "" {
 		*vaultMdxFlag = "docs/helm.mdx"
 	}
@@ -90,19 +91,14 @@ func main() {
 
 	if !*validateFlag {
 		// Only argument is path to Vault repo. If not set then we default.
-		if len(os.Args) < 2 {
-			abs, _ := filepath.Abs(chartDocsPath)
-			fmt.Printf("Defaulting to Vault repo path: %s\n", abs)
+		// Support absolute and relative paths to the Vault repo.
+		if filepath.IsAbs(*vaultMdxFlag) {
+			chartDocsPath = *vaultMdxFlag
 		} else {
-			// Support absolute and relative paths to the Vault repo.
-			if filepath.IsAbs(os.Args[1]) {
-				chartDocsPath = os.Args[1]
-			} else {
-				chartDocsPath = filepath.Join("../..", *vaultMdxFlag)
-			}
-			abs, _ := filepath.Abs(chartDocsPath)
-			fmt.Printf("Using Vault repo path: %s\n", abs)
+			chartDocsPath = filepath.Join("../..", *vaultMdxFlag)
 		}
+		abs, _ := filepath.Abs(chartDocsPath)
+		fmt.Printf("Using Vault repo path: %s\n", abs)
 	}
 
 	// Parse the values.yaml file.


### PR DESCRIPTION
* Updates the helm-gen tool and Makefile to use a path to the local copy of the helm documentation in the `hashicorp/vault` website repository.

This was used to generate https://github.com/hashicorp/vault/pull/20776.