### PR TITLE
use matrix for integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -254,10 +254,10 @@ jobs:
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}
         run: |
           make_target=integration-test
-          if [ ${{ matrix.installation-method }} == 'helm']; then
+          if [ ${{ matrix.installation-method }} == 'helm' ]; then
             make_target+='-helm'
           fi
-          if [ ${{ matrix.software-type }} == 'ent']; then
+          if [ ${{ matrix.software-type }} == 'ent' ]; then
             make_target+='-ent'
             export VAULT_IMAGE_TAG='${{ matrix.vault-version }}-ent'
           fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -189,6 +189,7 @@ jobs:
         include:
           - kind-k8s-version: 1.26.4
             vault-version: 1.13.2
+            integration-test: ${{ fromJSON(needs.build-integration-test-array.outputs.json) }}
           - kind-k8s-version: 1.25.9
             vault-version: 1.13.2
           - kind-k8s-version: 1.24.13

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,10 +13,6 @@ on:
 
 env:
   PKG_NAME: "vault-secrets-operator"
-  OSS_HELM_TEST_NAME: OSS tests using Helm
-  OSS_KUSTOMIZE_TEST_NAME: OSS tests using Kustomize
-  ENT_HELM_TEST_NAME: ENT tests using Helm
-  ENT_KUSTOMIZE_TEST_NAME: ENT tests using Kustomize
 
 jobs:
   get-product-version:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -189,35 +189,35 @@ jobs:
         include:
           - kind-k8s-version: 1.26.4
             vault-version: 1.13.2
-            integration-test: ${{ env.OSS_HELM_TEST_NAME }}
+            integration-test: env.OSS_HELM_TEST_NAME
           - kind-k8s-version: 1.25.9
             vault-version: 1.13.2
-            integration-test: ${{ env.OSS_HELM_TEST_NAME }}
+            integration-test: env.OSS_HELM_TEST_NAME
           - kind-k8s-version: 1.24.13
             vault-version: 1.13.2
-            integration-test: ${{ env.OSS_HELM_TEST_NAME }}
+            integration-test: env.OSS_HELM_TEST_NAME
           - kind-k8s-version: 1.23.17
             vault-version: 1.13.2
-            integration-test: ${{ env.OSS_HELM_TEST_NAME }}
+            integration-test: env.OSS_HELM_TEST_NAME
           - kind-k8s-version: 1.22.17
             vault-version: 1.13.2
-            integration-test: ${{ env.OSS_HELM_TEST_NAME }}
+            integration-test: env.OSS_HELM_TEST_NAM
 
           - kind-k8s-version: 1.26.4
             vault-version: 1.13.2
-            integration-test: ${{ env.OSS_KUSTOMIZE_TEST_NAME }}
+            integration-test: env.OSS_KUSTOMIZE_TEST_NAME
           - kind-k8s-version: 1.25.9
             vault-version: 1.13.2
-            integration-test: ${{ env.OSS_KUSTOMIZE_TEST_NAME }}
+            integration-test: env.OSS_KUSTOMIZE_TEST_NAME
           - kind-k8s-version: 1.24.13
             vault-version: 1.13.2
-            integration-test: ${{ env.OSS_KUSTOMIZE_TEST_NAME }}
+            integration-test: env.OSS_KUSTOMIZE_TEST_NAME
           - kind-k8s-version: 1.23.17
             vault-version: 1.13.2
-            integration-test: ${{ env.OSS_KUSTOMIZE_TEST_NAME }}
+            integration-test: env.OSS_KUSTOMIZE_TEST_NAME
           - kind-k8s-version: 1.22.17
             vault-version: 1.13.2
