### PR TITLE
Add validation for spec.refreshAfter and min constraints for HVSA

### DIFF
--- a/api/v1beta1/hcpvaultsecretsapp_types.go
+++ b/api/v1beta1/hcpvaultsecretsapp_types.go
@@ -19,7 +19,7 @@ type HCPVaultSecretsAppSpec struct {
 	HCPAuthRef string `json:"hcpAuthRef,omitempty"`
 	// RefreshAfter a period of time, in duration notation e.g. 30s, 1m, 24h
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern="^(-?[0-9]+(\\.[0-9]+)?(s|m|h))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(s|m|h))$"
 	// +kubebuilder:default="600s"
 	RefreshAfter string `json:"refreshAfter,omitempty"`
 	// RolloutRestartTargets should be configured whenever the application(s)

--- a/api/v1beta1/hcpvaultsecretsapp_types.go
+++ b/api/v1beta1/hcpvaultsecretsapp_types.go
@@ -18,6 +18,8 @@ type HCPVaultSecretsAppSpec struct {
 	// Kubernetes namespace. HCPAuthRef string `json:"hcpAuthRef,omitempty"`
 	HCPAuthRef string `json:"hcpAuthRef,omitempty"`
 	// RefreshAfter a period of time, in duration notation e.g. 30s, 1m, 24h
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^(-?[0-9]+(\\.[0-9]+)?(s|m|h))+$"
 	// +kubebuilder:default="600s"
 	RefreshAfter string `json:"refreshAfter,omitempty"`
 	// RolloutRestartTargets should be configured whenever the application(s)

--- a/api/v1beta1/vaultstaticsecret_types.go
+++ b/api/v1beta1/vaultstaticsecret_types.go
@@ -34,7 +34,7 @@ type VaultStaticSecretSpec struct {
 	Type string `json:"type"`
 	// RefreshAfter a period of time, in duration notation e.g. 30s, 1m, 24h
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern="^(-?[0-9]+(\\.[0-9]+)?(s|m|h))+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(s|m|h))$"
 	RefreshAfter string `json:"refreshAfter,omitempty"`
 	// HMACSecretData determines whether the Operator computes the
 	// HMAC of the Secret's data. The MAC value will be stored in

--- a/api/v1beta1/vaultstaticsecret_types.go
+++ b/api/v1beta1/vaultstaticsecret_types.go
@@ -33,6 +33,8 @@ type VaultStaticSecretSpec struct {
 	// +kubebuilder:validation:Enum={kv-v1,kv-v2}
 	Type string `json:"type"`
 	// RefreshAfter a period of time, in duration notation e.g. 30s, 1m, 24h
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^(-?[0-9]+(\\.[0-9]+)?(s|m|h))+$"
 	RefreshAfter string `json:"refreshAfter,omitempty"`
 	// HMACSecretData determines whether the Operator computes the
 	// HMAC of the Secret's data. The MAC value will be stored in

--- a/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -84,6 +84,7 @@ spec:
                 default: 600s
                 description: RefreshAfter a period of time, in duration notation e.g.
                   30s, 1m, 24h
+                pattern: ^(-?[0-9]+(\.[0-9]+)?(s|m|h))+$
                 type: string
               rolloutRestartTargets:
                 description: RolloutRestartTargets should be configured whenever the

--- a/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -84,7 +84,7 @@ spec:
                 default: 600s
                 description: RefreshAfter a period of time, in duration notation e.g.
                   30s, 1m, 24h
-                pattern: ^(-?[0-9]+(\.[0-9]+)?(s|m|h))+$
+                pattern: ^([0-9]+(\.[0-9]+)?(s|m|h))$
                 type: string
               rolloutRestartTargets:
                 description: RolloutRestartTargets should be configured whenever the

--- a/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -90,6 +90,7 @@ spec:
               refreshAfter:
                 description: RefreshAfter a period of time, in duration notation e.g.
                   30s, 1m, 24h
+                pattern: ^(-?[0-9]+(\.[0-9]+)?(s|m|h))+$
                 type: string
               rolloutRestartTargets:
                 description: RolloutRestartTargets should be configured whenever the

--- a/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -90,7 +90,7 @@ spec:
               refreshAfter:
                 description: RefreshAfter a period of time, in duration notation e.g.
                   30s, 1m, 24h
-                pattern: ^(-?[0-9]+(\.[0-9]+)?(s|m|h))+$
+                pattern: ^([0-9]+(\.[0-9]+)?(s|m|h))$
                 type: string
               rolloutRestartTargets:
                 description: RolloutRestartTargets should be configured whenever the

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -73,6 +73,9 @@ spec:
         {{- if .Values.controller.manager.maxConcurrentReconciles }}
         - --max-concurrent-reconciles-vds={{ .Values.controller.manager.maxConcurrentReconciles }}
         {{- end }}
+        {{- if .Values.controller.manager.extraArgs }}
+        {{- toYaml .Values.controller.manager.extraArgs | nindent 8 }}
+        {{- end }}
         command:
         - /vault-secrets-operator
         env:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -101,7 +101,6 @@ controller:
       repository: hashicorp/vault-secrets-operator
       tag: 0.3.0-rc.1
 
-
     # Configures the client cache which is used by the controller to cache (and potentially persist) vault tokens that
     # are the result of using the VaultAuthMethod. This enables re-use of Vault Tokens
     # throughout their TTLs as well as the ability to renew.
@@ -299,6 +298,13 @@ controller:
     #     value: http://proxy.example.com
     # @type: array<map>
     extraEnv: []
+
+    # Defines additional commandline arguments to be passed to the
+    # vault-secrets-operator manager container.
+    # extraArgs:
+    # - -zap-log-level=5
+    # @type: array
+    extraArgs: []
 
     # Configures the default resources for the vault-secrets-operator container.
     # For more information on configuring resources, see the K8s documentation:

--- a/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -84,6 +84,7 @@ spec:
                 default: 600s
                 description: RefreshAfter a period of time, in duration notation e.g.
                   30s, 1m, 24h
+                pattern: ^(-?[0-9]+(\.[0-9]+)?(s|m|h))+$
                 type: string
               rolloutRestartTargets:
                 description: RolloutRestartTargets should be configured whenever the

--- a/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -84,7 +84,7 @@ spec:
                 default: 600s
                 description: RefreshAfter a period of time, in duration notation e.g.
                   30s, 1m, 24h
-                pattern: ^(-?[0-9]+(\.[0-9]+)?(s|m|h))+$
+                pattern: ^([0-9]+(\.[0-9]+)?(s|m|h))$
                 type: string
               rolloutRestartTargets:
                 description: RolloutRestartTargets should be configured whenever the

--- a/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -90,6 +90,7 @@ spec:
               refreshAfter:
                 description: RefreshAfter a period of time, in duration notation e.g.
                   30s, 1m, 24h
+                pattern: ^(-?[0-9]+(\.[0-9]+)?(s|m|h))+$
                 type: string
               rolloutRestartTargets:
                 description: RolloutRestartTargets should be configured whenever the

--- a/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -90,7 +90,7 @@ spec:
               refreshAfter:
                 description: RefreshAfter a period of time, in duration notation e.g.
                   30s, 1m, 24h
-                pattern: ^(-?[0-9]+(\.[0-9]+)?(s|m|h))+$
+                pattern: ^([0-9]+(\.[0-9]+)?(s|m|h))$
                 type: string
               rolloutRestartTargets:
                 description: RolloutRestartTargets should be configured whenever the

--- a/config/hvsa-tests/kustomization.yaml
+++ b/config/hvsa-tests/kustomization.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+bases:
+- ../default
+
+patchesStrategicMerge:
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
+- manager_args_patch.yaml

--- a/config/hvsa-tests/manager_args_patch.yaml
+++ b/config/hvsa-tests/manager_args_patch.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - "-min-refresh-after-hvsa=3s"

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -9,12 +9,12 @@ import (
 	"math/rand"
 	"time"
 
-	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
-	"github.com/hashicorp/vault-secrets-operator/internal/common"
-
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
+	"github.com/hashicorp/vault-secrets-operator/internal/common"
 )
 
 var (
@@ -183,4 +183,23 @@ func removeFinalizers(ctx context.Context, c client.Client, log logr.Logger, obj
 		}
 	}
 	log.Info(fmt.Sprintf("Removed %d finalizers", cnt))
+}
+
+func parseDurationString(ds, path string, min time.Duration) (time.Duration, error) {
+	var err error
+	var d time.Duration
+	if ds != "" {
+		d, err = time.ParseDuration(ds)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"invalid value %q for %s, %w",
+				ds, path, err)
+		}
+		if d < min {
+			return 0, fmt.Errorf(
+				"invalid value %q for %s, below the minimum allowed value %s",
+				ds, path, min)
+		}
+	}
+	return d, nil
 }

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -185,20 +185,20 @@ func removeFinalizers(ctx context.Context, c client.Client, log logr.Logger, obj
 	log.Info(fmt.Sprintf("Removed %d finalizers", cnt))
 }
 
-func parseDurationString(ds, path string, min time.Duration) (time.Duration, error) {
+func parseDurationString(duration, path string, min time.Duration) (time.Duration, error) {
 	var err error
 	var d time.Duration
-	if ds != "" {
-		d, err = time.ParseDuration(ds)
+	if duration != "" {
+		d, err = time.ParseDuration(duration)
 		if err != nil {
 			return 0, fmt.Errorf(
 				"invalid value %q for %s, %w",
-				ds, path, err)
+				duration, path, err)
 		}
 		if d < min {
 			return 0, fmt.Errorf(
 				"invalid value %q for %s, below the minimum allowed value %s",
-				ds, path, min)
+				duration, path, min)
 		}
 	}
 	return d, nil

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -68,11 +68,11 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	var requeueAfter time.Duration
 	if o.Spec.RefreshAfter != "" {
-		d, err := time.ParseDuration(o.Spec.RefreshAfter)
+		d, err := parseDurationString(o.Spec.RefreshAfter, ".spec.refreshAfter", 0)
 		if err != nil {
-			logger.Error(err, "Failed to parse o.Spec.RefreshAfter")
+			logger.Error(err, "Field validation failed")
 			r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonVaultStaticSecret,
-				"Failed to parse o.Spec.RefreshAfter %s", o.Spec.RefreshAfter)
+				"Field validation failed, err=%s", err)
 			return ctrl.Result{}, err
 		}
 		requeueAfter = computeHorizonWithJitter(d)

--- a/demo/infra/app/main.tf
+++ b/demo/infra/app/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "2.8.0"
+      version = "2.11.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func main() {
 	var uninstall bool
 	var revokeClientCache bool
 	var preDeleteHookTimeoutSeconds int
+	var minRefreshAfterHVSA time.Duration
 
 	// command-line args and flags
 	flag.BoolVar(&printVersion, "version", false, "Print the operator version information")
@@ -90,7 +91,8 @@ func main() {
 		"upon Helm uninstall")
 	flag.IntVar(&preDeleteHookTimeoutSeconds, "pre-delete-hook-timeout-seconds", 120,
 		"Pre-delete hook timeout in seconds")
-
+	flag.DurationVar(&minRefreshAfterHVSA, "min-refresh-after-hvsa", time.Second*30,
+		"Minimum duration between HCPVaultSecretsApp resource reconciliation.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -301,6 +303,7 @@ func main() {
 		Recorder:          mgr.GetEventRecorderFor("HCPVaultSecretsApp"),
 		SecretDataBuilder: secretDataBuilder,
 		HMACValidator:     hmacValidator,
+		MinRefreshAfter:   minRefreshAfterHVSA,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HCPVaultSecretsApp")
 		os.Exit(1)

--- a/test/integration/hcpvaultsecretsapp/terraform/main.tf
+++ b/test/integration/hcpvaultsecretsapp/terraform/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.8.0"
+      version = "2.11.0"
     }
   }
 }
