### PR TITLE
support for db schedule-based static role rotations

### DIFF
--- a/api/v1beta1/vaultdynamicsecret_types.go
+++ b/api/v1beta1/vaultdynamicsecret_types.go
@@ -104,6 +104,11 @@ type VaultStaticCredsMetaData struct {
 	// "time to live". This value is compared to the LastVaultRotation to
 	// determine if a password needs to be rotated
 	RotationPeriod int64 `json:"rotationPeriod"`
+	// RotationSchedule is a "cron style" string representing the allowed
+	// schedule for each rotation.
+	// e.g. "1 0 * * *" would rotate at one minute past midnight (00:01) every
+	// day.
+	RotationSchedule string `json:"rotationSchedule"`
 	// TTL is the seconds remaining before the next rotation.
 	TTL int64 `json:"ttl"`
 }

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -226,6 +226,11 @@ spec:
                       be rotated
                     format: int64
                     type: integer
+                  rotationSchedule:
+                    description: RotationSchedule is a "cron style" string representing
+                      the allowed schedule for each rotation. e.g. "1 0 * * *" would
+                      rotate at one minute past midnight (00:01) every day.
+                    type: string
                   ttl:
                     description: TTL is the seconds remaining before the next rotation.
                     format: int64
@@ -233,6 +238,7 @@ spec:
                 required:
                 - lastVaultRotation
                 - rotationPeriod
+                - rotationSchedule
                 - ttl
                 type: object
             required:

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -226,6 +226,11 @@ spec:
                       be rotated
                     format: int64
                     type: integer
+                  rotationSchedule:
+                    description: RotationSchedule is a "cron style" string representing
+                      the allowed schedule for each rotation. e.g. "1 0 * * *" would
+                      rotate at one minute past midnight (00:01) every day.
+                    type: string
                   ttl:
                     description: TTL is the seconds remaining before the next rotation.
                     format: int64
@@ -233,6 +238,7 @@ spec:
                 required:
                 - lastVaultRotation
                 - rotationPeriod
+                - rotationSchedule
                 - ttl
                 type: object
             required:

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -17,7 +17,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
+	"github.com/hashicorp/vault-secrets-operator/internal/helpers"
 	"github.com/hashicorp/vault-secrets-operator/internal/vault"
 )
 