-            integration-test: ${{ env.OSS_KUSTOMIZE_TEST_NAME }}
+            integration-test: env.OSS_KUSTOMIZE_TEST_NAME
 
 
     name: Integration vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} test:${{ matrix.integration-test }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -185,6 +185,7 @@ jobs:
           - kind-k8s-version: 1.24.13
           - kind-k8s-version: 1.23.17
           - kind-k8s-version: 1.22.17
+
         include:
           - kind-k8s-version: 1.26.4
             vault-version: 1.13.2
@@ -197,7 +198,7 @@ jobs:
           - kind-k8s-version: 1.22.17
             vault-version: 1.13.2
 
-    name: Integration vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} test:${{ matrix.integration-test}}
+    name: Integration vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} test:${{ matrix.integration-test }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -149,17 +149,9 @@ jobs:
             exit 1
           fi
 
-  build-integration-test-array:
-    runs-on: ubuntu-latest
-    outputs:
-      json: ${{ steps.main.outputs.json }}
-    steps:
-      - id: main
-        run: echo "json=[\"$OSS_HELM_TEST_NAME\", \"$OSS_KUSTOMIZE_TEST_NAME\", \"$ENT_HELM_TEST_NAME\", \"$ENT_KUSTOMIZE_TEST_NAME\"]" > $GITHUB_OUTPUT
-
   integrationTest:
     runs-on: ubuntu-latest
-    needs: [get-product-version, build-pre-checks, build-docker, build-integration-test-array]
+    needs: [get-product-version, build-pre-checks, build-docker]
     env:
       KIND_CLUSTER_NAME: vault-secrets-operator
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -170,12 +162,11 @@ jobs:
       matrix:
         kind-k8s-version: [1.22.17, 1.23.17, 1.24.13, 1.25.9, 1.26.4, 1.27.2]
         vault-version: [1.11.10, 1.12.6, 1.13.2]
-        integration-test: ${{ fromJSON(needs.build-integration-test-array.outputs.json) }}
-        # Note: The below exclude and includes are a bit awkward, but they
-        # allow us to exclude the combos we don't really need. We want to test
-        # the operator with the different k8s versions, and with the different
-        # vault versions, but we don't care about testing all the k8s versions
-        # against all the vault versions.
+        installation-method: [ helm, kustomize ]
+        software-type: [ent, oss]
+        # Note: We want to test the operator with the different k8s versions,
+        # and with the different vault versions, but we don't care about testing
+        # all the k8s versions against all the vault versions.
         # Combos to exclude:
         #   kind-k8s-version: [1.22.17, 1.23.17, 1.24.13, 1.25.9, 1.26.4]
         #   vault-version: [1.11.10, 1.12.6]
@@ -203,7 +194,7 @@ jobs:
           - kind-k8s-version: 1.22.17
             vault-version: 1.12.6
 
-    name: Integration vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} test:${{ matrix.integration-test }}
+    name: vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} ${{ matrix.installation-method }}-${{ matrix.software-type }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
@@ -232,45 +223,25 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: .go-version
-      - name: ${{ env.OSS_HELM_TEST_NAME }}
-        # This step runs OSS tests using Helm if matrix.integration-test is env.OSS_HELM_TEST_NAME
-        # Ideally we only need to test the latest release of OSS Vault.
-        if: ${{ matrix.integration-test == env.OSS_HELM_TEST_NAME && matrix.vault-version == '1.13.2' }}
+      - name: ${{ matrix.installation-method }}-${{ matrix.software-type }}
+        # We run kustomize ent against the full matrix, and other tests against vault version 1.13.2
+        # TODO: When the VDS integration test supports Helm, test kustomize ent against one version of (ENT) Vault like the other tests.
+        # TODO: When the VDS integration test supports Helm, swap the matrix filter so helm ent test runs the full matrix.
+        if: ${{ matrix.integration-method == kustomize && matrix.software-type == ent|| matrix.vault-version == '1.13.2' }}
         env:
           INTEGRATION_TESTS: true
           VAULT_IMAGE_TAG: ${{ matrix.vault-version }}
-        run: |
-          make integration-test-helm SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
-      - name: ${{ env.OSS_KUSTOMIZE_TEST_NAME }}
-        # This step runs OSS tests using Kustomize if matrix.integration-test is env.OSS_KUSTOMIZE_TEST_NAME
-        # Ideally we only need to test the latest release of OSS Vault.
-        if: ${{ matrix.integration-test == env.OSS_KUSTOMIZE_TEST_NAME && matrix.vault-version == '1.13.2' }}
-        env:
-          INTEGRATION_TESTS: true
-          VAULT_IMAGE_TAG: ${{ matrix.vault-version }}
-        run: |
-          make integration-test SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
-      - name: ${{ env.ENT_KUSTOMIZE_TEST_NAME }}
-        # This step runs ENT tests using Kustomize if matrix.integration-test is env.ENT_KUSTOMIZE_TEST_NAME
-        # TODO: When the VDS integration test supports Helm we test against one version of (ENT) Vault like the other tests.
-        # if: ${{ matrix.vault-version == '1.13.2' }}
-        if: ${{ matrix.integration-test == env.ENT_KUSTOMIZE_TEST_NAME }}
-        env:
-          INTEGRATION_TESTS: true
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}
-          VAULT_IMAGE_TAG: ${{ matrix.vault-version }}-ent
         run: |
-          make integration-test-ent SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
-      - name: ${{ env.ENT_HELM_TEST_NAME }}
-        # This step runs ENT tests using Helm if matrix.integration-test is env.ENT_HELM_TEST_NAME
-        # TODO: When the VDS integration test supports Helm swap the matrix filter so this test runs the full matrix.
-        if: ${{ matrix.integration-test == env.ENT_HELM_TEST_NAME && matrix.vault-version == '1.13.2' }}
-        env:
-          INTEGRATION_TESTS: true
-          VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}
-          VAULT_IMAGE_TAG: ${{ matrix.vault-version }}-ent
-        run: |
-          make integration-test-helm-ent SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
+          make_target=integration-test
+          if [ ${{ matrix.installation-method }} != "helm"]; then
+            make_target+="-helm"
+          fi
+          if [ ${{ matrix.software-type }} != "ent"]; then
+            export VAULT_IMAGE_TAG=${{ matrix.vault-version }}-ent
+            make_target+="-ent"
+          fi
+          make $make_target SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: Store kind cluster logs
         if: success()
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -162,7 +162,7 @@ jobs:
       matrix:
         kind-k8s-version: [1.22.17, 1.23.17, 1.24.13, 1.25.9, 1.26.4, 1.27.2]
         vault-version: [1.11.10, 1.12.6, 1.13.2]
