### PR TITLE
Remove/disable revoke on uninstall

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -169,9 +169,6 @@ spec:
         image: {{ .Values.controller.manager.image.repository }}:{{ .Values.controller.manager.image.tag }}
         args:
         - --uninstall
-        {{- if .Values.controller.manager.clientCache.revokeClientCacheOnUninstall }}
-        - --revoke-client-cache
-        {{- end }}
         - --pre-delete-hook-timeout-seconds={{ .Values.controller.preDeleteHookTimeoutSeconds }}
         command:
         - /vault-secrets-operator

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -120,12 +120,6 @@ controller:
       # @type: string
       persistenceModel: ""
 
-      # Toggles the revocation of client cache on Helm uninstall.
-      # If revokeClientCacheOnUninstall is true, all Vault client tokens used by the operator will be revoked, and purged from the cache and storage.
-      # NOTE: When a token is revoked, all of its leases are also revoked. This can cause failures in the consuming applications.
-      # @type: boolean
-      revokeClientCacheOnUninstall: false
-
       # Defines the size of the in-memory LRU cache *in entries*, that is used by the client cache controller.
       # Larger numbers will increase memory usage by the controller, lower numbers will cause more frequent evictions
       # of the client cache which can result in additional Vault client counts.

--- a/main.go
+++ b/main.go
@@ -66,7 +66,6 @@ func main() {
 	var printVersion bool
 	var outputFormat string
 	var uninstall bool
-	var revokeClientCache bool
 	var preDeleteHookTimeoutSeconds int
 	var minRefreshAfterHVSA time.Duration
 
@@ -87,9 +86,7 @@ func main() {
 	flag.IntVar(&vdsOptions.MaxConcurrentReconciles, "max-concurrent-reconciles-vds", 100,
 		"Maximum number of concurrent reconciles for the VaultDynamicSecrets controller.")
 	flag.BoolVar(&uninstall, "uninstall", false, "Run in uninstall mode")
-	flag.BoolVar(&revokeClientCache, "revoke-client-cache", false, "Revoke the client cache "+
-		"upon Helm uninstall")
-	flag.IntVar(&preDeleteHookTimeoutSeconds, "pre-delete-hook-timeout-seconds", 120,
+	flag.IntVar(&preDeleteHookTimeoutSeconds, "pre-delete-hook-timeout-seconds", 60,
 		"Pre-delete hook timeout in seconds")
 	flag.DurationVar(&minRefreshAfterHVSA, "min-refresh-after-hvsa", time.Second*30,
 		"Minimum duration between HCPVaultSecretsApp resource reconciliation.")
@@ -157,18 +154,6 @@ func main() {
 			os.Exit(1)
 		}
 
-		cleanupLog.Info("Starting the operator uninstall process")
-		shutdownMode := vclient.ShutDownModeNoRevoke
-		if revokeClientCache {
-			shutdownMode = vclient.ShutDownModeRevoke
-		}
-
-		if err = shutDownOperator(preDeleteDeadlineCtx, defaultClient, shutdownMode); err != nil {
-			cleanupLog.Error(err, "Failed to complete the operator uninstall process")
-			os.Exit(1)
-		}
-
-		cleanupLog.Info("Successfully completed the operator uninstall process")
 		os.Exit(0)
 	}
 

--- a/test/integration/revocation_integration_test.go
+++ b/test/integration/revocation_integration_test.go
@@ -30,8 +30,11 @@ import (
 // TestRevocation tests the revocation logic on Helm uninstall
 func TestRevocation(t *testing.T) {
 	if !testWithHelm {
-		t.Skipf("Test is only compatiable with Helm")
+		t.Skip("Test is only compatible with Helm")
 	}
+
+	t.Skip("Disabling until VAULT-20196 is resolved")
+
 	ctx := context.Background()
 	testID := strings.ToLower(random.UniqueId())
 	testK8sNamespace := "k8s-tenant-" + testID

--- a/test/unit/deployment.bats
+++ b/test/unit/deployment.bats
@@ -328,48 +328,6 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# terminationGracePeriodSeconds
-
-@test "controller/Deployment: default terminationGracePeriodSeconds when revokeClientCacheOnUninstall is false by default" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -s templates/deployment.yaml  \
-      . | tee /dev/stderr |
-      yq '.spec.template.spec.terminationGracePeriodSeconds | select(documentIndex == 1)' | tee /dev/stderr)
-   [ "${actual}" = "120" ]
-}
-
-#--------------------------------------------------------------------
-# preDeleteHookTimeoutSeconds
-
-@test "controller/Deployment: default preDeleteHookTimeoutSeconds when revokeClientCacheOnUninstall is false by default" {
-  cd `chart_dir`
-  local object=$(helm template \
-      -s templates/deployment.yaml  \
-      . | tee /dev/stderr |
-      yq 'select(.kind == "Job" and .metadata.annotations."helm.sh/hook" == "pre-delete") | .spec.template.spec.containers[] | select(.name == "pre-delete-controller-cleanup") | .args' | tee /dev/stderr)
-
-  local actual=$(echo "$object" | yq 'contains(["--pre-delete-hook-timeout-seconds=120"])' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-#--------------------------------------------------------------------
-# when revokeClientCacheOnUninstall is true
-
-@test "controller/Deployment: correct args when revokeClientCacheOnUninstall is true" {
-  cd `chart_dir`
-  local object=$(helm template \
-      -s templates/deployment.yaml  \
-      --set 'controller.manager.clientCache.revokeClientCacheOnUninstall=true' \
-      --set 'controller.preDeleteHookTimeoutSeconds=180' \
-      . | tee /dev/stderr |
-      yq 'select(.kind == "Job" and .metadata.annotations."helm.sh/hook" == "pre-delete") | .spec.template.spec.containers[] | select(.name == "pre-delete-controller-cleanup") | .args' | tee /dev/stderr)
-
-  local actual=$(echo "$object" | yq 'contains(["--uninstall", "--revoke-client-cache","--pre-delete-hook-timeout-seconds=180"])' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-#--------------------------------------------------------------------
 # controller.imagePullSecrets
 
 @test "controller/Deployment: no image pull secrets by default" {


### PR DESCRIPTION
The revocation Helm pre-delete job could sometimes fail forever, preventing the VSO release from being uninstalled. This PR temporarily disables this feature until VAULT-20196 is resolved