@@ -60,4 +60,5 @@ module "vso-helm" {
   operator_helm_chart_path   = var.operator_helm_chart_path
   operator_image_repo        = var.operator_image_repo
   operator_image_tag         = var.operator_image_tag
+  manager_extra_args         = ["-min-refresh-after-hvsa=3s"]
 }

--- a/test/integration/hcpvaultsecretsapp_integration_test.go
+++ b/test/integration/hcpvaultsecretsapp_integration_test.go
@@ -123,7 +123,7 @@ func TestHCPVaultSecretsApp(t *testing.T) {
 		},
 	}
 
-	kustomizeConfigPath := filepath.Join(kustomizeConfigRoot, "default")
+	kustomizeConfigPath := filepath.Join(kustomizeConfigRoot, "hvsa-tests")
 	if !testWithHelm {
 		deployOperatorWithKustomize(t, k8sOpts, kustomizeConfigPath)
 	} else {

--- a/test/integration/infra/main.tf
+++ b/test/integration/infra/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "2.8.0"
+      version = "2.11.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -104,4 +104,3 @@ resource "kubernetes_cluster_role_binding" "oidc-reviewer" {
     name = "system:unauthenticated"
   }
 }
-

--- a/test/integration/modules/vso-helm/main.tf
+++ b/test/integration/modules/vso-helm/main.tf
@@ -37,7 +37,7 @@ resource "helm_release" "vault-secrets-operator" {
     name  = "defaultAuthMethod.kubernetes.role"
     value = var.k8s_auth_default_role
   }