-        installation-method: [ helm, kustomize ]
+        installation-method: [helm, kustomize]
         software-type: [ent, oss]
         # Note: We want to test the operator with the different k8s versions,
         # and with the different vault versions, but we don't care about testing
@@ -227,19 +227,19 @@ jobs:
         # We run kustomize ent against the full matrix, and other tests against vault version 1.13.2
         # TODO: When the VDS integration test supports Helm, test kustomize ent against one version of (ENT) Vault like the other tests.
         # TODO: When the VDS integration test supports Helm, swap the matrix filter so helm ent test runs the full matrix.
-        if: ${{ matrix.integration-method == kustomize && matrix.software-type == ent|| matrix.vault-version == '1.13.2' }}
+        if: ${{ matrix.integration-method == 'kustomize' && matrix.software-type == 'ent' || matrix.vault-version == '1.13.2' }}
         env:
           INTEGRATION_TESTS: true
           VAULT_IMAGE_TAG: ${{ matrix.vault-version }}
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}
         run: |
           make_target=integration-test
-          if [ ${{ matrix.installation-method }} != "helm"]; then
-            make_target+="-helm"
+          if [ ${{ matrix.installation-method }} != 'helm']; then
+            make_target+='-helm'
           fi
-          if [ ${{ matrix.software-type }} != "ent"]; then
+          if [ ${{ matrix.software-type }} != 'ent']; then
             export VAULT_IMAGE_TAG=${{ matrix.vault-version }}-ent
-            make_target+="-ent"
+            make_target+='-ent'
           fi
           make $make_target SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: Store kind cluster logs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -218,7 +218,7 @@ jobs:
             installation-method: kustomize
             software-type: oss
 
-    name: vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} ${{ matrix.installation-method }}-${{ matrix.software-type }}
+    name: vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} ${{ matrix.installation-method }} ${{ matrix.software-type }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -259,11 +259,11 @@ jobs:
           fi
           if [ ${{ matrix.software-type }} == 'ent']; then
             make_target+='-ent'
-            export VAULT_IMAGE_TAG=${{ matrix.vault-version }}-ent
+            export VAULT_IMAGE_TAG='${{ matrix.vault-version }}-ent'
           fi
-          echo "make_target=${make_targe}" >> $GITHUB_OUTPUT
+          echo "make_target=${make_target}" >> $GITHUB_OUTPUT
           echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG" >> $GITHUB_OUTPUT
-          echo "make_target=${make_targe}"
+          echo "make_target=${make_target}"
           echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG"
 #          make $make_target SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: Store kind cluster logs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -265,6 +265,7 @@ jobs:
           echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG" >> $GITHUB_OUTPUT
           echo "make_target=${make_target}"
           echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG"
+          echo "$INTEGRATION_TESTS"
 #          make $make_target SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: Store kind cluster logs
         if: success()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -263,7 +263,9 @@ jobs:
           fi
           echo "make_target=${make_targe}" >> $GITHUB_OUTPUT
           echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG" >> $GITHUB_OUTPUT
-          make $make_target SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
+          echo "make_target=${make_targe}"
+          echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG"
+#          make $make_target SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: Store kind cluster logs
         if: success()
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -261,12 +261,7 @@ jobs:
             make_target+='-ent'
             export VAULT_IMAGE_TAG='${{ matrix.vault-version }}-ent'
           fi
-          echo "make_target=${make_target}" >> $GITHUB_OUTPUT
-          echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG" >> $GITHUB_OUTPUT
-          echo "make_target=${make_target}"
-          echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG"
-          echo "$INTEGRATION_TESTS"
-#          make $make_target SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
+          make $make_target SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: Store kind cluster logs
         if: success()
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -214,7 +214,7 @@ jobs:
             installation-method: kustomize
             enterprise: false
 
-    name: vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} ${{ matrix.installation-method }} ent=${{ matrix.enterprise}}
+    name: vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} ${{ matrix.installation-method }} enterprise=${{ matrix.enterprise }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
@@ -257,11 +257,7 @@ jobs:
             make_target+='-ent'
             export VAULT_IMAGE_TAG='${{ matrix.vault-version }}-ent'
           fi
-          echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG" >> $GITHUB_OUTPUT
-          echo "make_target=${make_target}"
-          echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG"
-          echo "$INTEGRATION_TESTS"
-#          make $make_target SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
+          make $make_target SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: Store kind cluster logs
         if: success()
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,10 @@ on:
 
 env:
   PKG_NAME: "vault-secrets-operator"
+  OSS_HELM_TEST_NAME: OSS tests using Helm
+  OSS_KUSTOMIZE_TEST_NAME: OSS tests using Kustomize
+  ENT_HELM_TEST_NAME: ENT tests using Helm
+  ENT_KUSTOMIZE_TEST_NAME: ENT tests using Kustomize
 
 jobs:
   get-product-version:
@@ -145,9 +149,29 @@ jobs:
             exit 1
           fi
 
+  build-integration-test-array:
+    runs-on: ubuntu-latest
+    outputs:
+      json: ${{ steps.main.outputs.json }}
+    steps:
+      - id: main
+        run: echo "json=[\"$OSS_HELM_TEST_NAME\", \"$OSS_KUSTOMIZE_TEST_NAME\", \"$ENT_HELM_TEST_NAME\", \"$ENT_KUSTOMIZE_TEST_NAME\"]" > $GITHUB_OUTPUT
+
+  test-integration-test-matrix-setup:
+    runs-on: ubuntu-latest
+    needs: build-integration-test-array
+    strategy:
+      fail-fast: false
+      matrix:
+        integration-test: ${{ fromJSON(needs.build-integration-test-array.outputs.json) }}
+    steps:
+      - run: echo "${{ matrix.integration-test }}"
+        name: echo-step
+    name: test-integration-test-matrix-setup:${{ matrix.integration-test}}
+
   integrationTest:
     runs-on: ubuntu-latest
-    needs: [get-product-version, build-pre-checks, build-docker]
+    needs: [get-product-version, build-pre-checks, build-docker, build-integration-test-array]
     env:
       KIND_CLUSTER_NAME: vault-secrets-operator
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -158,6 +182,7 @@ jobs:
       matrix:
         kind-k8s-version: [1.22.17, 1.23.17, 1.24.13, 1.25.9, 1.26.4, 1.27.2]
         vault-version: [1.11.10, 1.12.6, 1.13.2]
+        integration-test: ${{ fromJSON(needs.build-integration-test-array.outputs.json) }}
         # Note: The below exclude and includes are a bit awkward, but they
         # allow us to exclude the combos we don't really need. We want to test
         # the operator with the different k8s versions, and with the different
@@ -184,7 +209,7 @@ jobs:
           - kind-k8s-version: 1.22.17
             vault-version: 1.13.2
 
-    name: Integration vault:${{ matrix.vault-version }} kind ${{ matrix.kind-k8s-version }}
+    name: Integration vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} test:${{ matrix.integration-test}}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
@@ -213,34 +238,35 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: .go-version
-      - name: OSS tests using Helm
+      - name: ${{ env.OSS_HELM_TEST_NAME }}
         # Ideally we only need to test the latest release of OSS Vault.
