### PR TITLE
Adding examples and maintainers to the ClusterServiceVersion

### DIFF
--- a/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
@@ -5,7 +5,56 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[]'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "secrets.hashicorp.com/v1beta1",
+          "kind": "VaultConnection",
+          "metadata": {
+            "name": "vaultconnection-sample",
+            "namespace": "tenant-1"
+          },
+          "spec": {
+            "address": "http://vault.vault.svc.cluster.local:8200"
+          }
+        },
+        {
+          "apiVersion": "secrets.hashicorp.com/v1beta1",
+          "kind": "VaultAuth",
+          "metadata": {
+            "name": "vaultauth-sample",
+            "namespace": "tenant-1"
+          },
+          "spec": {
+            "vaultConnectionRef": "vaultconnection-sample",
+            "method": "kubernetes",
+            "mount": "kubernetes",
+            "kubernetes": {
+              "role": "sample",
+              "serviceAccount": "default"
+            }
+          }
+        },
+        {
+          "apiVersion": "secrets.hashicorp.com/v1beta1",
+          "kind": "VaultStaticSecret",
+          "metadata": {
+            "name": "vaultstaticsecret-sample",
+            "namespace": "tenant-1"
+          },
+          "spec": {
+            "vaultAuthRef": "vaultauth-sample",
+            "mount": "kvv2",
+            "type": "kv-v2",
+            "path": "secret",
+            "refreshAfter": "5s",
+            "destination": {
+              "create": true,
+              "name": "secret1"
+            }
+          }
+        }
+      ]
     capabilities: Basic Install
     categories: Security
     containerImage: registry.connect.redhat.com/hashicorp/vault-secrets-operator
@@ -72,6 +121,9 @@ spec:
     url: https://github.com/hashicorp/vault-secrets-operator
   - name: Documentation
     url: https://developer.hashicorp.com/vault/docs/platform/k8s/vso
+  maintainers:
+  - email: support@hashicorp.com
+    name: HashiCorp Support
   maturity: stable
   provider:
     name: HashiCorp


### PR DESCRIPTION
Adds `alm-examples` and `maintainers` to the ClusterServiceVersion manifest. Per [Red Hat's docs](https://docs.openshift.com/container-platform/4.13/operators/operator_sdk/osdk-generating-csvs.html#osdk-manually-defined-csv-fields_osdk-generating-csvs).