### PR TITLE
Ensure client cache keys are always lower cased

### DIFF
--- a/internal/vault/cache_key.go
+++ b/internal/vault/cache_key.go
@@ -128,7 +128,7 @@ func computeClientCacheKey(authObj *secretsv1beta1.VaultAuth, connObj *secretsv1
 		connObj.GetUID(), connObj.GetGeneration(), providerUID)
 
 	sum := sha256.Sum256([]byte(input))
-	key := method + "-" + fmt.Sprintf("%x%x", sum[0:7], sum[len(sum)-4:])
+	key := strings.ToLower(method + "-" + fmt.Sprintf("%x%x", sum[0:7], sum[len(sum)-4:]))
 	if len(key) > 63 {
 		return "", errorKeyLengthExceeded
 	}

--- a/internal/vault/cache_key_test.go
+++ b/internal/vault/cache_key_test.go
@@ -33,7 +33,7 @@ type computeClientCacheKeyTest struct {
 }
 
 func Test_computeClientCacheKey(t *testing.T) {
-	type args struct{}
+	t.Parallel()
 	tests := []computeClientCacheKeyTest{
 		{
 			name: "valid",
@@ -75,6 +75,27 @@ func Test_computeClientCacheKey(t *testing.T) {
 			},
 			providerUID: providerUID,
 			want:        ClientCacheKey("ical" + strings.Repeat("x", 36) + "-" + computedHash),
+			wantErr:     assert.NoError,
+		},
+		{
+			name: "valid-mixed-case-method-name",
+			authObj: &secretsv1beta1.VaultAuth{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:        authUID,
+					Generation: 0,
+				},
+				Spec: secretsv1beta1.VaultAuthSpec{
+					Method: "icalBarBaz",
+				},
+			},
+			connObj: &secretsv1beta1.VaultConnection{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:        connUID,
+					Generation: 0,
+				},
+			},
+			providerUID: providerUID,
+			want:        ClientCacheKey("icalbarbaz" + "-" + computedHash),
 			wantErr:     assert.NoError,
 		},
 		{
@@ -179,6 +200,7 @@ func Test_computeClientCacheKey(t *testing.T) {
 }
 
 func TestComputeClientCacheKeyFromClient(t *testing.T) {
+	t.Parallel()
 	tests := []computeClientCacheKeyTest{
 		{
 			name: "valid",
@@ -226,6 +248,7 @@ func TestComputeClientCacheKeyFromClient(t *testing.T) {
 }
 
 func TestClientCacheKey_IsClone(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		k    ClientCacheKey
@@ -261,6 +284,7 @@ func TestClientCacheKey_IsClone(t *testing.T) {
 }
 
 func TestClientCacheKeyClone(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		key       ClientCacheKey


### PR DESCRIPTION
Since the Client cache key is encoded in the K8s Secret name it needs to follow the K8s specification for resource names, i.e. it can only contain lowercase characters.

To reproduce the issue:
- VSO running with persistent client cache enable
- Deploy a VaultAuth with the `appRole` method specified