-        if: ${{ matrix.vault-version == '1.13.2' }}
+        if: ${{ matrix.integration-test == env.OSS_HELM_TEST_NAME && matrix.vault-version == '1.13.2' }}
         env:
           INTEGRATION_TESTS: true
           VAULT_IMAGE_TAG: ${{ matrix.vault-version }}
         run: |
           make integration-test-helm SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
-      - name: OSS tests using Kustomize
+      - name: ${{ env.OSS_KUSTOMIZE_TEST_NAME }}
         # Ideally we only need to test the latest release of OSS Vault.
-        if: ${{ matrix.vault-version == '1.13.2' }}
+        if: ${{ matrix.integration-test == env.OSS_KUSTOMIZE_TEST_NAME && matrix.vault-version == '1.13.2' }}
         env:
           INTEGRATION_TESTS: true
           VAULT_IMAGE_TAG: ${{ matrix.vault-version }}
         run: |
           make integration-test SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
-      - name: ENT tests using Kustomize
+      - name: ${{ env.ENT_KUSTOMIZE_TEST_NAME }}
         # TODO: When the VDS integration test supports Helm we test against one version of (ENT) Vault like the other tests.
         # if: ${{ matrix.vault-version == '1.13.2' }}
+        if: ${{ matrix.integration-test == env.ENT_KUSTOMIZE_TEST_NAME }}
         env:
           INTEGRATION_TESTS: true
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}
           VAULT_IMAGE_TAG: ${{ matrix.vault-version }}-ent
         run: |
           make integration-test-ent SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
-      - name: ENT tests using Helm
+      - name: ${{ env.ENT_HELM_TEST_NAME }}
         # TODO: When the VDS integration test supports Helm swap the matrix filter so this test runs the full matrix.
-        if: ${{ matrix.vault-version == '1.13.2' }}
+        if: ${{ matrix.integration-test == env.ENT_HELM_TEST_NAME && matrix.vault-version == '1.13.2' }}
         env:
           INTEGRATION_TESTS: true
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -157,18 +157,6 @@ jobs:
       - id: main
         run: echo "json=[\"$OSS_HELM_TEST_NAME\", \"$OSS_KUSTOMIZE_TEST_NAME\", \"$ENT_HELM_TEST_NAME\", \"$ENT_KUSTOMIZE_TEST_NAME\"]" > $GITHUB_OUTPUT
 
-  test-integration-test-matrix-setup:
-    runs-on: ubuntu-latest
-    needs: build-integration-test-array
-    strategy:
-      fail-fast: false
-      matrix:
-        integration-test: ${{ fromJSON(needs.build-integration-test-array.outputs.json) }}
-    steps:
-      - run: echo "${{ matrix.integration-test }}"
-        name: echo-step
-    name: test-integration-test-matrix-setup:${{ matrix.integration-test}}
-
   integrationTest:
     runs-on: ubuntu-latest
     needs: [get-product-version, build-pre-checks, build-docker, build-integration-test-array]
@@ -239,6 +227,7 @@ jobs:
         with:
           go-version-file: .go-version
       - name: ${{ env.OSS_HELM_TEST_NAME }}
