### PR TITLE
Add extra envs to Helmchart values.yaml

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -83,6 +83,10 @@ spec:
               fieldPath: metadata.uid
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ .Values.controller.kubernetesClusterDomain }}
+        {{- range .Values.controller.manager.extraEnvs }}
+        - name: {{ .name }}
+          value: {{ .value | quote }}
+        {{- end }}
         image: {{ .Values.controller.manager.image.repository }}:{{ .Values.controller.manager.image.tag }}
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -257,6 +257,14 @@ controller:
     # @type: integer
     maxConcurrentReconciles:
 
+    # Defines additional environment variables to be added to the
+    # vault-secrets-operator container.
+    # extraEnvs:
+    #   - name: HTTP_PROXY
+    #     value: http://proxy.example.com
+    # @type: list
+    extraEnvs: []
+
     # Configures the default resources for the vault-secrets-operator container.
     # For more information on configuring resources, see the K8s documentation:
     # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/


### PR DESCRIPTION
This PR fixes #287 by introducing a new Helmchart value called `extraEnvs` to the `manager` container of the operator's deployment.

It allows users to define arbitrary environment variables they might need inside their operator, e.g. `HTTP_PROXY`/`NO_PROXY` settings.

I saw no use in adding the same configuration to the `kube-rbac-proxy` container, let me know if I should adapt this container's configuration, too.