### PR TITLE
chart: adding aws to defaultAuth and storageEncryption auth

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -105,5 +105,29 @@ VaultAuthMethod Spec
   {{- if $cur.params }}
   params:
     {{- toYaml $cur.params | nindent 8 }}
+  {{- else if eq $cur.method "aws" }}
+  aws:
+    role: {{ $cur.aws.role }}
+    {{- if $cur.aws.region }}
+    region: {{ $cur.aws.region }}
+    {{- end }}
+    {{- if $cur.aws.headerValue }}
+    headerValue: {{ $cur.aws.headerValue }}
+    {{- end }}
+    {{- if $cur.aws.sessionName }}
+    sessionName: {{ $cur.aws.sessionName }}
+    {{- end }}
+    {{- if $cur.aws.stsEndpoint }}
+    stsEndpoint: {{ $cur.aws.stsEndpoint }}
+    {{- end }}
+    {{- if $cur.aws.iamEndpoint }}
+    iamEndpoint: {{ $cur.aws.iamEndpoint }}
+    {{- end }}
+    {{- if $cur.aws.secretRef }}
+    secretRef: {{ $cur.aws.secretRef }}
+    {{- end }}
+    {{- if $cur.aws.irsaServiceAccount }}
+    irsaServiceAccount: {{ $cur.aws.irsaServiceAccount }}
+    {{- end }}
   {{- end }}
 {{- end}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -167,6 +167,45 @@ controller:
           # @type: string
           secretName: ""
 
+        # AWS auth method specific configuration
+        aws:
+          # Vault Auth Role to use
+          # This is a required field and must be setup in Vault prior to deploying the helm chart
+          # if using the AWS for the Transit auth method.
+          # @type: string
+          role: ""
+
+          # AWS region to use for signing the authentication request
+          # Optional, but most commonly will be the EKS cluster region.
+          # @type: string
+          region: ""
+
+          # Vault header value to include in the STS signing request
+          # @type: string
+          headerValue: ""
+
+          # The role session name to use when creating a WebIdentity provider
+          # @type: string
+          sessionName: ""
+
+          # The STS endpoint to use; if not set will use the default
+          # @type: string
+          stsEndpoint: ""
+
+          # The IAM endpoint to use; if not set will use the default
+          # @type: string
+          iamEndpoint: ""
+
+          # The name of a Kubernetes Secret which holds credentials for AWS. Supported keys
+          # include `access_key_id`, `secret_access_key`, `session_token`
+          # @type: string
+          secretRef: ""
+
+          # Name of a Kubernetes service account that is configured with IAM Roles
+          # for Service Accounts (IRSA). Should be annotated with "eks.amazonaws.com/role-arn".
+          # @type: string
+          irsaServiceAccount: ""
+
         # Params to use when authenticating to Vault using this auth method.
         # params:
         #   vault-something1: "foo"
@@ -359,6 +398,45 @@ defaultAuthMethod:
     # helm chart.
     # @type: string
     secretName: ""
+
+  # AWS auth method specific configuration
+  aws:
+    # Vault Auth Role to use
+    # This is a required field and must be setup in Vault prior to deploying the helm chart
+    # if using the AWS for the default auth method.
+    # @type: string
+    role: ""
+
+    # AWS region to use for signing the authentication request
+    # Optional, but most commonly will be the region where the EKS cluster is running
+    # @type: string
+    region: ""
+
+    # Vault header value to include in the STS signing request
+    # @type: string
+    headerValue: ""
+
+    # The role session name to use when creating a WebIdentity provider
+    # @type: string
+    sessionName: ""
+
+    # The STS endpoint to use; if not set will use the default
+    # @type: string
+    stsEndpoint: ""
+
+    # The IAM endpoint to use; if not set will use the default
+    # @type: string
+    iamEndpoint: ""
+
+    # The name of a Kubernetes Secret which holds credentials for AWS. Supported keys include
+    # `access_key_id`, `secret_access_key`, `session_token`
+    # @type: string
+    secretRef: ""
+
+    # Name of a Kubernetes service account that is configured with IAM Roles
+    # for Service Accounts (IRSA). Should be annotated with "eks.amazonaws.com/role-arn".
+    # @type: string
+    irsaServiceAccount: ""
 
   # Params to use when authenticating to Vault
   # params:

--- a/test/unit/default-transit-auth-method.bats
+++ b/test/unit/default-transit-auth-method.bats
@@ -258,3 +258,90 @@ load _helpers
     actual=$(echo "$object" | yq '.spec.appRole.secretRef' | tee /dev/stderr)
     [ "${actual}" = "secret-1" ]
 }