+        # This step runs OSS tests using Helm if matrix.integration-test is env.OSS_HELM_TEST_NAME
         # Ideally we only need to test the latest release of OSS Vault.
         if: ${{ matrix.integration-test == env.OSS_HELM_TEST_NAME && matrix.vault-version == '1.13.2' }}
         env:
@@ -247,6 +236,7 @@ jobs:
         run: |
           make integration-test-helm SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: ${{ env.OSS_KUSTOMIZE_TEST_NAME }}
+        # This step runs OSS tests using Kustomize if matrix.integration-test is env.OSS_KUSTOMIZE_TEST_NAME
         # Ideally we only need to test the latest release of OSS Vault.
         if: ${{ matrix.integration-test == env.OSS_KUSTOMIZE_TEST_NAME && matrix.vault-version == '1.13.2' }}
         env:
@@ -255,6 +245,7 @@ jobs:
         run: |
           make integration-test SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: ${{ env.ENT_KUSTOMIZE_TEST_NAME }}
+        # This step runs ENT tests using Kustomize if matrix.integration-test is env.ENT_KUSTOMIZE_TEST_NAME
         # TODO: When the VDS integration test supports Helm we test against one version of (ENT) Vault like the other tests.
         # if: ${{ matrix.vault-version == '1.13.2' }}
         if: ${{ matrix.integration-test == env.ENT_KUSTOMIZE_TEST_NAME }}
@@ -265,6 +256,7 @@ jobs:
         run: |
           make integration-test-ent SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: ${{ env.ENT_HELM_TEST_NAME }}
+        # This step runs ENT tests using Helm if matrix.integration-test is env.ENT_HELM_TEST_NAME
         # TODO: When the VDS integration test supports Helm swap the matrix filter so this test runs the full matrix.
         if: ${{ matrix.integration-test == env.ENT_HELM_TEST_NAME && matrix.vault-version == '1.13.2' }}
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -189,15 +189,36 @@ jobs:
         include:
           - kind-k8s-version: 1.26.4
             vault-version: 1.13.2
-            integration-test: ${{ fromJSON(needs.build-integration-test-array.outputs.json) }}
+            integration-test: ${{ env.OSS_HELM_TEST_NAME }}
           - kind-k8s-version: 1.25.9
             vault-version: 1.13.2
+            integration-test: ${{ env.OSS_HELM_TEST_NAME }}
           - kind-k8s-version: 1.24.13
             vault-version: 1.13.2
+            integration-test: ${{ env.OSS_HELM_TEST_NAME }}
           - kind-k8s-version: 1.23.17
             vault-version: 1.13.2
+            integration-test: ${{ env.OSS_HELM_TEST_NAME }}
           - kind-k8s-version: 1.22.17
             vault-version: 1.13.2
+            integration-test: ${{ env.OSS_HELM_TEST_NAME }}
+
+          - kind-k8s-version: 1.26.4
+            vault-version: 1.13.2
+            integration-test: ${{ env.OSS_KUSTOMIZE_TEST_NAME }}
+          - kind-k8s-version: 1.25.9
+            vault-version: 1.13.2
+            integration-test: ${{ env.OSS_KUSTOMIZE_TEST_NAME }}
+          - kind-k8s-version: 1.24.13
+            vault-version: 1.13.2
+            integration-test: ${{ env.OSS_KUSTOMIZE_TEST_NAME }}
+          - kind-k8s-version: 1.23.17
+            vault-version: 1.13.2
+            integration-test: ${{ env.OSS_KUSTOMIZE_TEST_NAME }}
+          - kind-k8s-version: 1.22.17
+            vault-version: 1.13.2
+            integration-test: ${{ env.OSS_KUSTOMIZE_TEST_NAME }}
+
 
     name: Integration vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} test:${{ matrix.integration-test }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -170,6 +170,12 @@ jobs:
         # Combos to exclude:
         #   kind-k8s-version: [1.22.17, 1.23.17, 1.24.13, 1.25.9, 1.26.4]
         #   vault-version: [1.11.10, 1.12.6]
+        # We run kustomize ent against the full matrix, and other tests against vault version 1.13.2.
+        # Combos to exclude:
+        #   vault-version: [1.11.10, 1.12.6]
+        #   any combos from installation-method and software-type except for kustomize ent
+        # TODO: When the VDS integration test supports Helm, test kustomize ent against one version of (ENT) Vault like the other tests.
+        # TODO: When the VDS integration test supports Helm, swap the matrix filter so helm ent test runs the full matrix.
         exclude:
           # vault version 1.11.10
           - kind-k8s-version: 1.26.4
@@ -182,6 +188,15 @@ jobs:
             vault-version: 1.11.10
           - kind-k8s-version: 1.22.17
             vault-version: 1.11.10
+          - vault-version: 1.11.10
+            installation-method: helm
+            software-type: ent
+          - vault-version: 1.11.10
+            installation-method: helm
+            software-type: oss
+          - vault-version: 1.11.10
+            installation-method: kustomize
+            software-type: oss
           # vault version 1.12.6
           - kind-k8s-version: 1.26.4
             vault-version: 1.12.6
@@ -193,6 +208,15 @@ jobs:
             vault-version: 1.12.6
           - kind-k8s-version: 1.22.17
             vault-version: 1.12.6
+          - vault-version: 1.12.6
+            installation-method: helm
+            software-type: ent
+          - vault-version: 1.12.6
+            installation-method: helm
+            software-type: oss
+          - vault-version: 1.12.6
+            installation-method: kustomize
+            software-type: oss
 
     name: vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} ${{ matrix.installation-method }}-${{ matrix.software-type }}
     steps:
@@ -224,10 +248,6 @@ jobs:
         with:
           go-version-file: .go-version
       - name: ${{ matrix.installation-method }}-${{ matrix.software-type }}
-        # We run kustomize ent against the full matrix, and other tests against vault version 1.13.2
-        # TODO: When the VDS integration test supports Helm, test kustomize ent against one version of (ENT) Vault like the other tests.
-        # TODO: When the VDS integration test supports Helm, swap the matrix filter so helm ent test runs the full matrix.
-        if: ${{ matrix.integration-method == 'kustomize' && matrix.software-type == 'ent' || matrix.vault-version == '1.13.2' }}
         env:
           INTEGRATION_TESTS: true
           VAULT_IMAGE_TAG: ${{ matrix.vault-version }}
@@ -241,6 +261,8 @@ jobs:
             export VAULT_IMAGE_TAG=${{ matrix.vault-version }}-ent
             make_target+='-ent'
           fi
+          echo "make_target=${make_targe}" >> $GITHUB_OUTPUT
+          echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG" >> $GITHUB_OUTPUT
           make $make_target SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: Store kind cluster logs
         if: success()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -157,17 +157,9 @@ jobs:
       - id: main
         run: echo "json=[\"$OSS_HELM_TEST_NAME\", \"$OSS_KUSTOMIZE_TEST_NAME\", \"$ENT_HELM_TEST_NAME\", \"$ENT_KUSTOMIZE_TEST_NAME\"]" > $GITHUB_OUTPUT
 
-  test-integration-test-matrix-setup:
-    runs-on: ubuntu-latest
-    needs: build-integration-test-matrix-include
-    steps:
-      - run: echo "${{ fromJSON(needs.build-integration-test-matrix-include.outputs.json) }}"
-        name: echo-step
-    name: test-integration-test-matrix-setup
-
   integrationTest:
     runs-on: ubuntu-latest
-    needs: [get-product-version, build-pre-checks, build-docker, build-integration-test-array, build-integration-test-matrix-include]
+    needs: [get-product-version, build-pre-checks, build-docker, build-integration-test-array]
     env:
       KIND_CLUSTER_NAME: vault-secrets-operator
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -188,6 +180,7 @@ jobs:
         #   kind-k8s-version: [1.22.17, 1.23.17, 1.24.13, 1.25.9, 1.26.4]
         #   vault-version: [1.11.10, 1.12.6]
         exclude:
+          # vault version 1.11.10
           - kind-k8s-version: 1.26.4
             vault-version: 1.11.10
           - kind-k8s-version: 1.25.9
@@ -198,7 +191,7 @@ jobs:
             vault-version: 1.11.10
           - kind-k8s-version: 1.22.17
             vault-version: 1.11.10
-
+          # vault version 1.12.6
           - kind-k8s-version: 1.26.4
             vault-version: 1.12.6
           - kind-k8s-version: 1.25.9

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -254,12 +254,12 @@ jobs:
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}
         run: |
           make_target=integration-test
-          if [ ${{ matrix.installation-method }} != 'helm']; then
+          if [ ${{ matrix.installation-method }} == 'helm']; then
             make_target+='-helm'
           fi
-          if [ ${{ matrix.software-type }} != 'ent']; then
-            export VAULT_IMAGE_TAG=${{ matrix.vault-version }}-ent
+          if [ ${{ matrix.software-type }} == 'ent']; then
             make_target+='-ent'
+            export VAULT_IMAGE_TAG=${{ matrix.vault-version }}-ent
           fi
           echo "make_target=${make_targe}" >> $GITHUB_OUTPUT
           echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -159,7 +159,7 @@ jobs:
         kind-k8s-version: [1.22.17, 1.23.17, 1.24.13, 1.25.9, 1.26.4, 1.27.2]
         vault-version: [1.11.10, 1.12.6, 1.13.2]
         installation-method: [helm, kustomize]
-        software-type: [ent, oss]
+        enterprise: [true, false]
         # Note: We want to test the operator with the different k8s versions,
         # and with the different vault versions, but we don't care about testing
         # all the k8s versions against all the vault versions.
@@ -169,8 +169,8 @@ jobs:
         # We run kustomize ent against the full matrix, and other tests against vault version 1.13.2.
         # Combos to exclude:
         #   vault-version: [1.11.10, 1.12.6]
-        #   any combos from installation-method and software-type except for kustomize ent
-        # TODO: When the VDS integration test supports Helm, test kustomize ent against one version of (ENT) Vault like the other tests.
+        #   any combos from installation-method and enterprise except for kustomize true
+        # TODO: When the VDS integration test supports Helm, test kustomize enterprise against one version of (ENT) Vault like the other tests.
         # TODO: When the VDS integration test supports Helm, swap the matrix filter so helm ent test runs the full matrix.
         exclude:
           # vault version 1.11.10