-  set {
+  set_list {
     name  = "defaultAuthMethod.kubernetes.tokenAudiences"
     value = var.k8s_auth_default_token_audiences
   }
@@ -95,5 +95,9 @@ resource "helm_release" "vault-secrets-operator" {
   set {
     name  = "controller.manager.clientCache.storageEncryption.kubernetes.tokenAudiences"
     value = var.client_cache_config.storage_encryption.kubernetes_auth_token_audiences
+  }
+  set_list {
+    name  = "controller.manager.extraArgs"
+    value = var.manager_extra_args
   }
 }

--- a/test/integration/modules/vso-helm/variables.tf
+++ b/test/integration/modules/vso-helm/variables.tf
@@ -22,7 +22,8 @@ variable "operator_image_tag" {
 }
 
 variable "k8s_auth_default_token_audiences" {
-  default = ""
+  type    = list(string)
+  default = []
 }
 
 variable "k8s_auth_default_mount" {
@@ -79,4 +80,9 @@ variable "client_cache_config" {
       kubernetes_auth_token_audiences = ""
     }
   }
+}
+
+variable "manager_extra_args" {
+  type    = list(string)
+  default = []
 }

--- a/test/integration/revocation/terraform/main.tf
+++ b/test/integration/revocation/terraform/main.tf
@@ -15,7 +15,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.8.0"
+      version = "2.11.0"
     }
   }
 }