+
+@test "defaultTransitAuthMethod/CR: settings can be modified for aws auth method - minimum" {
+    cd `chart_dir`
+    local object=$(helm template \
+        -s templates/default-transit-auth-method.yaml \
+        --set 'controller.manager.clientCache.storageEncryption.enabled=true' \
+        --set 'controller.manager.clientCache.persistenceModel=direct-encrypted' \
+        --set 'controller.manager.clientCache.storageEncryption.namespace=tenant-2' \
+        --set 'controller.manager.clientCache.storageEncryption.method=aws' \
+        --set 'controller.manager.clientCache.storageEncryption.mount=foo' \
+        --set 'controller.manager.clientCache.storageEncryption.aws.role=role-1' \
+        . | tee /dev/stderr)
+
+    local actual=$(echo "$object" | yq '.metadata.namespace' | tee /dev/stderr)
+    [ "${actual}" = "default" ]
+    actual=$(echo "$object" | yq '.spec.namespace' | tee /dev/stderr)
+    [ "${actual}" = "tenant-2" ]
+
+    actual=$(echo "$object" | yq '.spec.method' | tee /dev/stderr)
+    [ "${actual}" = "aws" ]
+    actual=$(echo "$object" | yq '.spec.mount' | tee /dev/stderr)
+    [ "${actual}" = "foo" ]
+    actual=$(echo "$object" | yq '.spec.aws.role' | tee /dev/stderr)
+    [ "${actual}" = "role-1" ]
+
+    # the rest should not be set
+    actual=$(echo "$object" | yq '.spec.aws.region' | tee /dev/stderr)
+    [ "${actual}" = null ]
+    actual=$(echo "$object" | yq '.spec.aws.headerValue' | tee /dev/stderr)
+    [ "${actual}" = null ]
+    actual=$(echo "$object" | yq '.spec.aws.sessionName' | tee /dev/stderr)
+    [ "${actual}" = null ]
+    actual=$(echo "$object" | yq '.spec.aws.stsEndpoint' | tee /dev/stderr)
+    [ "${actual}" = null ]
+    actual=$(echo "$object" | yq '.spec.aws.iamEndpoint' | tee /dev/stderr)
+    [ "${actual}" = null ]
+    actual=$(echo "$object" | yq '.spec.aws.secretRef' | tee /dev/stderr)
+    [ "${actual}" = null ]
+    actual=$(echo "$object" | yq '.spec.aws.irsaServiceAccount' | tee /dev/stderr)
+    [ "${actual}" = null ]
+}
+
+@test "defaultTransitAuthMethod/CR: settings can be modified for aws auth method - everything" {
+    cd `chart_dir`
+    local object=$(helm template \
+        -s templates/default-transit-auth-method.yaml  \
+        --set 'controller.manager.clientCache.storageEncryption.enabled=true' \
+        --set 'controller.manager.clientCache.persistenceModel=direct-encrypted' \
+        --set 'controller.manager.clientCache.storageEncryption.namespace=tenant-2' \
+        --set 'controller.manager.clientCache.storageEncryption.method=aws' \
+        --set 'controller.manager.clientCache.storageEncryption.mount=foo' \
+        --set 'controller.manager.clientCache.storageEncryption.aws.role=role-1' \
+        --set 'controller.manager.clientCache.storageEncryption.aws.region=us-test-2' \
+        --set 'controller.manager.clientCache.storageEncryption.aws.headerValue=test-value' \
+        --set 'controller.manager.clientCache.storageEncryption.aws.sessionName=new-session' \
+        --set 'controller.manager.clientCache.storageEncryption.aws.stsEndpoint=www.sts' \
+        --set 'controller.manager.clientCache.storageEncryption.aws.iamEndpoint=www.iam' \
+        --set 'controller.manager.clientCache.storageEncryption.aws.secretRef=aws-creds' \
+        --set 'controller.manager.clientCache.storageEncryption.aws.irsaServiceAccount=iam-irsa-acct' \
+        . | tee /dev/stderr)
+
+    local actual=$(echo "$object" | yq '.metadata.namespace' | tee /dev/stderr)
+    [ "${actual}" = "default" ]
+    actual=$(echo "$object" | yq '.spec.namespace' | tee /dev/stderr)
+    [ "${actual}" = "tenant-2" ]
+
+    actual=$(echo "$object" | yq '.spec.method' | tee /dev/stderr)
+    [ "${actual}" = "aws" ]
+    actual=$(echo "$object" | yq '.spec.mount' | tee /dev/stderr)
+    [ "${actual}" = "foo" ]
+    actual=$(echo "$object" | yq '.spec.aws.role' | tee /dev/stderr)
+    [ "${actual}" = "role-1" ]
+    actual=$(echo "$object" | yq '.spec.aws.region' | tee /dev/stderr)
+    [ "${actual}" = "us-test-2" ]
+    actual=$(echo "$object" | yq '.spec.aws.headerValue' | tee /dev/stderr)
+    [ "${actual}" = "test-value" ]
+    actual=$(echo "$object" | yq '.spec.aws.sessionName' | tee /dev/stderr)
+    [ "${actual}" = "new-session" ]
+    actual=$(echo "$object" | yq '.spec.aws.stsEndpoint' | tee /dev/stderr)
+    [ "${actual}" = "www.sts" ]
+    actual=$(echo "$object" | yq '.spec.aws.iamEndpoint' | tee /dev/stderr)
+    [ "${actual}" = "www.iam" ]
+    actual=$(echo "$object" | yq '.spec.aws.secretRef' | tee /dev/stderr)
+    [ "${actual}" = "aws-creds" ]
+    actual=$(echo "$object" | yq '.spec.aws.irsaServiceAccount' | tee /dev/stderr)
+    [ "${actual}" = "iam-irsa-acct" ]
+}

