### PR TITLE
support for db schedule-based static role rotations

### DIFF
--- a/api/v1beta1/vaultdynamicsecret_types.go
+++ b/api/v1beta1/vaultdynamicsecret_types.go
@@ -104,6 +104,11 @@ type VaultStaticCredsMetaData struct {
 	// "time to live". This value is compared to the LastVaultRotation to
 	// determine if a password needs to be rotated
 	RotationPeriod int64 `json:"rotationPeriod"`
+	// RotationSchedule is a "chron style" string representing the allowed
+	// schedule for each rotation.
+	// e.g. "1 0 * * *" would rotate at one minute past midnight (00:01) every
+	// day.
+	RotationSchedule string `json:"rotationSchedule"`
 	// TTL is the seconds remaining before the next rotation.
 	TTL int64 `json:"ttl"`
 }

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -226,6 +226,11 @@ spec:
                       be rotated
                     format: int64
                     type: integer
+                  rotationSchedule:
+                    description: RotationSchedule is a "chron style" string representing
+                      the allowed schedule for each rotation. e.g. "1 0 * * *" would
+                      rotate at one minute past midnight (00:01) every day.
+                    type: string
                   ttl:
                     description: TTL is the seconds remaining before the next rotation.
                     format: int64
@@ -233,6 +238,7 @@ spec:
                 required:
                 - lastVaultRotation
                 - rotationPeriod
+                - rotationSchedule
                 - ttl
                 type: object
             required:

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -226,6 +226,11 @@ spec:
                       be rotated
                     format: int64
                     type: integer
+                  rotationSchedule:
+                    description: RotationSchedule is a "chron style" string representing
+                      the allowed schedule for each rotation. e.g. "1 0 * * *" would
+                      rotate at one minute past midnight (00:01) every day.
+                    type: string
                   ttl:
                     description: TTL is the seconds remaining before the next rotation.
                     format: int64
@@ -233,6 +238,7 @@ spec:
                 required:
                 - lastVaultRotation
                 - rotationPeriod
+                - rotationSchedule
                 - ttl
                 type: object
             required:

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -543,6 +543,7 @@ _Appears in:_
 | --- | --- |
 | `lastVaultRotation` _integer_ | LastVaultRotation represents the last time Vault rotated the password |
 | `rotationPeriod` _integer_ | RotationPeriod is number in seconds between each rotation, effectively a "time to live". This value is compared to the LastVaultRotation to determine if a password needs to be rotated |
+| `rotationSchedule` _string_ | RotationSchedule is a "chron style" string representing the allowed schedule for each rotation. e.g. "1 0 * * *" would rotate at one minute past midnight (00:01) every day. |
 | `ttl` _integer_ | TTL is the seconds remaining before the next rotation. |
 
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -327,7 +327,7 @@ type dynamicK8SOutputs struct {
 }
 
 func assertDynamicSecret(t *testing.T, client ctrlclient.Client, maxRetries int,
-	delay time.Duration, vdsObj *secretsv1beta1.VaultDynamicSecret, expected map[string]int,
+	delay time.Duration, vdsObj *secretsv1beta1.VaultDynamicSecret, expected map[string]interface{},
 ) {
 	t.Helper()
 

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -189,8 +189,8 @@ func TestVaultDynamicSecret(t *testing.T) {
 	tests := []struct {
 		name           string
 		authObj        *secretsv1beta1.VaultAuth
-		expected       map[string]int
-		expectedStatic map[string]int
+		expected       map[string]interface{}
+		expectedStatic map[string]interface{}
 		create         int
 		createStatic   int
 		existing       []string
@@ -199,7 +199,7 @@ func TestVaultDynamicSecret(t *testing.T) {
 			name:     "existing-only",
 			existing: outputs.K8sDBSecrets,
 			authObj:  auths[0],
-			expected: map[string]int{
+			expected: map[string]interface{}{
 				helpers.SecretDataKeyRaw: 100,
 				"username":               51,
 				"password":               20,
@@ -209,7 +209,7 @@ func TestVaultDynamicSecret(t *testing.T) {
 			name:    "create-only",
 			create:  5,
 			authObj: auths[0],
-			expected: map[string]int{
+			expected: map[string]interface{}{
 				helpers.SecretDataKeyRaw: 100,
 				"username":               51,
 				"password":               20,
@@ -221,12 +221,12 @@ func TestVaultDynamicSecret(t *testing.T) {
 			createStatic: 5,
 			existing:     outputs.K8sDBSecrets,
 			authObj:      auths[0],
-			expected: map[string]int{
+			expected: map[string]interface{}{
 				helpers.SecretDataKeyRaw: 100,
 				"username":               51,
 				"password":               20,
 			},
-			expectedStatic: map[string]int{
+			expectedStatic: map[string]interface{}{
 				// the _raw, last_vault_rotation, and ttl keys are only tested for their presence in
 				// assertDynamicSecret, so no need to include them here.
 				"password":        20,
@@ -238,12 +238,43 @@ func TestVaultDynamicSecret(t *testing.T) {
 			name:         "create-static",
 			createStatic: 5,
 			authObj:      auths[0],
-			expectedStatic: map[string]int{
+			expectedStatic: map[string]interface{}{
 				// the _raw, last_vault_rotation, and ttl keys are only tested for their presence in
 				// assertDynamicSecret, so no need to include them here.
 				"password":        20,
 				"rotation_period": 2,
 				"username":        24,
+			},
+		},
+		{
+			name:         "mixed-rotation-schedule",
+			create:       5,
+			createStatic: 5,
+			existing:     outputs.K8sDBSecrets,
+			authObj:      auths[0],
+			expected: map[string]interface{}{
+				helpers.SecretDataKeyRaw: 100,
+				"username":               51,
+				"password":               20,
+			},
+			expectedStatic: map[string]interface{}{
+				// the _raw, last_vault_rotation, and ttl keys are only tested for their presence in
+				// assertDynamicSecret, so no need to include them here.
+				"password":          20,
+				"rotation_schedule": "0 0 * * SAT",
+				"username":          24,
+			},
+		},
+		{
+			name:         "create-static-rotation-schedule",
+			createStatic: 5,
+			authObj:      auths[0],
+			expectedStatic: map[string]interface{}{
+				// the _raw, last_vault_rotation, and ttl keys are only tested for their presence in
+				// assertDynamicSecret, so no need to include them here.
+				"password":          20,
+				"rotation_schedule": "0 0 * * SAT",
+				"username":          24,
 			},
 		},
 	}


### PR DESCRIPTION
Add support for the upcoming 1.15 Vault feature
- https://github.com/hashicorp/vault/pull/22484

Related docs PR for the feature
- https://github.com/hashicorp/vault/pull/22863