### PR TITLE
Upgrade to golang-lru/v2 (v2.0.6)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/go-secure-stdlib/awsutil v0.2.3-0.20230606170242-1a4b95565d57
-	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.6
 	github.com/hashicorp/vault/api v1.9.2
 	github.com/hashicorp/vault/sdk v0.9.2
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.6 h1:3xi/Cafd1NaoEnS/yDssIiuVeDVywU0QdFGl3aQaQHM=
+github.com/hashicorp/golang-lru/v2 v2.0.6/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31RPDgJM=
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/hcl/v2 v2.9.1 h1:eOy4gREY0/ZQHNItlfuEZqtcQbXIxzojlP301hDpnac=

--- a/internal/vault/cache.go
+++ b/internal/vault/cache.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/golang-lru/v2"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -30,8 +30,8 @@ var _ ClientCache = (*clientCache)(nil)
 
 // clientCache implements ClientCache with an underlying LRU cache. The cache size is fixed.
 type clientCache struct {
-	cache              *lru.Cache
-	cloneCache         *lru.Cache
+	cache              *lru.Cache[ClientCacheKey, Client]
+	cloneCache         *lru.Cache[ClientCacheKey, Client]
 	evictionGauge      prometheus.Gauge
 	hitCounter         prometheus.Counter
 	missCounter        prometheus.Counter
@@ -44,11 +44,7 @@ type clientCache struct {
 // CachingClientFactory.
 func (c *clientCache) Purge() []ClientCacheKey {
 	var purged []ClientCacheKey
-	for _, v := range c.cache.Keys() {
-		key, ok := v.(ClientCacheKey)
-		if !ok {
-			continue
-		}
+	for _, key := range c.cache.Keys() {
 		client, ok := c.Get(key)
 		if !ok {
 			continue
@@ -77,7 +73,7 @@ func (c *clientCache) Get(key ClientCacheKey) (Client, bool) {
 	if key.IsClone() {
 		if v, ok := c.cloneCache.Get(key); ok {
 			c.hitCloneCounter.Inc()
-			return v.(Client), ok
+			return v, ok
 		} else {
 			c.missCloneCounter.Inc()
 		}
@@ -86,7 +82,7 @@ func (c *clientCache) Get(key ClientCacheKey) (Client, bool) {
 
 	if v, ok := c.cache.Get(key); ok {
 		c.hitCounter.Inc()
-		return v.(Client), ok
+		return v, ok
 	} else {
 		c.missCounter.Inc()
 		return nil, false
@@ -132,8 +128,7 @@ func (c *clientCache) Add(client Client) (bool, error) {
 func (c *clientCache) Remove(key ClientCacheKey) bool {
 	var removed bool
 	if v, ok := c.cache.Peek(key); ok {
-		client := v.(Client)
-		removed = c.remove(key, client)
+		removed = c.remove(key, v)
 	}
 
 	return removed
@@ -143,11 +138,10 @@ func (c *clientCache) Prune(filterFunc ClientCachePruneFilterFunc) []ClientCache
 	var pruned []ClientCacheKey
 	for _, k := range c.cache.Keys() {
 		if v, ok := c.cache.Peek(k); ok {
-			key := k.(ClientCacheKey)
 			client := v.(Client)
 			if filterFunc(client) {
-				if c.remove(key, client) {
-					pruned = append(pruned, key)
+				if c.remove(k, client) {
+					pruned = append(pruned, k)
 				}
 			}
 		}
@@ -166,7 +160,7 @@ func (c *clientCache) remove(key ClientCacheKey, client Client) bool {
 
 func (c *clientCache) pruneClones(cacheKey ClientCacheKey) {
 	for _, k := range c.cloneCache.Keys() {
-		if !strings.HasPrefix(k.(ClientCacheKey).String(), cacheKey.String()) {
+		if !strings.HasPrefix(k.String(), cacheKey.String()) {
 			continue
 		}
 
@@ -217,19 +211,19 @@ func NewClientCache(size int, callbackFunc onEvictCallbackFunc, metricsRegistry 
 		}),
 	}
 
-	onEvictFunc := func(key, value interface{}) {
+	onEvictFunc := func(key ClientCacheKey, value Client) {
 		if callbackFunc != nil {
 			callbackFunc(key, value)
 		}
 		onEvictPruneClonesFunc(cache)(key, value)
 	}
 
-	lruCache, err := lru.NewWithEvict(size, onEvictFunc)
+	lruCache, err := lru.NewWithEvict[ClientCacheKey, Client](size, onEvictFunc)
 	if err != nil {
 		return nil, err
 	}
 
-	lruCloneCache, err := lru.New(size)
+	lruCloneCache, err := lru.New[ClientCacheKey, Client](size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vault/cache.go
+++ b/internal/vault/cache.go
@@ -71,18 +71,18 @@ func (c *clientCache) Len() int {
 // was found in the cache.
 func (c *clientCache) Get(key ClientCacheKey) (Client, bool) {
 	if key.IsClone() {
-		if v, ok := c.cloneCache.Get(key); ok {
+		if client, ok := c.cloneCache.Get(key); ok {
 			c.hitCloneCounter.Inc()
-			return v, ok
+			return client, ok
 		} else {
 			c.missCloneCounter.Inc()
 		}
 		return nil, false
 	}
 
-	if v, ok := c.cache.Get(key); ok {
+	if client, ok := c.cache.Get(key); ok {
 		c.hitCounter.Inc()
-		return v, ok
+		return client, ok
 	} else {
 		c.missCounter.Inc()
 		return nil, false
@@ -127,8 +127,8 @@ func (c *clientCache) Add(client Client) (bool, error) {
 // If it was present then Client.Close() will be called.
 func (c *clientCache) Remove(key ClientCacheKey) bool {
 	var removed bool
-	if v, ok := c.cache.Peek(key); ok {
-		removed = c.remove(key, v)
+	if client, ok := c.cache.Peek(key); ok {
+		removed = c.remove(key, client)
 	}
 
 	return removed
@@ -137,8 +137,7 @@ func (c *clientCache) Remove(key ClientCacheKey) bool {
 func (c *clientCache) Prune(filterFunc ClientCachePruneFilterFunc) []ClientCacheKey {
 	var pruned []ClientCacheKey
 	for _, k := range c.cache.Keys() {
-		if v, ok := c.cache.Peek(k); ok {
-			client := v.(Client)
+		if client, ok := c.cache.Peek(k); ok {
 			if filterFunc(client) {
 				if c.remove(k, client) {
 					pruned = append(pruned, k)

--- a/internal/vault/cache_test.go
+++ b/internal/vault/cache_test.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"testing"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_clientCache_Prune(t *testing.T) {
-	dummyCallbackFunc := func(key, value interface{}) {}
+	dummyCallbackFunc := func(_ ClientCacheKey, _ Client) {}
 	cacheSize := 10
 
 	tests := []struct {
@@ -47,9 +47,9 @@ func Test_clientCache_Prune(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &clientCache{}
-			cache, err := lru.NewWithEvict(cacheSize, dummyCallbackFunc)
-			c.cache = cache
+			cache, err := lru.NewWithEvict[ClientCacheKey, Client](cacheSize, dummyCallbackFunc)
 			require.NoError(t, err)
+			c.cache = cache
 
 			var expectedPrunedKeys []ClientCacheKey
 			for i := 0; i < tt.cacheLen; i++ {


### PR DESCRIPTION
golang-lru v0/1 is no longer being maintained. The recommended update path is to move to v2 per:
https://github.com/hashicorp/golang-lru/releases/tag/v1.0.2