### PR TITLE
fix: GCP "private_key_data" not decoded before write to k8s secrets

### DIFF
--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -191,7 +191,7 @@ func Test_MarshalSecretData(t *testing.T) {
 				"private_key_data": "test string",
 			},
 		},
-		"secrets include a valid base64": {
+		"secrets include a invalid base64": {
 			input: api.Secret{
 				Data: map[string]interface{}{
 					"key_algorithm":    "KEY_ALG_RSA_2048",


### PR DESCRIPTION
fixes #332