### PR TITLE
Bump the chart version and default tags to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1 (September 27th, 2023)
+Fix:
+* Helm: bump the chart version and default tags to 0.3.1: [GH-386](https://github.com/hashicorp/vault-secrets-operator/pull/386)
+
 ## 0.3.0 (September 27th, 2023)
 
 Improvements:

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault-secrets-operator
-version: 0.3.0-rc.1
-appVersion: "0.3.0-rc.1"
+version: 0.3.1
+appVersion: "0.3.1"
 kubeVersion: ">=1.22.0-0"
 description: Official Vault Secrets Operator Chart
 type: application

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -100,7 +100,7 @@ controller:
     # Image sets the repo and tag of the vault-secrets-operator image to use for the controller.
     image:
       repository: hashicorp/vault-secrets-operator
-      tag: 0.3.0-rc.1
+      tag: 0.3.1
 
     # Configures the client cache which is used by the controller to cache (and potentially persist) vault tokens that
     # are the result of using the VaultAuthMethod. This enables re-use of Vault Tokens

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,4 +16,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: hashicorp/vault-secrets-operator
-  newTag: 0.3.0-rc.1
+  newTag: 0.3.1


### PR DESCRIPTION
Missed the version bump in the 0.3.0 release, so bumping everything to 0.3.1.