### PR TITLE
Use the kubernetes_default_service_account resource for vaultauthmethod test

### DIFF
--- a/test/integration/vaultauthmethods/terraform/main.tf
+++ b/test/integration/vaultauthmethods/terraform/main.tf
@@ -36,19 +36,18 @@ resource "kubernetes_namespace" "tenant-1" {
   }
 }
 
-resource "kubernetes_service_account" "test-sa" {
+resource "kubernetes_default_service_account" "default-sa" {
   metadata {
-    name      = var.test_service_account
     namespace = kubernetes_namespace.tenant-1.metadata[0].name
   }
 }
 
-resource "kubernetes_secret" "test-sa-secret" {
+resource "kubernetes_secret" "default-sa-secret" {
   metadata {
     namespace = kubernetes_namespace.tenant-1.metadata[0].name
     name      = "test-sa-secret"
     annotations = {
-      "kubernetes.io/service-account.name" = kubernetes_service_account.test-sa.metadata[0].name
+      "kubernetes.io/service-account.name" = kubernetes_default_service_account.default-sa.metadata[0].name
     }
   }
   type                           = "kubernetes.io/service-account-token"
@@ -98,7 +97,7 @@ resource "vault_kubernetes_auth_backend_role" "default" {
   namespace                        = vault_auth_backend.default.namespace
   backend                          = vault_kubernetes_auth_backend_config.default.backend
   role_name                        = var.auth_role
-  bound_service_account_names      = [kubernetes_service_account.test-sa.metadata[0].name]
+  bound_service_account_names      = [kubernetes_default_service_account.default-sa.metadata[0].name]
   bound_service_account_namespaces = [kubernetes_namespace.tenant-1.metadata[0].name]
   token_ttl                        = 3600
   token_policies                   = [vault_policy.default.name]
@@ -110,7 +109,7 @@ resource "vault_jwt_auth_backend" "dev" {
   namespace             = local.namespace
   path                  = "jwt"
   oidc_discovery_url    = "https://kubernetes.default.svc.cluster.local"
-  oidc_discovery_ca_pem = nonsensitive(kubernetes_secret.test-sa-secret.data["ca.crt"])
+  oidc_discovery_ca_pem = nonsensitive(kubernetes_secret.default-sa-secret.data["ca.crt"])
 }
 
 resource "vault_jwt_auth_backend_role" "dev" {

--- a/test/integration/vaultauthmethods/terraform/main.tf
+++ b/test/integration/vaultauthmethods/terraform/main.tf
@@ -113,12 +113,13 @@ resource "vault_jwt_auth_backend" "dev" {
 }
 
 resource "vault_jwt_auth_backend_role" "dev" {
-  namespace      = vault_jwt_auth_backend.dev.namespace
-  backend        = "jwt"
-  role_name      = var.auth_role
-  role_type      = "jwt"
-  user_claim     = "sub"
-  token_policies = [vault_policy.default.name]
+  namespace       = vault_jwt_auth_backend.dev.namespace
+  backend         = "jwt"
+  role_name       = var.auth_role
+  role_type       = "jwt"
+  bound_audiences = ["vault"]
+  user_claim      = "sub"
+  token_policies  = [vault_policy.default.name]
 }
 
 # Create the Vault Auth Backend for AppRole

--- a/test/integration/vaultauthmethods_integration_test.go
+++ b/test/integration/vaultauthmethods_integration_test.go
@@ -32,7 +32,6 @@ func TestVaultAuthMethods(t *testing.T) {
 	testVaultNamespace := ""
 	k8sConfigContext := "kind-" + clusterName
 	appRoleMountPath := "approle"
-	testServiceAccount := "test-sa"
 
 	require.NotEmpty(t, clusterName, "KIND_CLUSTER_NAME is not set")
 	operatorNS := os.Getenv("OPERATOR_NAMESPACE")
@@ -60,7 +59,6 @@ func TestVaultAuthMethods(t *testing.T) {
 			"vault_kvv2_mount_path":        testKvv2MountPath,
 			"operator_helm_chart_path":     chartPath,
 			"approle_mount_path":           appRoleMountPath,
-			"test_service_account":         testServiceAccount,
 		},
 	}
 	if operatorImageRepo != "" {
@@ -122,7 +120,7 @@ func TestVaultAuthMethods(t *testing.T) {
 				Mount:     "kubernetes",
 				Kubernetes: &secretsv1alpha1.VaultAuthConfigKubernetes{
 					Role:           outputs.AuthRole,
-					ServiceAccount: testServiceAccount,
+					ServiceAccount: consts.NameDefault,
 					TokenAudiences: []string{"vault"},
 				},
 			},
@@ -138,7 +136,7 @@ func TestVaultAuthMethods(t *testing.T) {
 				Mount:     "jwt",
 				JWT: &secretsv1alpha1.VaultAuthConfigJWT{
 					Role:           outputs.AuthRole,
-					ServiceAccount: testServiceAccount,
+					ServiceAccount: consts.NameDefault,
 					TokenAudiences: []string{"vault"},
 				},
 			},


### PR DESCRIPTION
This is a follow-on change to #208 which introduced it's own serviceaccount to ensure that we could get a valid JWT token for authentication in the auth method tests.
Instead of creating our own serviceaccount we will use `kubernetes_default_service_account` resources which provide a guarantee that the default serviceaccount for a namespace does exist.