--- a/test/integration/vaultauthmethods/terraform/main.tf
+++ b/test/integration/vaultauthmethods/terraform/main.tf
@@ -13,7 +13,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.8.0"
+      version = "2.11.0"
     }
   }
 }

--- a/test/integration/vaultdynamicsecret/terraform/main.tf
+++ b/test/integration/vaultdynamicsecret/terraform/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "2.8.0"
+      version = "2.11.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -92,7 +92,7 @@ module "vso-helm" {
   operator_helm_chart_path         = var.operator_helm_chart_path
   k8s_auth_default_mount           = local.auth_mount
   k8s_auth_default_role            = vault_kubernetes_auth_backend_role.dev.role_name
-  k8s_auth_default_token_audiences = "{${vault_kubernetes_auth_backend_role.dev.audience}}"
+  k8s_auth_default_token_audiences = [vault_kubernetes_auth_backend_role.dev.audience]
   k8s_vault_connection_address     = var.k8s_vault_connection_address
   vault_test_namespace             = local.namespace
   client_cache_config = {

--- a/test/integration/vaultpkisecret/terraform/main.tf
+++ b/test/integration/vaultpkisecret/terraform/main.tf
@@ -13,7 +13,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.8.0"
+      version = "2.11.0"
     }
   }
 }

--- a/test/integration/vaultstaticsecret/terraform/main.tf
+++ b/test/integration/vaultstaticsecret/terraform/main.tf
@@ -13,7 +13,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.8.0"
+      version = "2.11.0"
     }
   }
 }

--- a/test/unit/deployment.bats
+++ b/test/unit/deployment.bats
@@ -10,7 +10,7 @@ load _helpers
   local actual=$(helm template \
       -s templates/deployment.yaml  \
       . | tee /dev/stderr |
-      yq '.spec.replicas | select(documentIndex == 1)' | tee /dev/stderr)
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") .spec.replicas' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
 
@@ -20,7 +20,7 @@ load _helpers
       -s templates/deployment.yaml  \
       --set 'controller.replicas=2' \
       . | tee /dev/stderr |
-      yq '.spec.replicas | select(documentIndex == 1)' | tee /dev/stderr)
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") .spec.replicas' | tee /dev/stderr)
   [ "${actual}" = "2" ]
 }
 
@@ -32,7 +32,7 @@ load _helpers
   local object=$(helm template \
       -s templates/deployment.yaml  \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].resources | select(documentIndex == 1)' | tee /dev/stderr)
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "kube-rbac-proxy") | .resources' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '.requests.cpu' | tee /dev/stderr)
     [ "${actual}" = "5m" ]
@@ -53,7 +53,7 @@ load _helpers
       --set 'controller.kubeRbacProxy.resources.limits.memory=200Mi' \
       --set 'controller.kubeRbacProxy.resources.limits.cpu=200m' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].resources | select(documentIndex == 1)' | tee /dev/stderr)
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "kube-rbac-proxy") | .resources' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '.requests.cpu' | tee /dev/stderr)
     [ "${actual}" = "100m" ]
