### PR TITLE
Stage 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,22 @@
 ## Unreleased
 
-Features:
-* UBI-based images now built and published with releases: [GH-288](https://github.com/hashicorp/vault-secrets-operator/pull/288)
+## 0.1.1 (August 16th, 2023)
 
 Improvements:
 * Helm: `controller.imagePullSecrets` stanza is added to provide imagePullSecrets to the controller's containers via the serviceAccount: [GH-266](https://github.com/hashicorp/vault-secrets-operator/pull/266)
 * Helm: `controller.manager.resources` values now also apply to the pre-delete-controller-cleanup-job. [GH-280](https://github.com/hashicorp/vault-secrets-operator/pull/280)
+* Helm: Adding nodeselector and tolerations to deployment: [GH-272](https://github.com/hashicorp/vault-secrets-operator/pull/272)
+* Helm: Add extraLabels to deployment: [#281](https://github.com/hashicorp/vault-secrets-operator/pull/281)
+* Add K8s namespace support to VaultAuthRef and VaultConnectionRef: ([#291](https://github.com/hashicorp/vault-secrets-operator/pull/291))
 
 Changes:
 * Helm: Update default kube-rbac-proxy container image in helm chart from `v0.11.0` to `v0.14.1`: [GH-267](https://github.com/hashicorp/vault-secrets-operator/pull/267)
 * Added Vault 1.14 and removed 1.11 from CI testing [GH-324](https://github.com/hashicorp/vault-secrets-operator/pull/324)
 * K8s versions tested are now 1.23-1.27 [GH-324](https://github.com/hashicorp/vault-secrets-operator/pull/324)
+* UBI-based images now built and published with releases: [GH-288](https://github.com/hashicorp/vault-secrets-operator/pull/288)
+
+Bugs:
+* VaultStaticSecrets (VSS): fix issue where the response error was not being set: [GH-301](https://github.com/hashicorp/vault-secrets-operator/pull/301)
 
 ## 0.1.0 (June 12th, 2023)
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault-secrets-operator
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"
 kubeVersion: ">=1.22.0-0"
 description: Official Vault Secrets Operator Chart
 type: application

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -74,7 +74,7 @@ controller:
     # Image sets the repo and tag of the vault-secrets-operator image to use for the controller.
     image:
       repository: hashicorp/vault-secrets-operator
-      tag: 0.1.0
+      tag: 0.1.1
 
     # Configures the client cache which is used by the controller to cache (and potentially persist) vault tokens that
     # are the result of using the VaultAuthMethod. This enables re-use of Vault Tokens

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,4 +16,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: hashicorp/vault-secrets-operator
-  newTag: 0.1.0
+  newTag: 0.1.1


### PR DESCRIPTION
Improvements:
* Helm: `controller.imagePullSecrets` stanza is added to provide imagePullSecrets to the controller's containers via the serviceAccount: [GH-266](https://github.com/hashicorp/vault-secrets-operator/pull/266)
* Helm: `controller.manager.resources` values now also apply to the pre-delete-controller-cleanup-job. [GH-280](https://github.com/hashicorp/vault-secrets-operator/pull/280)
* Helm: Adding nodeselector and tolerations to deployment: [GH-272](https://github.com/hashicorp/vault-secrets-operator/pull/272)
* Helm: Add extraLabels to deployment: [#281](https://github.com/hashicorp/vault-secrets-operator/pull/281)
* Add K8s namespace support to VaultAuthRef and VaultConnectionRef: ([#291](https://github.com/hashicorp/vault-secrets-operator/pull/291))

Changes:
* Helm: Update default kube-rbac-proxy container image in helm chart from `v0.11.0` to `v0.14.1`: [GH-267](https://github.com/hashicorp/vault-secrets-operator/pull/267)
* Added Vault 1.14 and removed 1.11 from CI testing [GH-324](https://github.com/hashicorp/vault-secrets-operator/pull/324)
* K8s versions tested are now 1.23-1.27 [GH-324](https://github.com/hashicorp/vault-secrets-operator/pull/324)
* UBI-based images now built and published with releases: [GH-288](https://github.com/hashicorp/vault-secrets-operator/pull/288)

Bugs:
* VaultStaticSecrets (VSS): fix issue where the response error was not being set: [GH-301](https://github.com/hashicorp/vault-secrets-operator/pull/301)