@@ -186,13 +186,13 @@ jobs:
             vault-version: 1.11.10
           - vault-version: 1.11.10
             installation-method: helm
-            software-type: ent
+            enterprise: true
           - vault-version: 1.11.10
             installation-method: helm
-            software-type: oss
+            enterprise: false
           - vault-version: 1.11.10
             installation-method: kustomize
-            software-type: oss
+            enterprise: false
           # vault version 1.12.6
           - kind-k8s-version: 1.26.4
             vault-version: 1.12.6
@@ -206,15 +206,15 @@ jobs:
             vault-version: 1.12.6
           - vault-version: 1.12.6
             installation-method: helm
-            software-type: ent
+            enterprise: true
           - vault-version: 1.12.6
             installation-method: helm
-            software-type: oss
+            enterprise: false
           - vault-version: 1.12.6
             installation-method: kustomize
-            software-type: oss
+            enterprise: false
 
-    name: vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} ${{ matrix.installation-method }} ${{ matrix.software-type }}
+    name: vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} ${{ matrix.installation-method }} ent=${{ matrix.enterprise}}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
@@ -243,7 +243,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: .go-version
-      - name: ${{ matrix.installation-method }}-${{ matrix.software-type }}
+      - name: ${{ matrix.installation-method }} enterprise=${{ matrix.enterprise }}
         env:
           INTEGRATION_TESTS: true
           VAULT_IMAGE_TAG: ${{ matrix.vault-version }}
@@ -253,11 +253,15 @@ jobs:
           if [ ${{ matrix.installation-method }} == 'helm' ]; then
             make_target+='-helm'
           fi
-          if [ ${{ matrix.software-type }} == 'ent' ]; then
+          if [ ${{ matrix.enterprise }} == 'true' ]; then
             make_target+='-ent'
             export VAULT_IMAGE_TAG='${{ matrix.vault-version }}-ent'
           fi
-          make $make_target SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
+          echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "make_target=${make_target}"
+          echo "VAULT_IMAGE_TAG=$VAULT_IMAGE_TAG"
+          echo "$INTEGRATION_TESTS"
+#          make $make_target SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
       - name: Store kind cluster logs
         if: success()
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -157,14 +157,6 @@ jobs:
       - id: main
         run: echo "json=[\"$OSS_HELM_TEST_NAME\", \"$OSS_KUSTOMIZE_TEST_NAME\", \"$ENT_HELM_TEST_NAME\", \"$ENT_KUSTOMIZE_TEST_NAME\"]" > $GITHUB_OUTPUT
 
-  build-integration-test-matrix-include:
-    runs-on: ubuntu-latest
-    outputs:
-      json: ${{ steps.main.outputs.json }}
-    steps:
-      - id: main
-        run: echo "json=[{\"kind-k8s-version\":\"1.26.4\",\"vault-version\":\"1.13.2\",\"integration-test\":\"$OSS_HELM_TEST_NAME\"}]"> $GITHUB_OUTPUT
-
   test-integration-test-matrix-setup:
     runs-on: ubuntu-latest
     needs: build-integration-test-matrix-include
@@ -197,27 +189,26 @@ jobs:
         #   vault-version: [1.11.10, 1.12.6]
         exclude:
           - kind-k8s-version: 1.26.4
+            vault-version: 1.11.10
           - kind-k8s-version: 1.25.9
+            vault-version: 1.11.10
           - kind-k8s-version: 1.24.13
+            vault-version: 1.11.10
           - kind-k8s-version: 1.23.17
+            vault-version: 1.11.10
           - kind-k8s-version: 1.22.17
+            vault-version: 1.11.10
 
