### PR TITLE
HCPVS: rename servicePrinciple data key clientKey to clientSecret

### DIFF
--- a/api/v1beta1/hcpauth_types.go
+++ b/api/v1beta1/hcpauth_types.go
@@ -42,7 +42,7 @@ type HCPAuthServicePrincipal struct {
 	//
 	//The secret data must have the following structure {
 	//   "clientID": "clientID",
-	//   "clientKey": "clientKey",
+	//   "clientSecret": "clientSecret",
 	// }
 	SecretRef string `json:"secretRef"`
 }

--- a/api/v1beta1/hcpauth_types.go
+++ b/api/v1beta1/hcpauth_types.go
@@ -38,7 +38,7 @@ type HCPAuthSpec struct {
 type HCPAuthServicePrincipal struct {
 	// SecretRef is the name of a Kubernetes secret in the consumer's
 	// (VDS/VSS/PKI/HCP) namespace which provides the HCP ServicePrincipal clientID,
-	// and clientKey.
+	// and clientSecret.
 	//
 	//The secret data must have the following structure {
 	//   "clientID": "clientID",

--- a/chart/crds/secrets.hashicorp.com_hcpauths.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpauths.yaml
@@ -72,7 +72,7 @@ spec:
                       the consumer's (VDS/VSS/PKI/HCP) namespace which provides the
                       HCP ServicePrincipal clientID, and clientKey. \n The secret
                       data must have the following structure { \"clientID\": \"clientID\",
-                      \"clientKey\": \"clientKey\", }"
+                      \"clientSecret\": \"clientSecret\", }"
                     type: string
                 required:
                 - secretRef

--- a/chart/crds/secrets.hashicorp.com_hcpauths.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpauths.yaml
@@ -70,7 +70,7 @@ spec:
                   secretRef:
                     description: "SecretRef is the name of a Kubernetes secret in
                       the consumer's (VDS/VSS/PKI/HCP) namespace which provides the
-                      HCP ServicePrincipal clientID, and clientKey. \n The secret
+                      HCP ServicePrincipal clientID, and clientSecret. \n The secret
                       data must have the following structure { \"clientID\": \"clientID\",
                       \"clientSecret\": \"clientSecret\", }"
                     type: string

--- a/config/crd/bases/secrets.hashicorp.com_hcpauths.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpauths.yaml
@@ -72,7 +72,7 @@ spec:
                       the consumer's (VDS/VSS/PKI/HCP) namespace which provides the
                       HCP ServicePrincipal clientID, and clientKey. \n The secret
                       data must have the following structure { \"clientID\": \"clientID\",
-                      \"clientKey\": \"clientKey\", }"
+                      \"clientSecret\": \"clientSecret\", }"
                     type: string
                 required:
                 - secretRef

--- a/config/crd/bases/secrets.hashicorp.com_hcpauths.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpauths.yaml
@@ -70,7 +70,7 @@ spec:
                   secretRef:
                     description: "SecretRef is the name of a Kubernetes secret in
                       the consumer's (VDS/VSS/PKI/HCP) namespace which provides the
-                      HCP ServicePrincipal clientID, and clientKey. \n The secret
+                      HCP ServicePrincipal clientID, and clientSecret. \n The secret
                       data must have the following structure { \"clientID\": \"clientID\",
                       \"clientSecret\": \"clientSecret\", }"
                     type: string

--- a/controllers/hcpvaultsecretsapp_controller.go
+++ b/controllers/hcpvaultsecretsapp_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/vault-secrets-operator/internal/common"
 	"github.com/hashicorp/vault-secrets-operator/internal/consts"
 	"github.com/hashicorp/vault-secrets-operator/internal/credentials"
+	"github.com/hashicorp/vault-secrets-operator/internal/credentials/hcp"
 	"github.com/hashicorp/vault-secrets-operator/internal/helpers"
 )
 
@@ -167,7 +168,8 @@ func (r *HCPVaultSecretsAppReconciler) hvsClient(ctx context.Context, o *secrets
 			ProjectID:      authObj.Spec.ProjectID,
 		}),
 		hcpconfig.WithClientCredentials(
-			creds["clientID"].(string), creds["clientKey"].(string),
+			creds[hcp.ProviderSecretClientID].(string),
+			creds[hcp.ProviderSecretClientSecret].(string),
 		),
 	)
 	if err != nil {

--- a/demo/infra/app/hcpvs.tf
+++ b/demo/infra/app/hcpvs.tf
@@ -33,8 +33,8 @@ resource "kubernetes_secret" "hcp-vsa-sp" {
     namespace = kubernetes_namespace.dev.metadata[0].name
   }
   data = {
-    "clientID"  = var.hcp_client_id
-    "clientKey" = var.hcp_client_key
+    "clientID"     = var.hcp_client_id
+    "clientSecret" = var.hcp_client_secret
   }
 }
 

--- a/demo/infra/app/variables.tf
+++ b/demo/infra/app/variables.tf
@@ -56,7 +56,7 @@ variable "hcp_client_id" {
   default = ""
 }
 
-variable "hcp_client_key" {
+variable "hcp_client_secret" {
   type    = string
   default = ""
 }

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -92,7 +92,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `secretRef` _string_ | SecretRef is the name of a Kubernetes secret in the consumer's (VDS/VSS/PKI/HCP) namespace which provides the HCP ServicePrincipal clientID, and clientKey. 
- The secret data must have the following structure { "clientID": "clientID", "clientKey": "clientKey", } |
+ The secret data must have the following structure { "clientID": "clientID", "clientSecret": "clientSecret", } |
 
 
 #### HCPAuthSpec

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -91,7 +91,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `secretRef` _string_ | SecretRef is the name of a Kubernetes secret in the consumer's (VDS/VSS/PKI/HCP) namespace which provides the HCP ServicePrincipal clientID, and clientKey. 
+| `secretRef` _string_ | SecretRef is the name of a Kubernetes secret in the consumer's (VDS/VSS/PKI/HCP) namespace which provides the HCP ServicePrincipal clientID, and clientSecret. 
  The secret data must have the following structure { "clientID": "clientID", "clientSecret": "clientSecret", } |
 
 

--- a/docs/diags/hcp-secrets.puml
+++ b/docs/diags/hcp-secrets.puml
@@ -31,7 +31,7 @@ Container_Boundary(c6, "App Deployment", $tags="namespace") {
     Container(pod1, "app1", "Pod", "", $sprite="pod")
 }
     Container(app_secret, "app-secret", "HVS Secret Data", "", $sprite="secret")
-    Container(sp_secret, "hcp-sp-auth-secret", "{clientID=client1, clientKey=clientKey1}", "", $sprite="secret")
+    Container(sp_secret, "hcp-sp-auth-secret", "{clientID=client1, clientSecret=clientSecret1}", "", $sprite="secret")
 }
 }
 

--- a/internal/credentials/hcp/service_principal.go
+++ b/internal/credentials/hcp/service_principal.go
@@ -19,7 +19,7 @@ import (
 const (
 	ProviderMethodServicePrincipal = "servicePrincipal"
 	ProviderSecretClientID         = "clientID"
-	ProviderSecretClientKey        = "clientKey"
+	ProviderSecretClientSecret     = "clientSecret"
 )
 
 var _ CredentialProviderHCP = (*ServicePrincipleCredentialProvider)(nil)
@@ -80,7 +80,7 @@ func (l *ServicePrincipleCredentialProvider) GetCreds(ctx context.Context,
 		return nil, fmt.Errorf("%w, %s", errors.InvalidCredentialDataError, err)
 	}
 
-	keys := []string{ProviderSecretClientKey, ProviderSecretClientID}
+	keys := []string{ProviderSecretClientSecret, ProviderSecretClientID}
 	result := make(map[string]any, len(keys))
 	var invalidKeys []string
 	for _, k := range keys {

--- a/internal/credentials/hcp/service_principal_test.go
+++ b/internal/credentials/hcp/service_principal_test.go
@@ -42,12 +42,12 @@ func TestServicePrincipleCredentialProvider_GetCreds(t *testing.T) {
 			authObj:           authObj,
 			providerNamespace: "tenant-ns",
 			secretData: map[string][]byte{
-				ProviderSecretClientID:  []byte("client-id-1"),
-				ProviderSecretClientKey: []byte("client-key-1"),
+				ProviderSecretClientID:     []byte("client-id-1"),
+				ProviderSecretClientSecret: []byte("client-secret-1"),
 			},
 			want: map[string]any{
-				ProviderSecretClientID:  "client-id-1",
-				ProviderSecretClientKey: "client-key-1",
+				ProviderSecretClientID:     "client-id-1",
+				ProviderSecretClientSecret: "client-secret-1",
 			},
 			wantErr: assert.NoError,
 		},
@@ -75,7 +75,7 @@ func TestServicePrincipleCredentialProvider_GetCreds(t *testing.T) {
 			want:              nil,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				expectErr := errors.NewIncompleteCredentialError(
-					ProviderSecretClientKey,
+					ProviderSecretClientSecret,
 					ProviderSecretClientID,
 				)
 				return assert.EqualError(t, err, expectErr.Error(), i...)
@@ -86,20 +86,20 @@ func TestServicePrincipleCredentialProvider_GetCreds(t *testing.T) {
 			authObj:           authObj,
 			providerNamespace: "tenant-ns",
 			secretData: map[string][]byte{
-				ProviderSecretClientID:  make([]byte, 0),
-				ProviderSecretClientKey: make([]byte, 0),
+				ProviderSecretClientID:     make([]byte, 0),
+				ProviderSecretClientSecret: make([]byte, 0),
 			},
 			want: nil,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				expectErr := errors.NewIncompleteCredentialError(
-					ProviderSecretClientKey,
+					ProviderSecretClientSecret,
 					ProviderSecretClientID,
 				)
 				return assert.EqualError(t, err, expectErr.Error(), i...)
 			},
 		},
 		{
-			name:              "invalid-secret-client-key",
+			name:              "invalid-secret-client-secret",
 			authObj:           authObj,
 			providerNamespace: "tenant-ns",
 			secretData: map[string][]byte{
@@ -108,7 +108,7 @@ func TestServicePrincipleCredentialProvider_GetCreds(t *testing.T) {
 			want: nil,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				expectErr := errors.NewIncompleteCredentialError(
-					ProviderSecretClientKey,
+					ProviderSecretClientSecret,
 				)
 				return assert.EqualError(t, err, expectErr.Error(), i...)
 			},
@@ -118,7 +118,7 @@ func TestServicePrincipleCredentialProvider_GetCreds(t *testing.T) {
 			authObj:           authObj,
 			providerNamespace: "tenant-ns",
 			secretData: map[string][]byte{
-				ProviderSecretClientKey: []byte("client-key-1"),
+				ProviderSecretClientSecret: []byte("client-secret-1"),
 			},
 			want: nil,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {

--- a/test/integration/hcpvaultsecretsapp/terraform/main.tf
+++ b/test/integration/hcpvaultsecretsapp/terraform/main.tf
@@ -46,8 +46,8 @@ resource "kubernetes_secret" "sp" {
     namespace = kubernetes_namespace.dev.metadata[0].name
   }
   data = {
-    "clientID"  = var.hcp_client_id
-    "clientKey" = var.hcp_client_secret
+    "clientID"     = var.hcp_client_id
+    "clientSecret" = var.hcp_client_secret
   }
 }
 


### PR DESCRIPTION
In the HCP interface the name of the service-principle's client access key is `clientSecret`. This PR provides better alignment with HCP's naming conventions.