### PR TITLE
Support running bats tests in parallel

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
       - run: npm install -g bats@${BATS_VERSION}
         shell: bash
         env:
-          BATS_VERSION: '1.8.2'
+          BATS_VERSION: '1.10.0'
       - run: bats -v
         shell: bash
       - run: make unit-test

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ SKIP_AWS_STATIC_CREDS_TEST ?= true
 # filter bats unit tests to run.
 BATS_TESTS_FILTER ?= .\*
 # number of parallel bats to run
-BATS_PARALLEL_JOBS ?= 10
+BATS_PARALLEL_JOBS ?= 30
 # set by the 'bats-parallel' target, requires that 'parallel'
 # be installed on the build host.
 BATS_PARALLEL_ARGS ?=


### PR DESCRIPTION
Add support for running all bats test in parallel. It requires that the `parallel` command be installed on the build host.