### PR TITLE
Update license headers

### DIFF
--- a/internal/vault/requests.go
+++ b/internal/vault/requests.go
@@ -1,5 +1,5 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
 
 package vault
 

--- a/internal/vault/requests_test.go
+++ b/internal/vault/requests_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
 
 package vault
 

--- a/internal/vault/responses.go
+++ b/internal/vault/responses.go
@@ -1,5 +1,5 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
 
 package vault
 

--- a/internal/vault/responses_test.go
+++ b/internal/vault/responses_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
 
 package vault
 

--- a/internal/vault/testutils_test.go
+++ b/internal/vault/testutils_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
 
 package vault
 

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: BUSL-1.1
 
 package vault
 


### PR DESCRIPTION
PR updates some straggler files that still contained the MPL license BUSL-1.1.