### PR TITLE
chart: make defaultVaultConnection.headers a map

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ K8S_DB_SECRET_COUNT ?=
 # Cloud test options
 SKIP_AWS_TESTS ?= true
 SKIP_AWS_STATIC_CREDS_TEST ?= true
+# filter bats unit tests to run.
+BATS_TESTS_FILTER ?= .\*
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -386,7 +388,7 @@ teardown-integration-test: undeploy ## Teardown the integration test setup
 
 .PHONY: unit-test
 unit-test: ## Run unit tests for the helm chart
-	PATH="$(CURDIR)/scripts:$(PATH)" bats test/unit/
+	PATH="$(CURDIR)/scripts:$(PATH)" bats -f $(BATS_TESTS_FILTER) test/unit/
 
 .PHONY: port-forward
 port-forward:

--- a/chart/templates/default-vault-connection.yaml
+++ b/chart/templates/default-vault-connection.yaml
@@ -25,6 +25,6 @@ spec:
   {{- end }}
   {{- if .Values.defaultVaultConnection.headers }}
   headers:
-    {{ tpl .Values.defaultVaultConnection.headers . | trim }}
+    {{- toYaml .Values.defaultVaultConnection.headers | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -150,7 +150,7 @@ controller:
           # Token Audience should match the bound_audiences or the `aud` list in bound_claims if
           # applicable of the Vault JWT auth role.
           # @type: array<string>
-          tokenAudiences: [ ]
+          tokenAudiences: []
 
         # AppRole auth method specific configuration
         appRole:
@@ -169,17 +169,13 @@ controller:
 
         # Params to use when authenticating to Vault using this auth method.
         # params:
-        #   vault-something1: "foo"
-        #   vault-something2: "bar"
-        #   vault-something3: "baz"
+        #   param-something1: "foo"
         # @type: map
         params: {}
 
         # Headers to be included in all Vault requests.
         # headers:
-        #   vault-something1: "foo"
-        #   vault-something2: "bar"
-        #   vault-something3: "baz"
+        #   X-vault-something1: "foo"
         # @type:  map
         headers: {}
 
@@ -271,12 +267,10 @@ defaultVaultConnection:
   skipTLSVerify: false
 
   # Headers to be included in all Vault requests.
-  # headers: |
-  #   "vault-something1": "foo"
-  #   "vault-something2": "bar"
-  #   "vault-something3": "baz"
-  # @type: string
-  headers: ""
+  # headers:
+  #   X-vault-something: "foo"
+  # @type: map
+  headers: {}
 
 
 # Configures and deploys the default VaultAuthMethod CR which will be used by resources
@@ -343,7 +337,7 @@ defaultAuthMethod:
     # Token Audience should match the bound_audiences or the `aud` list in bound_claims if applicable
     # of the Vault JWT auth role.
     # @type: array<string>
-    tokenAudiences: [ ]
+    tokenAudiences: []
 
   # AppRole auth method specific configuration
   appRole:
@@ -362,17 +356,13 @@ defaultAuthMethod:
 
   # Params to use when authenticating to Vault
   # params:
-  #   vault-something1: "foo"
-  #   vault-something2: "bar"
-  #   vault-something3: "baz"
+  #   param-something1: "foo"
   # @type: map
   params: {}
 
   # Headers to be included in all Vault requests.
   # headers:
-  #   vault-something1: "foo"
-  #   vault-something2: "bar"
-  #   vault-something3: "baz"
+  #   X-vault-something1: "foo"
   # @type: map
   headers: {}
 

--- a/test/unit/default-vault-connection.bats
+++ b/test/unit/default-vault-connection.bats
@@ -4,7 +4,7 @@ load _helpers
 
 #--------------------------------------------------------------------
 # enabled/disabled
-  
+
 @test "defaultConnection/CR: disabled by default" {
     cd `chart_dir`
     local actual=$(helm template \
@@ -52,7 +52,8 @@ load _helpers
         --set 'defaultVaultConnection.skipTLSVerify=true' \
         --set 'defaultVaultConnection.caCertSecret=foo' \
         --set 'defaultVaultConnection.tlsServerName=foo.com' \
-        --set 'defaultVaultConnection.headers=foo: bar' \
+        --set 'defaultVaultConnection.headers.foo=bar' \
+        --set 'defaultVaultConnection.headers.baz=qux' \
         . | tee /dev/stderr)
 
     local actual=$(echo "$object" | yq '.metadata.name' | tee /dev/stderr)
@@ -67,9 +68,10 @@ load _helpers
      [ "${actual}" = "foo" ]
     actual=$(echo "$object" | yq '.spec.tlsServerName' | tee /dev/stderr)
      [ "${actual}" = "foo.com" ]
+    actual=$(echo "$object" | yq '.spec.headers | length' | tee /dev/stderr)
+     [ "${actual}" = "2" ]
     actual=$(echo "$object" | yq '.spec.headers.foo' | tee /dev/stderr)
      [ "${actual}" = "bar" ]
+    actual=$(echo "$object" | yq '.spec.headers.baz' | tee /dev/stderr)
+     [ "${actual}" = "qux" ]
 }
-
-
-


### PR DESCRIPTION
Additional fixes:
- add support for filtering bats tests
- simplify some of the header/params examples