### PR TITLE
Simplify the way KV requests are handled

### DIFF
--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
+	"github.com/hashicorp/vault-secrets-operator/internal/vault"
 )
 
 func Test_inRenewalWindow(t *testing.T) {
@@ -515,8 +516,15 @@ type mockRequest struct {
 	params map[string]any
 }
 
+var _ vault.ClientBase = (*mockRecordingVaultClient)(nil)
+
 type mockRecordingVaultClient struct {
 	requests []*mockRequest
+}
+
+func (m *mockRecordingVaultClient) ReadKV(ctx context.Context, request vault.KVReadRequest) (*api.KVSecret, error) {
+	// TODO implement me
+	panic("implement me")
 }
 
 func (m *mockRecordingVaultClient) Read(ctx context.Context, s string) (*api.Secret, error) {
@@ -540,12 +548,4 @@ func (m *mockRecordingVaultClient) Write(ctx context.Context, s string, params m
 	return &api.Secret{
 		Data: make(map[string]interface{}),
 	}, nil
-}
-
-func (m *mockRecordingVaultClient) KVv1(s string) (*api.KVv1, error) {
-	return nil, nil
-}
-
-func (m *mockRecordingVaultClient) KVv2(s string) (*api.KVv2, error) {
-	return nil, nil
 }

--- a/controllers/vaultstaticsecret_controller_test.go
+++ b/controllers/vaultstaticsecret_controller_test.go
@@ -39,7 +39,7 @@ func Test_makeK8sSecret(t *testing.T) {
 				Data: map[string]interface{}{},
 			},
 			expectedK8sSecret: nil,
-			expectedError:     fmt.Errorf("raw portion of vault secret was nil"),
+			expectedError:     fmt.Errorf("raw portion of vault KV secret was nil"),
 		},
 		"empty data": {
 			vaultSecret: &api.KVSecret{
@@ -91,7 +91,7 @@ func Test_makeK8sSecret(t *testing.T) {
 				},
 			},
 			expectedK8sSecret: nil,
-			expectedError:     fmt.Errorf(`failed to marshal key "password" from Vault secret: json: unsupported type: chan int`),
+			expectedError:     fmt.Errorf(`json: unsupported type: chan int`),
 		},
 		"fail to marshal secret raw": {
 			vaultSecret: &api.KVSecret{
@@ -102,7 +102,7 @@ func Test_makeK8sSecret(t *testing.T) {
 				},
 			},
 			expectedK8sSecret: nil,
-			expectedError:     fmt.Errorf("failed to marshal raw Vault secret: json: unsupported type: chan int"),
+			expectedError:     fmt.Errorf("json: unsupported type: chan int"),
 		},
 	}
 

--- a/internal/vault/client_test.go
+++ b/internal/vault/client_test.go
@@ -5,7 +5,10 @@ package vault
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -518,6 +521,211 @@ func Test_defaultClient_Validate(t *testing.T) {
 				lastWatcherErr: tt.lastWatcherErr,
 			}
 			tt.wantErr(t, c.Validate(), fmt.Sprintf("Validate()"))
