### PR TITLE
Fix typos in the chart templates and values.yaml

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -95,7 +95,7 @@ VaultAuthMethod Spec
     {{- end }}
   {{- else if eq $cur.method "appRole" }}
   appRole:
-    roleId: {{ $cur.appRole.roleid }}
+    roleId: {{ $cur.appRole.roleId }}
     secretRef: {{ $cur.appRole.secretRef }}
   {{- end }}
   {{- if $cur.headers }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -72,8 +72,8 @@ controller:
       # This should only be configured when client cache persistence with encryption is enabled and
       # will deploy an additional VaultAuthMethod to be used by the Vault Transit Engine.
       # E.g. when `controller.manager.clientCache.persistenceModel=direct-encrypted`
-      # Supported Vault authentication methods for the Transit Auth method are: jwt, approle,
-      # and kubernetes.
+      # Supported Vault authentication methods for the Transit Auth method are: jwt, appRole,
+      # aws, and kubernetes.
       # Typically, there should only ever be one VaultAuth configured with
       # StorageEncryption in the Cluster.
       storageEncryption:
@@ -141,7 +141,7 @@ controller:
           # must exist in the namespace of any consuming VaultSecret CR. This is a required field if
           # a JWT token is provided.
           # @type: string
-          secretName: ""
+          secretRef: ""
 
           # Kubernetes ServiceAccount to generate a service account JWT
           # @type: string
@@ -165,7 +165,7 @@ controller:
           # This is a required field when using appRole and must be setup in Vault prior to
           # deploying the helm chart.
           # @type: string
-          secretName: ""
+          secretRef: ""
 
         # AWS auth method specific configuration
         aws:
@@ -367,7 +367,7 @@ defaultAuthMethod:
     # The Kubernetes Secret must contain a key named `jwt` which references the JWT token, and must exist in the namespace
     # of any consuming VaultSecret CR. This is a required field if a JWT token is provided.
     # @type: string
-    secretName: ""
+    secretRef: ""
 
     # Kubernetes ServiceAccount to generate a service account JWT
     # @type: string
@@ -391,7 +391,7 @@ defaultAuthMethod:
     # This is a required field when using appRole and must be setup in Vault prior to deploying the
     # helm chart.
     # @type: string
-    secretName: ""
+    secretRef: ""
 
   # AWS auth method specific configuration
   aws:

--- a/test/unit/default-transit-auth-method.bats
+++ b/test/unit/default-transit-auth-method.bats
@@ -239,7 +239,7 @@ load _helpers
         --set 'controller.manager.clientCache.persistenceModel=direct-encrypted' \
         --set 'controller.manager.clientCache.storageEncryption.method=appRole' \
         --set 'controller.manager.clientCache.storageEncryption.namespace=tenant-2' \
-        --set 'controller.manager.clientCache.storageEncryption.appRole.roleid=role-1' \
+        --set 'controller.manager.clientCache.storageEncryption.appRole.roleId=role-1' \
         --set 'controller.manager.clientCache.storageEncryption.appRole.secretRef=secret-1' \
         --set 'controller.manager.clientCache.storageEncryption.mount=foo' \
         . | tee /dev/stderr)

--- a/test/unit/default-vault-auth-method.bats
+++ b/test/unit/default-vault-auth-method.bats
@@ -204,7 +204,7 @@ load _helpers
         --set 'defaultAuthMethod.enabled=true' \
         --set 'defaultAuthMethod.method=appRole' \
         --set 'defaultAuthMethod.namespace=tenant-2' \
-        --set 'defaultAuthMethod.appRole.roleid=role-1' \
+        --set 'defaultAuthMethod.appRole.roleId=role-1' \
         --set 'defaultAuthMethod.appRole.secretRef=secret-1' \
         --set 'defaultAuthMethod.mount=foo' \
         . | tee /dev/stderr)


### PR DESCRIPTION
Fixes some typos in the auth method templates and values.yaml that occurred when the templating was changed to a function for auth methods.
There are a couple places where `appRole` is typo'd as `approle` and `roleid` instead of `roleId`, and `secretName` instead of `secretRef` either in the template or values.yaml :( 
The correct naming conventions are intended to be : `appRole`, `roleId`, and `secretRef`.

Fixes the issue reported here:
https://github.com/hashicorp/vault-secrets-operator/pull/155#issuecomment-1585101050

This is technically a breaking change from Beta1 to GA.