@@ -498,6 +500,419 @@ func TestVaultDynamicSecretReconciler_syncSecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &VaultDynamicSecretReconciler{
 				Client: tt.fields.Client,
+			}
+			got, _, err := r.syncSecret(tt.args.ctx, tt.args.vClient, tt.args.o)
+			if !tt.wantErr(t, err, fmt.Sprintf("syncSecret(%v, %v, %v)", tt.args.ctx, tt.args.vClient, tt.args.o)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "syncSecret(%v, %v, %v)", tt.args.ctx, tt.args.vClient, tt.args.o)
+			assert.Equalf(t, tt.expectRequests, tt.args.vClient.Requests, "syncSecret(%v, %v, %v)", tt.args.ctx, tt.args.vClient, tt.args.o)
+		})
+	}
+}
+
+func TestVaultDynamicSecretReconciler_syncSecret_staticCreds(t *testing.T) {
+	type fields struct {
+		Client        client.Client
+		runtimePodUID types.UID
+	}
+	type args struct {
+		ctx     context.Context
+		vClient *vault.MockRecordingVaultClient
+		o       *secretsv1beta1.VaultDynamicSecret
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		want           *secretsv1beta1.VaultSecretLease
+		expectRequests []*vault.MockRequest
+		wantErr        assert.ErrorAssertionFunc
+	}{
+		{
+			name: "without-params",
+			fields: fields{
+				Client:        fake.NewClientBuilder().Build(),
+				runtimePodUID: "",
+			},
+			args: args{
+				ctx:     nil,
+				vClient: &vault.MockRecordingVaultClient{},
+				o: &secretsv1beta1.VaultDynamicSecret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "default",
+					},
+					Spec: secretsv1beta1.VaultDynamicSecretSpec{
+						Mount:  "baz",
+						Path:   "foo",
+						Params: nil,
+						Destination: secretsv1beta1.Destination{
+							Name:   "baz",
+							Create: true,
+						},
+						AllowStaticCreds: true,
+					},
+					Status: secretsv1beta1.VaultDynamicSecretStatus{
+						StaticCredsMetaData: v1beta1.VaultStaticCredsMetaData{
+							LastVaultRotation: 1695419440,
+							RotationSchedule:  "1 0 * * *",
+						},
+						SecretMAC: "vso-cc-storage-hmac-key",
+					},
+				},
+			},
+			want: &secretsv1beta1.VaultSecretLease{
+				LeaseDuration: 0,
+				Renewable:     false,
+			},
+			expectRequests: []*vault.MockRequest{
+				{
+					Method: http.MethodGet,
+					Path:   "baz/foo",
+					Params: nil,
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		// {
+		// 	name: "with-params",
+		// 	fields: fields{
+		// 		Client:        fake.NewClientBuilder().Build(),
+		// 		runtimePodUID: "",
+		// 	},
+		// 	args: args{
+		// 		ctx:     nil,
+		// 		vClient: &vault.MockRecordingVaultClient{},
+		// 		o: &secretsv1beta1.VaultDynamicSecret{
+		// 			ObjectMeta: metav1.ObjectMeta{
+		// 				Name:      "baz",
+		// 				Namespace: "default",
+		// 			},
+		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
+		// 				Mount: "baz",
+		// 				Path:  "foo",
+		// 				Params: map[string]string{
+		// 					"qux": "bar",
+		// 				},
+		// 				Destination: secretsv1beta1.Destination{
+		// 					Name:   "baz",
+		// 					Create: true,
+		// 				},
+		// 			},
+		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
+		// 		},
+		// 	},
+		// 	want: &secretsv1beta1.VaultSecretLease{
+		// 		LeaseDuration: 0,
+		// 		Renewable:     false,
+		// 	},
+		// 	expectRequests: []*vault.MockRequest{
+		// 		{
+		// 			Method: http.MethodPut,
+		// 			Path:   "baz/foo",
+		// 			Params: map[string]any{
+		// 				"qux": "bar",
+		// 			},
+		// 		},
+		// 	},
+		// 	wantErr: assert.NoError,
+		// },
+		// {
+		// 	name: "with-method-put-and-params",
+		// 	fields: fields{
+		// 		Client:        fake.NewClientBuilder().Build(),
+		// 		runtimePodUID: "",
+		// 	},
+		// 	args: args{
+		// 		ctx:     nil,
+		// 		vClient: &vault.MockRecordingVaultClient{},
+		// 		o: &secretsv1beta1.VaultDynamicSecret{
+		// 			ObjectMeta: metav1.ObjectMeta{
+		// 				Name:      "baz",
+		// 				Namespace: "default",
+		// 			},
+		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
+		// 				Mount:             "baz",
+		// 				Path:              "foo",
+		// 				RequestHTTPMethod: http.MethodPut,
+		// 				Params: map[string]string{
+		// 					"qux": "bar",
+		// 				},
+		// 				Destination: secretsv1beta1.Destination{
+		// 					Name:   "baz",
+		// 					Create: true,
+		// 				},
+		// 			},
+		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
+		// 		},
+		// 	},
+		// 	want: &secretsv1beta1.VaultSecretLease{
+		// 		LeaseDuration: 0,
+		// 		Renewable:     false,
+		// 	},
+		// 	expectRequests: []*vault.MockRequest{
+		// 		{
+		// 			Method: http.MethodPut,
+		// 			Path:   "baz/foo",
+		// 			Params: map[string]any{
+		// 				"qux": "bar",
+		// 			},
+		// 		},
+		// 	},
+		// 	wantErr: assert.NoError,
+		// },
+		// {
+		// 	name: "with-method-post-and-params",
+		// 	fields: fields{
+		// 		Client:        fake.NewClientBuilder().Build(),
+		// 		runtimePodUID: "",
+		// 	},
+		// 	args: args{
+		// 		ctx:     nil,
+		// 		vClient: &vault.MockRecordingVaultClient{},
+		// 		o: &secretsv1beta1.VaultDynamicSecret{
+		// 			ObjectMeta: metav1.ObjectMeta{
+		// 				Name:      "baz",
+		// 				Namespace: "default",
+		// 			},
+		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
+		// 				Mount:             "baz",
+		// 				Path:              "foo",
+		// 				RequestHTTPMethod: http.MethodPost,
+		// 				Params: map[string]string{
+		// 					"qux": "bar",
+		// 				},
+		// 				Destination: secretsv1beta1.Destination{
+		// 					Name:   "baz",
+		// 					Create: true,
+		// 				},
+		// 			},
+		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
+		// 		},
+		// 	},
+		// 	want: &secretsv1beta1.VaultSecretLease{
+		// 		LeaseDuration: 0,
+		// 		Renewable:     false,
+		// 	},
+		// 	expectRequests: []*vault.MockRequest{
+		// 		{
+		// 			// the vault client API always translates POST to PUT
+		// 			Method: http.MethodPut,
+		// 			Path:   "baz/foo",
+		// 			Params: map[string]any{
+		// 				"qux": "bar",
+		// 			},
+		// 		},
+		// 	},
+		// 	wantErr: assert.NoError,
+		// },
+		// {
+		// 	name: "with-method-get-and-params",
+		// 	fields: fields{
+		// 		Client:        fake.NewClientBuilder().Build(),
+		// 		runtimePodUID: "",
+		// 	},
+		// 	args: args{
+		// 		ctx:     nil,
+		// 		vClient: &vault.MockRecordingVaultClient{},
+		// 		o: &secretsv1beta1.VaultDynamicSecret{
+		// 			ObjectMeta: metav1.ObjectMeta{
+		// 				Name:      "baz",
+		// 				Namespace: "default",
+		// 			},
+		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
+		// 				Mount:             "baz",
+		// 				Path:              "foo",
+		// 				RequestHTTPMethod: http.MethodGet,
+		// 				Params: map[string]string{
+		// 					"qux": "bar",
+		// 				},
+		// 				Destination: secretsv1beta1.Destination{
+		// 					Name:   "baz",
+		// 					Create: true,
+		// 				},
+		// 			},
+		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
+		// 		},
+		// 	},
+		// 	want: &secretsv1beta1.VaultSecretLease{
+		// 		LeaseDuration: 0,
+		// 		Renewable:     false,
+		// 	},
+		// 	expectRequests: []*vault.MockRequest{
+		// 		{
+		// 			Method: http.MethodPut,
+		// 			Path:   "baz/foo",
+		// 			Params: map[string]any{
+		// 				"qux": "bar",
+		// 			},
+		// 		},
+		// 	},
+		// 	wantErr: assert.NoError,
+		// },
+		// {
+		// 	name: "without-params-and-method-get",
+		// 	fields: fields{
+		// 		Client:        fake.NewClientBuilder().Build(),
+		// 		runtimePodUID: "",
+		// 	},
+		// 	args: args{
+		// 		ctx:     nil,
+		// 		vClient: &vault.MockRecordingVaultClient{},
+		// 		o: &secretsv1beta1.VaultDynamicSecret{
+		// 			ObjectMeta: metav1.ObjectMeta{
+		// 				Name:      "baz",
+		// 				Namespace: "default",
+		// 			},
+		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
+		// 				Mount:             "baz",
+		// 				Path:              "foo",
+		// 				RequestHTTPMethod: http.MethodGet,
+		// 				Params:            nil,
+		// 				Destination: secretsv1beta1.Destination{
+		// 					Name:   "baz",
+		// 					Create: true,
+		// 				},
+		// 			},
+		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
+		// 		},
+		// 	},
+		// 	want: &secretsv1beta1.VaultSecretLease{
+		// 		LeaseDuration: 0,
+		// 		Renewable:     false,
+		// 	},
+		// 	expectRequests: []*vault.MockRequest{
+		// 		{
+		// 			Method: http.MethodGet,
+		// 			Path:   "baz/foo",
+		// 			Params: nil,
+		// 		},
+		// 	},
+		// 	wantErr: assert.NoError,
+		// },
+		// {
+		// 	name: "without-params-and-method-put",
+		// 	fields: fields{
+		// 		Client:        fake.NewClientBuilder().Build(),
+		// 		runtimePodUID: "",
+		// 	},
+		// 	args: args{
+		// 		ctx:     nil,
+		// 		vClient: &vault.MockRecordingVaultClient{},
+		// 		o: &secretsv1beta1.VaultDynamicSecret{
+		// 			ObjectMeta: metav1.ObjectMeta{
+		// 				Name:      "baz",
+		// 				Namespace: "default",
+		// 			},
+		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
+		// 				Mount:             "baz",
+		// 				Path:              "foo",
+		// 				RequestHTTPMethod: http.MethodPut,
+		// 				Params:            nil,
+		// 				Destination: secretsv1beta1.Destination{
+		// 					Name:   "baz",
+		// 					Create: true,
+		// 				},
+		// 			},
+		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
+		// 		},
+		// 	},
+		// 	want: &secretsv1beta1.VaultSecretLease{
+		// 		LeaseDuration: 0,
+		// 		Renewable:     false,
+		// 	},
+		// 	expectRequests: []*vault.MockRequest{
+		// 		{
+		// 			Method: http.MethodPut,
+		// 			Path:   "baz/foo",
+		// 			Params: nil,
+		// 		},
+		// 	},
+		// 	wantErr: assert.NoError,
+		// },
+		// {
+		// 	name: "without-params-and-method-post",
+		// 	fields: fields{
+		// 		Client:        fake.NewClientBuilder().Build(),
+		// 		runtimePodUID: "",
+		// 	},
+		// 	args: args{
+		// 		ctx:     nil,
+		// 		vClient: &vault.MockRecordingVaultClient{},
+		// 		o: &secretsv1beta1.VaultDynamicSecret{
+		// 			ObjectMeta: metav1.ObjectMeta{
+		// 				Name:      "baz",
+		// 				Namespace: "default",
+		// 			},
+		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
+		// 				Mount:             "baz",
+		// 				Path:              "foo",
+		// 				RequestHTTPMethod: http.MethodPost,
+		// 				Params:            nil,
+		// 				Destination: secretsv1beta1.Destination{
+		// 					Name:   "baz",
+		// 					Create: true,
+		// 				},
+		// 			},
+		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
+		// 		},
+		// 	},
+		// 	want: &secretsv1beta1.VaultSecretLease{
+		// 		LeaseDuration: 0,
+		// 		Renewable:     false,
+		// 	},
+		// 	expectRequests: []*vault.MockRequest{
+		// 		{
+		// 			// the vault client API always translates POST to PUT
+		// 			Method: http.MethodPut,
+		// 			Path:   "baz/foo",
+		// 			Params: nil,
+		// 		},
+		// 	},
+		// 	wantErr: assert.NoError,
+		// },
+		// {
+		// 	name: "with-unsupported-method",
+		// 	fields: fields{
+		// 		Client:        fake.NewClientBuilder().Build(),
+		// 		runtimePodUID: "",
+		// 	},
+		// 	args: args{
+		// 		ctx:     nil,
+		// 		vClient: &vault.MockRecordingVaultClient{},
+		// 		o: &secretsv1beta1.VaultDynamicSecret{
+		// 			ObjectMeta: metav1.ObjectMeta{
+		// 				Name:      "baz",
+		// 				Namespace: "default",
+		// 			},
+		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
+		// 				Mount:             "baz",
+		// 				Path:              "foo",
+		// 				RequestHTTPMethod: http.MethodOptions,
+		// 				Params:            nil,
+		// 				Destination: secretsv1beta1.Destination{
+		// 					Name:   "baz",
+		// 					Create: true,
+		// 				},
+		// 			},
+		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
+		// 		},
+		// 	},
+		// 	want:           nil,
+		// 	expectRequests: nil,
+		// 	wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+		// 		return assert.EqualError(t, err, fmt.Sprintf(
+		// 			"unsupported HTTP method %q for sync", http.MethodOptions), i...)
+		// 	},
+		// },
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := helpers.NewHMACValidator(vault.DefaultClientCacheStorageConfig().HMACSecretObjKey)
+			r := &VaultDynamicSecretReconciler{
+				Client:        tt.fields.Client,
+				HMACValidator: validator,
 			}
 			got, _, err := r.syncSecret(tt.args.ctx, tt.args.vClient, tt.args.o)
 			if !tt.wantErr(t, err, fmt.Sprintf("syncSecret(%v, %v, %v)", tt.args.ctx, tt.args.vClient, tt.args.o)) {

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
-	"github.com/hashicorp/vault-secrets-operator/internal/helpers"
 	"github.com/hashicorp/vault-secrets-operator/internal/vault"
 )
 
@@ -511,415 +510,57 @@ func TestVaultDynamicSecretReconciler_syncSecret(t *testing.T) {
 	}
 }
 
-func TestVaultDynamicSecretReconciler_syncSecret_staticCreds(t *testing.T) {
-	type fields struct {
-		Client        client.Client
-		runtimePodUID types.UID
-	}
-	type args struct {
-		ctx     context.Context
-		vClient *vault.MockRecordingVaultClient
-		o       *secretsv1beta1.VaultDynamicSecret
-	}
+// Test_isStaticCreds tests that we can appropriately identify if a vault
+// credential is "static" by checking the LastVaultRotation, RotationPeriod,
+// and RotationSchedule fields
+func Test_isStaticCreds(t *testing.T) {
 	tests := []struct {
-		name           string
-		fields         fields
-		args           args
-		want           *secretsv1beta1.VaultSecretLease
-		expectRequests []*vault.MockRequest
-		wantErr        assert.ErrorAssertionFunc
+		name     string
+		metaData v1beta1.VaultStaticCredsMetaData
+		want     bool
 	}{
 		{
-			name: "without-params",
-			fields: fields{
-				Client:        fake.NewClientBuilder().Build(),
-				runtimePodUID: "",
+			name: "static-cred-with-rotation-period",
+			metaData: v1beta1.VaultStaticCredsMetaData{
+				LastVaultRotation: 1695430611,
+				RotationPeriod:    300,
 			},
-			args: args{
-				ctx:     nil,
-				vClient: &vault.MockRecordingVaultClient{},
-				o: &secretsv1beta1.VaultDynamicSecret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "baz",
-						Namespace: "default",
-					},
-					Spec: secretsv1beta1.VaultDynamicSecretSpec{
-						Mount:  "baz",
-						Path:   "foo",
-						Params: nil,
-						Destination: secretsv1beta1.Destination{
-							Name:   "baz",
-							Create: true,
-						},
-						AllowStaticCreds: true,
-					},
-					Status: secretsv1beta1.VaultDynamicSecretStatus{
-						StaticCredsMetaData: v1beta1.VaultStaticCredsMetaData{
-							LastVaultRotation: 1695419440,
-							RotationSchedule:  "1 0 * * *",
-						},
-						SecretMAC: "vso-cc-storage-hmac-key",
-					},
-				},
-			},
-			want: &secretsv1beta1.VaultSecretLease{
-				LeaseDuration: 0,
-				Renewable:     false,
-			},
-			expectRequests: []*vault.MockRequest{
-				{
-					Method: http.MethodGet,
-					Path:   "baz/foo",
-					Params: nil,
-				},
-			},
-			wantErr: assert.NoError,
+			want: true,
 		},
-		// {
-		// 	name: "with-params",
-		// 	fields: fields{
-		// 		Client:        fake.NewClientBuilder().Build(),
-		// 		runtimePodUID: "",
-		// 	},
-		// 	args: args{
-		// 		ctx:     nil,
-		// 		vClient: &vault.MockRecordingVaultClient{},
-		// 		o: &secretsv1beta1.VaultDynamicSecret{
-		// 			ObjectMeta: metav1.ObjectMeta{
-		// 				Name:      "baz",
-		// 				Namespace: "default",
-		// 			},
-		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
-		// 				Mount: "baz",
-		// 				Path:  "foo",
-		// 				Params: map[string]string{
-		// 					"qux": "bar",
-		// 				},
-		// 				Destination: secretsv1beta1.Destination{
-		// 					Name:   "baz",
-		// 					Create: true,
-		// 				},
-		// 			},
-		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
-		// 		},
-		// 	},
-		// 	want: &secretsv1beta1.VaultSecretLease{
-		// 		LeaseDuration: 0,
-		// 		Renewable:     false,
-		// 	},
-		// 	expectRequests: []*vault.MockRequest{
-		// 		{
-		// 			Method: http.MethodPut,
-		// 			Path:   "baz/foo",
-		// 			Params: map[string]any{
-		// 				"qux": "bar",
-		// 			},
-		// 		},
-		// 	},
-		// 	wantErr: assert.NoError,
-		// },
-		// {
-		// 	name: "with-method-put-and-params",
-		// 	fields: fields{
-		// 		Client:        fake.NewClientBuilder().Build(),
-		// 		runtimePodUID: "",
-		// 	},
-		// 	args: args{
-		// 		ctx:     nil,
-		// 		vClient: &vault.MockRecordingVaultClient{},
-		// 		o: &secretsv1beta1.VaultDynamicSecret{
-		// 			ObjectMeta: metav1.ObjectMeta{
-		// 				Name:      "baz",
-		// 				Namespace: "default",
-		// 			},
-		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
-		// 				Mount:             "baz",
-		// 				Path:              "foo",
-		// 				RequestHTTPMethod: http.MethodPut,
-		// 				Params: map[string]string{
-		// 					"qux": "bar",
-		// 				},
-		// 				Destination: secretsv1beta1.Destination{
-		// 					Name:   "baz",
-		// 					Create: true,
-		// 				},
-		// 			},
-		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
-		// 		},
-		// 	},
-		// 	want: &secretsv1beta1.VaultSecretLease{
-		// 		LeaseDuration: 0,
-		// 		Renewable:     false,
-		// 	},
-		// 	expectRequests: []*vault.MockRequest{
-		// 		{
-		// 			Method: http.MethodPut,
-		// 			Path:   "baz/foo",
-		// 			Params: map[string]any{
-		// 				"qux": "bar",
-		// 			},
-		// 		},
-		// 	},
-		// 	wantErr: assert.NoError,
-		// },
-		// {
-		// 	name: "with-method-post-and-params",
-		// 	fields: fields{
-		// 		Client:        fake.NewClientBuilder().Build(),
-		// 		runtimePodUID: "",
-		// 	},
-		// 	args: args{
-		// 		ctx:     nil,
-		// 		vClient: &vault.MockRecordingVaultClient{},
-		// 		o: &secretsv1beta1.VaultDynamicSecret{
-		// 			ObjectMeta: metav1.ObjectMeta{
-		// 				Name:      "baz",
-		// 				Namespace: "default",
-		// 			},
-		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
-		// 				Mount:             "baz",
-		// 				Path:              "foo",
-		// 				RequestHTTPMethod: http.MethodPost,
-		// 				Params: map[string]string{
-		// 					"qux": "bar",
-		// 				},
-		// 				Destination: secretsv1beta1.Destination{
-		// 					Name:   "baz",
-		// 					Create: true,
-		// 				},
-		// 			},
-		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
-		// 		},
-		// 	},
-		// 	want: &secretsv1beta1.VaultSecretLease{
-		// 		LeaseDuration: 0,
-		// 		Renewable:     false,
-		// 	},
-		// 	expectRequests: []*vault.MockRequest{
-		// 		{
-		// 			// the vault client API always translates POST to PUT
-		// 			Method: http.MethodPut,
-		// 			Path:   "baz/foo",
-		// 			Params: map[string]any{
-		// 				"qux": "bar",
-		// 			},
-		// 		},
-		// 	},
-		// 	wantErr: assert.NoError,
-		// },
-		// {
-		// 	name: "with-method-get-and-params",
-		// 	fields: fields{
-		// 		Client:        fake.NewClientBuilder().Build(),
-		// 		runtimePodUID: "",
-		// 	},
-		// 	args: args{
-		// 		ctx:     nil,
-		// 		vClient: &vault.MockRecordingVaultClient{},
-		// 		o: &secretsv1beta1.VaultDynamicSecret{
-		// 			ObjectMeta: metav1.ObjectMeta{
-		// 				Name:      "baz",
-		// 				Namespace: "default",
-		// 			},
-		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
-		// 				Mount:             "baz",
-		// 				Path:              "foo",
-		// 				RequestHTTPMethod: http.MethodGet,
-		// 				Params: map[string]string{
-		// 					"qux": "bar",
-		// 				},
-		// 				Destination: secretsv1beta1.Destination{
-		// 					Name:   "baz",
-		// 					Create: true,
-		// 				},
-		// 			},
-		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
-		// 		},
-		// 	},
-		// 	want: &secretsv1beta1.VaultSecretLease{
-		// 		LeaseDuration: 0,
-		// 		Renewable:     false,
-		// 	},
-		// 	expectRequests: []*vault.MockRequest{
-		// 		{
-		// 			Method: http.MethodPut,
-		// 			Path:   "baz/foo",
-		// 			Params: map[string]any{
-		// 				"qux": "bar",
-		// 			},
-		// 		},
-		// 	},
-		// 	wantErr: assert.NoError,
-		// },
-		// {
-		// 	name: "without-params-and-method-get",
-		// 	fields: fields{
-		// 		Client:        fake.NewClientBuilder().Build(),
-		// 		runtimePodUID: "",
-		// 	},
-		// 	args: args{
-		// 		ctx:     nil,
-		// 		vClient: &vault.MockRecordingVaultClient{},
-		// 		o: &secretsv1beta1.VaultDynamicSecret{
-		// 			ObjectMeta: metav1.ObjectMeta{
-		// 				Name:      "baz",
-		// 				Namespace: "default",
-		// 			},
-		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
-		// 				Mount:             "baz",
-		// 				Path:              "foo",
-		// 				RequestHTTPMethod: http.MethodGet,
-		// 				Params:            nil,
-		// 				Destination: secretsv1beta1.Destination{
-		// 					Name:   "baz",
-		// 					Create: true,
-		// 				},
-		// 			},
-		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
-		// 		},
-		// 	},
-		// 	want: &secretsv1beta1.VaultSecretLease{
-		// 		LeaseDuration: 0,
-		// 		Renewable:     false,
-		// 	},
-		// 	expectRequests: []*vault.MockRequest{
-		// 		{
-		// 			Method: http.MethodGet,
-		// 			Path:   "baz/foo",
-		// 			Params: nil,
-		// 		},
-		// 	},
-		// 	wantErr: assert.NoError,
-		// },
-		// {
-		// 	name: "without-params-and-method-put",
-		// 	fields: fields{
-		// 		Client:        fake.NewClientBuilder().Build(),
-		// 		runtimePodUID: "",
-		// 	},
-		// 	args: args{
-		// 		ctx:     nil,
-		// 		vClient: &vault.MockRecordingVaultClient{},
-		// 		o: &secretsv1beta1.VaultDynamicSecret{
-		// 			ObjectMeta: metav1.ObjectMeta{
-		// 				Name:      "baz",
-		// 				Namespace: "default",
-		// 			},
-		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
-		// 				Mount:             "baz",
-		// 				Path:              "foo",
-		// 				RequestHTTPMethod: http.MethodPut,
-		// 				Params:            nil,
-		// 				Destination: secretsv1beta1.Destination{
-		// 					Name:   "baz",
-		// 					Create: true,
-		// 				},
-		// 			},
-		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
-		// 		},
-		// 	},
-		// 	want: &secretsv1beta1.VaultSecretLease{
-		// 		LeaseDuration: 0,
-		// 		Renewable:     false,
-		// 	},
-		// 	expectRequests: []*vault.MockRequest{
-		// 		{
-		// 			Method: http.MethodPut,
-		// 			Path:   "baz/foo",
-		// 			Params: nil,
-		// 		},
-		// 	},
-		// 	wantErr: assert.NoError,
-		// },
-		// {
-		// 	name: "without-params-and-method-post",
-		// 	fields: fields{
-		// 		Client:        fake.NewClientBuilder().Build(),
-		// 		runtimePodUID: "",
-		// 	},
-		// 	args: args{
-		// 		ctx:     nil,
-		// 		vClient: &vault.MockRecordingVaultClient{},
-		// 		o: &secretsv1beta1.VaultDynamicSecret{
-		// 			ObjectMeta: metav1.ObjectMeta{
-		// 				Name:      "baz",
-		// 				Namespace: "default",
-		// 			},
-		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
-		// 				Mount:             "baz",
-		// 				Path:              "foo",
-		// 				RequestHTTPMethod: http.MethodPost,
-		// 				Params:            nil,
-		// 				Destination: secretsv1beta1.Destination{
-		// 					Name:   "baz",
-		// 					Create: true,
-		// 				},
-		// 			},
-		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
-		// 		},
-		// 	},
-		// 	want: &secretsv1beta1.VaultSecretLease{
-		// 		LeaseDuration: 0,
-		// 		Renewable:     false,
-		// 	},
-		// 	expectRequests: []*vault.MockRequest{
-		// 		{
-		// 			// the vault client API always translates POST to PUT
-		// 			Method: http.MethodPut,
-		// 			Path:   "baz/foo",
-		// 			Params: nil,
-		// 		},
-		// 	},
-		// 	wantErr: assert.NoError,
-		// },
-		// {
-		// 	name: "with-unsupported-method",
-		// 	fields: fields{
-		// 		Client:        fake.NewClientBuilder().Build(),
-		// 		runtimePodUID: "",
-		// 	},
-		// 	args: args{
-		// 		ctx:     nil,
-		// 		vClient: &vault.MockRecordingVaultClient{},
-		// 		o: &secretsv1beta1.VaultDynamicSecret{
-		// 			ObjectMeta: metav1.ObjectMeta{
-		// 				Name:      "baz",
-		// 				Namespace: "default",
-		// 			},
-		// 			Spec: secretsv1beta1.VaultDynamicSecretSpec{
-		// 				Mount:             "baz",
-		// 				Path:              "foo",
-		// 				RequestHTTPMethod: http.MethodOptions,
-		// 				Params:            nil,
-		// 				Destination: secretsv1beta1.Destination{
-		// 					Name:   "baz",
-		// 					Create: true,
-		// 				},
-		// 			},
-		// 			Status: secretsv1beta1.VaultDynamicSecretStatus{},
-		// 		},
-		// 	},
-		// 	want:           nil,
-		// 	expectRequests: nil,
-		// 	wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-		// 		return assert.EqualError(t, err, fmt.Sprintf(
-		// 			"unsupported HTTP method %q for sync", http.MethodOptions), i...)
-		// 	},
-		// },
+		{
+			name: "not-static-cred-with-rotation-period",
+			metaData: v1beta1.VaultStaticCredsMetaData{
+				LastVaultRotation: 0,
+				RotationPeriod:    0,
+			},
+			want: false,
+		},
+		{
+			name: "static-cred-with-rotation-schedule",
+			metaData: v1beta1.VaultStaticCredsMetaData{
+				LastVaultRotation: 1695430611,
+				RotationSchedule:  "1 0 * * *",
+			},
+			want: true,
+		},
+		{
+			name: "not-static-cred-with-rotation-schedule",
+			metaData: v1beta1.VaultStaticCredsMetaData{
+				LastVaultRotation: 0,
+				RotationSchedule:  "",
+			},
+			want: false,
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			validator := helpers.NewHMACValidator(vault.DefaultClientCacheStorageConfig().HMACSecretObjKey)
 			r := &VaultDynamicSecretReconciler{
-				Client:        tt.fields.Client,
-				HMACValidator: validator,
+				Client: fake.NewClientBuilder().Build(),
 			}
-			got, _, err := r.syncSecret(tt.args.ctx, tt.args.vClient, tt.args.o)
-			if !tt.wantErr(t, err, fmt.Sprintf("syncSecret(%v, %v, %v)", tt.args.ctx, tt.args.vClient, tt.args.o)) {
-				return
-			}
-			assert.Equalf(t, tt.want, got, "syncSecret(%v, %v, %v)", tt.args.ctx, tt.args.vClient, tt.args.o)
-			assert.Equalf(t, tt.expectRequests, tt.args.vClient.Requests, "syncSecret(%v, %v, %v)", tt.args.ctx, tt.args.vClient, tt.args.o)
+
+			got := r.isStaticCreds(&tt.metaData)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -543,6 +543,7 @@ _Appears in:_
 | --- | --- |
 | `lastVaultRotation` _integer_ | LastVaultRotation represents the last time Vault rotated the password |
 | `rotationPeriod` _integer_ | RotationPeriod is number in seconds between each rotation, effectively a "time to live". This value is compared to the LastVaultRotation to determine if a password needs to be rotated |
+| `rotationSchedule` _string_ | RotationSchedule is a "cron style" string representing the allowed schedule for each rotation. e.g. "1 0 * * *" would rotate at one minute past midnight (00:01) every day. |
 | `ttl` _integer_ | TTL is the seconds remaining before the next rotation. |
 
 


### PR DESCRIPTION
Add support for the upcoming 1.15 Vault feature
- https://github.com/hashicorp/vault/pull/22484

Related docs PR for the feature
- https://github.com/hashicorp/vault/pull/22863

We will update integration tests in a separate PR once https://github.com/hashicorp/terraform-provider-vault/pull/2011 is merged. For now we add a unit test to test the changes made in this PR.