+		})
+	}
+}
+
+func Test_defaultClient_ReadKV(t *testing.T) {
+	handlerFunc := func(t *testHandler, w http.ResponseWriter, req *http.Request) {
+		m, err := json.Marshal(
+			&api.Secret{
+				Data: map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+		)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(m)
+	}
+
+	ctx := context.Background()
+	tests := []struct {
+		name           string
+		request        KVReadRequest
+		handler        *testHandler
+		expectRequests int
+		expectPaths    []string
+		expectParams   []map[string]interface{}
+		expectValues   []url.Values
+		want           *api.KVSecret
+		wantErr        assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "kv-v1-request",
+			request: NewKVSecretRequestV1("kv-v1", "secrets"),
+			handler: &testHandler{
+				handlerFunc: handlerFunc,
+			},
+			expectRequests: 1,
+			expectPaths:    []string{"/v1/kv-v1/secrets"},
+			want: &api.KVSecret{
+				Data: map[string]interface{}{
+					"foo": "bar",
+				},
+				VersionMetadata: nil,
+				CustomMetadata:  nil,
+				Raw: &api.Secret{
+					Data: map[string]interface{}{
+						"foo": "bar",
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "kv-v2-request",
+			request: NewKVSecretRequestV2("kv-v2", "secrets", 0),
+			handler: &testHandler{
+				handlerFunc: func(t *testHandler, w http.ResponseWriter, req *http.Request) {
+					m, err := json.Marshal(
+						&api.Secret{
+							Data: map[string]interface{}{
+								"data": map[string]interface{}{
+									"foo": "bar",
+								},
+							},
+						},
+					)
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+
+					w.WriteHeader(http.StatusOK)
+					w.Write(m)
+				},
+			},
+			expectRequests: 1,
+			expectPaths:    []string{"/v1/kv-v2/data/secrets"},
+			want: &api.KVSecret{
+				Data: map[string]interface{}{
+					"foo": "bar",
+				},
+				VersionMetadata: nil,
+				CustomMetadata:  nil,
+				Raw: &api.Secret{
+					Data: map[string]interface{}{
+						"data": map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "kv-v2-request-with-version",
+			request: NewKVSecretRequestV2("kv-v2", "secrets", 1),
+			handler: &testHandler{
+				handlerFunc: func(t *testHandler, w http.ResponseWriter, req *http.Request) {
+					m, err := json.Marshal(
+						&api.Secret{
+							Data: map[string]interface{}{
+								"data": map[string]interface{}{
+									"foo": "bar",
+								},
+							},
+						},
+					)
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+
+					w.WriteHeader(http.StatusOK)
+					w.Write(m)
+				},
+			},
+			expectRequests: 1,
+			expectPaths:    []string{"/v1/kv-v2/data/secrets"},
+			expectValues: []url.Values{
+				{
+					"version": []string{"1"},
+				},
+			},
+			want: &api.KVSecret{
+				Data: map[string]interface{}{
+					"foo": "bar",
+				},
+				VersionMetadata: nil,
+				CustomMetadata:  nil,
+				Raw: &api.Secret{
+					Data: map[string]interface{}{
+						"data": map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "fail-kv-v1-nil-response",
+			request: NewKVSecretRequestV1("kv-v1", "secrets"),
+			handler: &testHandler{
+				handlerFunc: func(t *testHandler, w http.ResponseWriter, req *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				},
+			},
+			expectRequests: 1,
+			expectPaths:    []string{"/v1/kv-v1/secrets"},
+			want:           nil,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err,
+					fmt.Sprintf(`empty response from Vault, path="kv-v1/secrets"`))
+			},
+		},
+		{
+			name:    "fail-kv-v2-nil-response",
+			request: NewKVSecretRequestV2("kv-v2", "secrets", 0),
+			handler: &testHandler{
+				handlerFunc: func(t *testHandler, w http.ResponseWriter, req *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				},
+			},
+			expectRequests: 1,
+			expectPaths:    []string{"/v1/kv-v2/data/secrets"},
+			want:           nil,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err,
+					fmt.Sprintf(`empty response from Vault, path="kv-v2/data/secrets"`))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, l := NewTestHTTPServer(t, tt.handler.handler())
+			t.Cleanup(func() {
+				l.Close()
+			})
+
+			client, err := api.NewClient(config)
+			require.NoError(t, err)
+
+			c := &defaultClient{
+				client: client,
+				// needed for Client Prometheus metrics
+				connObj: &secretsv1beta1.VaultConnection{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "bar",
+					},
+				},
+			}
+			got, err := c.ReadKV(ctx, tt.request)
+			if !tt.wantErr(t, err, fmt.Sprintf("ReadKV(%v, %v)", ctx, tt.request)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "ReadKV(%v, %v)", ctx, tt.request)
+			assert.Equal(t, tt.expectRequests, tt.handler.requestCount)
+			assert.Equal(t, tt.expectPaths, tt.handler.paths)
+			assert.Equal(t, tt.expectParams, tt.handler.params)
+			assert.Equal(t, tt.expectValues, tt.handler.values)
 		})
 	}
 }

--- a/internal/vault/kv.go
+++ b/internal/vault/kv.go
@@ -1,0 +1,72 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"net/url"
+	"strconv"
+)
+
+type KVReadRequest interface {
+	Path() string
+	Values() url.Values
+}
+
+var (
+	_ KVReadRequest = (*KVReadRequestV1)(nil)
+	_ KVReadRequest = (*KVReadRequestV2)(nil)
+)
+
+// KVReadRequestV1 can be used in ClientBase.ReadKV to get KV version 1 secrets
+// from Vault.
+type KVReadRequestV1 struct {
+	mount string
+	path  string
+}
+
+func (r *KVReadRequestV1) Path() string {
+	return JoinPath(r.mount, r.path)
+}
+
+func (r *KVReadRequestV1) Values() url.Values {
+	return nil
+}
+
+// KVReadRequestV2 can be used in ClientBase.ReadKV to get KV version 2 secrets
+// from Vault.
+type KVReadRequestV2 struct {
+	mount   string
+	path    string
+	version int
+}
+
+func (r *KVReadRequestV2) Path() string {
+	return JoinPath(r.mount, "data", r.path)
+}
+
+func (r *KVReadRequestV2) Values() url.Values {
+	var vals url.Values
+	if r.version > 0 {
+		vals = map[string][]string{
+			"version": {strconv.Itoa(r.version)},
+		}
+	}
+
+	return vals
+}
+
+func NewKVSecretRequestV1(mount, path string) *KVReadRequestV1 {
+	return &KVReadRequestV1{
+		mount: mount,
+		path:  path,
+	}
+}
+
+func NewKVSecretRequestV2(mount, path string, version int) *KVReadRequestV2 {
+	return &KVReadRequestV2{
+		mount:   mount,
+		path:    path,
+		version: version,
+	}
+}

--- a/internal/vault/testutils_test.go
+++ b/internal/vault/testutils_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+)
+
+// TestHTTPServer creates a test HTTP server that handles requests until
+// the listener returned is closed.
+// XXX: based off of github.com/hashicorp/vault/api/client_test.go
+func NewTestHTTPServer(t *testing.T, handler http.Handler) (*api.Config, net.Listener) {
+	t.Helper()
+
+	server, ln, err := testHTTPServer(handler, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	go server.Serve(ln)
+
+	config := api.DefaultConfig()
+	config.Address = fmt.Sprintf("http://%s", ln.Addr())
+
+	return config, ln
+}
+
+func testHTTPServer(handler http.Handler, tlsConfig *tls.Config) (*http.Server, net.Listener, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	server := &http.Server{
+		Handler:   handler,
+		TLSConfig: tlsConfig,
+	}
+
+	return server, ln, err
+}
+
+type testHandler struct {
+	requestCount  int
+	paths         []string
+	params        []map[string]interface{}
+	values        []url.Values
+	excludeParams []string
+	handlerFunc   func(t *testHandler, w http.ResponseWriter, req *http.Request)
+}
+
+func (t *testHandler) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		t.requestCount++
+
+		t.paths = append(t.paths, req.URL.Path)
+
+		var params map[string]interface{}
+		switch req.Method {
+		case http.MethodPut:
+			b, err := io.ReadAll(req.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			if len(b) > 0 {
+				if err := json.Unmarshal(b, &params); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+			}
+		case http.MethodGet:
+			if req.URL.RawQuery != "" {
+				vals, err := url.ParseQuery(req.URL.RawQuery)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				t.values = append(t.values, vals)
+			}
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		for _, p := range t.excludeParams {
+			delete(params, p)
+		}
+
+		if len(params) > 0 {
+			t.params = append(t.params, params)
+		}
+
+		t.handlerFunc(t, w, req)
+	}
+}


### PR DESCRIPTION
Move away from the use of api.Client.Kv*, since it does not easily allow for Prometheus instrumentation and makes the overall ClientBase interface a bit more cumbersome.