### PR TITLE
Fix up Helm and API docs for v0.3.0

### DIFF
--- a/api/v1beta1/hcpauth_types.go
+++ b/api/v1beta1/hcpauth_types.go
@@ -39,8 +39,7 @@ type HCPAuthServicePrincipal struct {
 	// SecretRef is the name of a Kubernetes secret in the consumer's
 	// (VDS/VSS/PKI/HCP) namespace which provides the HCP ServicePrincipal clientID,
 	// and clientSecret.
-	//
-	//The secret data must have the following structure {
+	// The secret data must have the following structure {
 	//   "clientID": "clientID",
 	//   "clientSecret": "clientSecret",
 	// }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -17,6 +17,7 @@ controller:
   #   - ip: 192.168.1.100
   #     hostnames:
   #     - vault.example.com
+  # @type: array<map>
   hostAliases: []
 
   # nodeSelector labels for vault-secrets-operator pod assignment.

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -91,8 +91,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `secretRef` _string_ | SecretRef is the name of a Kubernetes secret in the consumer's (VDS/VSS/PKI/HCP) namespace which provides the HCP ServicePrincipal clientID, and clientSecret. 
- The secret data must have the following structure { "clientID": "clientID", "clientSecret": "clientSecret", } |
+| `secretRef` _string_ | SecretRef is the name of a Kubernetes secret in the consumer's (VDS/VSS/PKI/HCP) namespace which provides the HCP ServicePrincipal clientID, and clientSecret. The secret data must have the following structure { "clientID": "clientID", "clientSecret": "clientSecret", } |
 
 
 #### HCPAuthSpec


### PR DESCRIPTION
- helm: hostAliases did not provide a type, which broke Helm documentation generation
- api-ref: the HCPAuthServicePrincipal table contained an extra row.