-        include: ${{ fromJSON(needs.build-integration-test-matrix-include.outputs.json) }}
-#          - kind-k8s-version: 1.26.4
-#            vault-version: 1.13.2
-#            integration-test: env.OSS_HELM_TEST_NAME
-#          - kind-k8s-version: 1.25.9
-#            vault-version: 1.13.2
-#            integration-test: env.OSS_HELM_TEST_NAME
-#          - kind-k8s-version: 1.24.13
-#            vault-version: 1.13.2
-#            integration-test: env.OSS_HELM_TEST_NAME
-#          - kind-k8s-version: 1.23.17
-#            vault-version: 1.13.2
-#            integration-test: env.OSS_HELM_TEST_NAME
-#          - kind-k8s-version: 1.22.17
-#            vault-version: 1.13.2
-#            integration-test: env.OSS_HELM_TEST_NAM
+          - kind-k8s-version: 1.26.4
+            vault-version: 1.12.6
+          - kind-k8s-version: 1.25.9
+            vault-version: 1.12.6
+          - kind-k8s-version: 1.24.13
+            vault-version: 1.12.6
+          - kind-k8s-version: 1.23.17
+            vault-version: 1.12.6
+          - kind-k8s-version: 1.22.17
+            vault-version: 1.12.6
 
     name: Integration vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} test:${{ matrix.integration-test }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -157,9 +157,25 @@ jobs:
       - id: main
         run: echo "json=[\"$OSS_HELM_TEST_NAME\", \"$OSS_KUSTOMIZE_TEST_NAME\", \"$ENT_HELM_TEST_NAME\", \"$ENT_KUSTOMIZE_TEST_NAME\"]" > $GITHUB_OUTPUT
 
+  build-integration-test-matrix-include:
+    runs-on: ubuntu-latest
+    outputs:
+      json: ${{ steps.main.outputs.json }}
+    steps:
+      - id: main
+        run: echo "json=[{\"kind-k8s-version\":\"1.26.4\",\"vault-version\":\"1.13.2\",\"integration-test\":\"$OSS_HELM_TEST_NAME\"}]"> $GITHUB_OUTPUT
+
+  test-integration-test-matrix-setup:
+    runs-on: ubuntu-latest
+    needs: build-integration-test-matrix-include
+    steps:
+      - run: echo "${{ fromJSON(needs.build-integration-test-matrix-include.outputs.json) }}"
+        name: echo-step
+    name: test-integration-test-matrix-setup
+
   integrationTest:
     runs-on: ubuntu-latest
-    needs: [get-product-version, build-pre-checks, build-docker, build-integration-test-array]
+    needs: [get-product-version, build-pre-checks, build-docker, build-integration-test-array, build-integration-test-matrix-include]
     env:
       KIND_CLUSTER_NAME: vault-secrets-operator
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -186,39 +202,22 @@ jobs:
           - kind-k8s-version: 1.23.17
           - kind-k8s-version: 1.22.17
 
-        include:
-          - kind-k8s-version: 1.26.4
-            vault-version: 1.13.2
-            integration-test: env.OSS_HELM_TEST_NAME
-          - kind-k8s-version: 1.25.9
-            vault-version: 1.13.2
-            integration-test: env.OSS_HELM_TEST_NAME
-          - kind-k8s-version: 1.24.13
-            vault-version: 1.13.2
-            integration-test: env.OSS_HELM_TEST_NAME
-          - kind-k8s-version: 1.23.17
-            vault-version: 1.13.2
-            integration-test: env.OSS_HELM_TEST_NAME
-          - kind-k8s-version: 1.22.17
-            vault-version: 1.13.2
-            integration-test: env.OSS_HELM_TEST_NAM
-
-          - kind-k8s-version: 1.26.4
-            vault-version: 1.13.2
-            integration-test: env.OSS_KUSTOMIZE_TEST_NAME
-          - kind-k8s-version: 1.25.9
-            vault-version: 1.13.2
-            integration-test: env.OSS_KUSTOMIZE_TEST_NAME
-          - kind-k8s-version: 1.24.13
-            vault-version: 1.13.2
-            integration-test: env.OSS_KUSTOMIZE_TEST_NAME
-          - kind-k8s-version: 1.23.17
-            vault-version: 1.13.2
-            integration-test: env.OSS_KUSTOMIZE_TEST_NAME
-          - kind-k8s-version: 1.22.17
-            vault-version: 1.13.2
-            integration-test: env.OSS_KUSTOMIZE_TEST_NAME
-
+        include: ${{ fromJSON(needs.build-integration-test-matrix-include.outputs.json) }}
+#          - kind-k8s-version: 1.26.4
+#            vault-version: 1.13.2
+#            integration-test: env.OSS_HELM_TEST_NAME
+#          - kind-k8s-version: 1.25.9
+#            vault-version: 1.13.2
+#            integration-test: env.OSS_HELM_TEST_NAME
+#          - kind-k8s-version: 1.24.13
+#            vault-version: 1.13.2
+#            integration-test: env.OSS_HELM_TEST_NAME
+#          - kind-k8s-version: 1.23.17
+#            vault-version: 1.13.2
+#            integration-test: env.OSS_HELM_TEST_NAME
+#          - kind-k8s-version: 1.22.17
+#            vault-version: 1.13.2
+#            integration-test: env.OSS_HELM_TEST_NAM
 
     name: Integration vault:${{ matrix.vault-version }} kind:${{ matrix.kind-k8s-version }} test:${{ matrix.integration-test }}
     steps:


### PR DESCRIPTION
The current `integrationTest` job of the `build` workflow creates multiple job runs that are based on the combinations of `kind-k8s-version` and `vault-version` values using matrix. Each run consists of some setup steps (Create K8s Kind Cluster,...), integration test steps (OSS tests using Helm, OSS tests using Kustomize, ENT tests using Helm, ENT tests using Kustomize), and some teardown steps (Store kind cluster logs,...).

Given that integration test steps taking [up to 17 minute each, which takes the build workflow over an hour to run](https://github.com/hashicorp/vault-secrets-operator/actions/runs/5343345048/jobs/9686400849), this PR aims to parallelize these integration test steps to shorten the build workflow time. The PR adds to the `integrationTest` job another matrix "dimension" named `integration-test` containing the names of the aforementioned integration test steps. Additionally, this PR adds a new job `build-integration-test-array` to form a json array of integration test values, preparing for the matrix setup in `integrationTest` job. The integration test steps now run according to the matrix `integration-test` value.