@@ -133,7 +133,7 @@ load _helpers
   local object=$(helm template \
       -s templates/deployment.yaml  \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[1].args | select(documentIndex == 1)' | tee /dev/stderr)
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq 'contains(["--client-cache"])' | tee /dev/stderr)
     [ "${actual}" = "false" ]
@@ -146,7 +146,7 @@ load _helpers
       --set 'controller.manager.clientCache.cacheSize=22' \
       --set 'controller.manager.clientCache.persistenceModel=direct-encrypted' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[1].args | select(documentIndex == 1)' | tee /dev/stderr)
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq 'contains(["--client-cache-size=22", "--client-cache-persistence-model=direct-encrypted"])' | tee /dev/stderr)
     [ "${actual}" = "true" ]
@@ -160,7 +160,7 @@ load _helpers
   local object=$(helm template \
       -s templates/deployment.yaml  \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[1].args | select(documentIndex == 1)' | tee /dev/stderr)
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq 'contains(["--max-concurrent-reconciles-vds"])' | tee /dev/stderr)
     [ "${actual}" = "false" ]
@@ -172,7 +172,7 @@ load _helpers
       -s templates/deployment.yaml  \
       --set 'controller.manager.maxConcurrentReconciles=5' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[1].args | select(documentIndex == 1)' | tee /dev/stderr)
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq 'contains(["--max-concurrent-reconciles-vds=5"])' | tee /dev/stderr)
     [ "${actual}" = "true" ]
@@ -347,7 +347,7 @@ load _helpers
   local object=$(helm template \
       -s templates/deployment.yaml  \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].args | select(documentIndex == 2)' | tee /dev/stderr)
+      yq 'select(.kind == "Job" and .metadata.annotations."helm.sh/hook" == "pre-delete") | .spec.template.spec.containers[] | select(.name == "pre-delete-controller-cleanup") | .args' | tee /dev/stderr)
 
   local actual=$(echo "$object" | yq 'contains(["--pre-delete-hook-timeout-seconds=120"])' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -363,7 +363,7 @@ load _helpers
       --set 'controller.manager.clientCache.revokeClientCacheOnUninstall=true' \
       --set 'controller.preDeleteHookTimeoutSeconds=180' \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[0].args | select(documentIndex == 2)' | tee /dev/stderr)
+      yq 'select(.kind == "Job" and .metadata.annotations."helm.sh/hook" == "pre-delete") | .spec.template.spec.containers[] | select(.name == "pre-delete-controller-cleanup") | .args' | tee /dev/stderr)
 
   local actual=$(echo "$object" | yq 'contains(["--uninstall", "--revoke-client-cache","--pre-delete-hook-timeout-seconds=180"])' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -678,7 +678,7 @@ load _helpers
   local object=$(helm template \
       -s templates/deployment.yaml  \
       . | tee /dev/stderr |
-      yq '.spec.template.metadata.labels | select(documentIndex == 1)' | tee /dev/stderr)
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") .spec.template.metadata | .labels' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
    [ "${actual}" = "3" ]
@@ -691,7 +691,7 @@ load _helpers
       --set 'controller.extraLabels.label1=value1' \
       --set 'controller.extraLabels.label2=value2' \
       . | tee /dev/stderr |
-      yq '.spec.template.metadata.labels | select(documentIndex == 1)' | tee /dev/stderr)
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") .spec.template.metadata | .labels' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
    [ "${actual}" = "5" ]
@@ -709,11 +709,13 @@ load _helpers
   local object=$(helm template \
       -s templates/deployment.yaml  \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[1].args | select(documentIndex == 1)' | tee /dev/stderr)
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
    [ "${actual}" = "3" ]
 }
+
+#
 
 @test "controller/Deployment: with extraArgs" {
   cd `chart_dir`
@@ -721,7 +723,7 @@ load _helpers
       -s templates/deployment.yaml  \
       --set 'controller.manager.extraArgs={--foo=baz,--bar=qux}'  \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.containers[1].args | select(documentIndex == 1)' | tee /dev/stderr)
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
    [ "${actual}" = "5" ]


### PR DESCRIPTION
Ensure that only support duration string values can be set for `spec.refreshAfter`. This change affects VaultStaticSecret and HCPVaultSecretsApp specs.

In addition to the change above, apply a minimum constraint on the configured HVSA refreshAfter, with the default value being 30s. This value can be set from the command line option `-min-refresh-after-hvsa`.

Additional enhancements:
- chart: support extending the controller.manager's args with the new extraArgs value.