--- a/test/unit/default-vault-auth-method.bats
+++ b/test/unit/default-vault-auth-method.bats
@@ -223,3 +223,88 @@ load _helpers
     actual=$(echo "$object" | yq '.spec.appRole.secretRef' | tee /dev/stderr)
     [ "${actual}" = "secret-1" ]
 }
+
+@test "defaultAuthMethod/CR: settings can be modified for aws auth method - minimum" {
+    cd `chart_dir`
+    local object=$(helm template \
+        -s templates/default-vault-auth-method.yaml  \
+        --set 'defaultAuthMethod.enabled=true' \
+        --set 'defaultAuthMethod.namespace=tenant-2' \
+        --set 'defaultAuthMethod.method=aws' \
+        --set 'defaultAuthMethod.mount=foo' \
+        --set 'defaultAuthMethod.aws.role=role-1' \
+        . | tee /dev/stderr)
+
+    local actual=$(echo "$object" | yq '.metadata.namespace' | tee /dev/stderr)
+    [ "${actual}" = "default" ]
+    actual=$(echo "$object" | yq '.spec.namespace' | tee /dev/stderr)
+    [ "${actual}" = "tenant-2" ]
+
+    actual=$(echo "$object" | yq '.spec.method' | tee /dev/stderr)
+    [ "${actual}" = "aws" ]
+    actual=$(echo "$object" | yq '.spec.mount' | tee /dev/stderr)
+    [ "${actual}" = "foo" ]
+    actual=$(echo "$object" | yq '.spec.aws.role' | tee /dev/stderr)
+    [ "${actual}" = "role-1" ]
+
+    # the rest should not be set
+    actual=$(echo "$object" | yq '.spec.aws.region' | tee /dev/stderr)
+    [ "${actual}" = null ]
+    actual=$(echo "$object" | yq '.spec.aws.headerValue' | tee /dev/stderr)
+    [ "${actual}" = null ]
+    actual=$(echo "$object" | yq '.spec.aws.sessionName' | tee /dev/stderr)
+    [ "${actual}" = null ]
+    actual=$(echo "$object" | yq '.spec.aws.stsEndpoint' | tee /dev/stderr)
+    [ "${actual}" = null ]
+    actual=$(echo "$object" | yq '.spec.aws.iamEndpoint' | tee /dev/stderr)
+    [ "${actual}" = null ]
+    actual=$(echo "$object" | yq '.spec.aws.secretRef' | tee /dev/stderr)
+    [ "${actual}" = null ]
+    actual=$(echo "$object" | yq '.spec.aws.irsaServiceAccount' | tee /dev/stderr)
+    [ "${actual}" = null ]
+}
+
+@test "defaultAuthMethod/CR: settings can be modified for aws auth method - everything" {
+    cd `chart_dir`
+    local object=$(helm template \
+        -s templates/default-vault-auth-method.yaml  \
+        --set 'defaultAuthMethod.enabled=true' \
+        --set 'defaultAuthMethod.namespace=tenant-2' \
+        --set 'defaultAuthMethod.method=aws' \
+        --set 'defaultAuthMethod.mount=foo' \
+        --set 'defaultAuthMethod.aws.role=role-1' \
+        --set 'defaultAuthMethod.aws.region=us-test-2' \
+        --set 'defaultAuthMethod.aws.headerValue=test-value' \
+        --set 'defaultAuthMethod.aws.sessionName=new-session' \
+        --set 'defaultAuthMethod.aws.stsEndpoint=www.sts' \
+        --set 'defaultAuthMethod.aws.iamEndpoint=www.iam' \
+        --set 'defaultAuthMethod.aws.secretRef=aws-creds' \
+        --set 'defaultAuthMethod.aws.irsaServiceAccount=iam-irsa-acct' \
+        . | tee /dev/stderr)
+
+    local actual=$(echo "$object" | yq '.metadata.namespace' | tee /dev/stderr)
+    [ "${actual}" = "default" ]
+    actual=$(echo "$object" | yq '.spec.namespace' | tee /dev/stderr)
+    [ "${actual}" = "tenant-2" ]
+
+    actual=$(echo "$object" | yq '.spec.method' | tee /dev/stderr)
+    [ "${actual}" = "aws" ]
+    actual=$(echo "$object" | yq '.spec.mount' | tee /dev/stderr)
+    [ "${actual}" = "foo" ]
+    actual=$(echo "$object" | yq '.spec.aws.role' | tee /dev/stderr)
+    [ "${actual}" = "role-1" ]
+    actual=$(echo "$object" | yq '.spec.aws.region' | tee /dev/stderr)
+    [ "${actual}" = "us-test-2" ]
+    actual=$(echo "$object" | yq '.spec.aws.headerValue' | tee /dev/stderr)
+    [ "${actual}" = "test-value" ]
+    actual=$(echo "$object" | yq '.spec.aws.sessionName' | tee /dev/stderr)
+    [ "${actual}" = "new-session" ]
+    actual=$(echo "$object" | yq '.spec.aws.stsEndpoint' | tee /dev/stderr)
+    [ "${actual}" = "www.sts" ]
+    actual=$(echo "$object" | yq '.spec.aws.iamEndpoint' | tee /dev/stderr)
+    [ "${actual}" = "www.iam" ]
+    actual=$(echo "$object" | yq '.spec.aws.secretRef' | tee /dev/stderr)
+    [ "${actual}" = "aws-creds" ]
+    actual=$(echo "$object" | yq '.spec.aws.irsaServiceAccount' | tee /dev/stderr)
+    [ "${actual}" = "iam-irsa-acct" ]
+}


### PR DESCRIPTION
Adding support for aws auth in the `defaultAuth` and `storageEncryption` (transit) sections of the chart, along with tests.