### PR TITLE
Check Helm and Kustomize versions for production builds.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,7 @@ jobs:
 
   build-pre-checks:
     runs-on: ubuntu-latest
+    needs: get-product-version
     outputs:
       go-version: ${{ steps.setup-go.outputs.go-version }}
     steps:
@@ -48,6 +49,9 @@ jobs:
         run: |
           go mod tidy
           test -z "$(git status --porcelain)"
+      - name: check versions
+        run: |
+          make check-versions VERSION=${{ needs.get-product-version.outputs.product-version }}
       - name: generate manifests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -634,3 +634,7 @@ bats-parallel:
 ifneq (,$(shell which parallel 2>/dev/null))
 	$(eval BATS_PARALLEL_ARGS=-j $(BATS_PARALLEL_JOBS))
 endif
+
+.PHONY: check-versions
+check-versions:
+	VERSION=$(VERSION) ./scripts/check-versions.sh

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -31,7 +31,6 @@ function checkVersion {
  fi
 
  local doc="$(cat ${filename})"
- local queries=
  echo "* Checking version(s) in ${filename}"
  for query in "${@:2}"
  do

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -e
+
+if [ -z "${VERSION}" ]; then
+  echo "VERSION variable must be set" >&2
+  exit 1
+fi
+
+if [ "${VERSION}" == "0.0.0-dev" ]; then
+  echo "dev build, skipping version checks"
+  exit 0
+fi
+
+ROOT_DIR="${0%/*}"
+# update PATH to prefer scripts relative to this one e.g. yq
+export PATH="${ROOT_DIR}:${PATH}"
+
+CHART_ROOT="${CHART_ROOT-$(readlink -f ${0%/*}/../chart)}"
+KUSTOMIZE_ROOT="${KUSTOMIZE_ROOT-$(readlink -f ${0%/*}/../config)}"
+
+_result=0
+function checkVersion {
+ local filename="${1}"
+ if ! [ -e ${filename} ]; then
+   echo "${filename} file does not exist'" >&2
+   _result=1
+   return 1
+ fi
+
+ local doc="$(cat ${filename})"
+ local queries=
+ echo "* Checking version(s) in ${filename}"
+ for query in "${@:2}"
+ do
+   actual="$(echo "${doc}" | yq "${query}")"
+   if [ "${actual}" != "${VERSION}" ]; then
+        echo "yq-expr '${query}' does not match expected '${VERSION}', actual='${actual}'" >&2
+        _result=1
+   fi
+ done
+}
+
+checkVersion "${CHART_ROOT}/Chart.yaml" .version .appVersion
+checkVersion "${CHART_ROOT}/values.yaml" .controller.manager.image.tag
+checkVersion "${KUSTOMIZE_ROOT}/manager/kustomization.yaml" ".images.[] | select(.name == \"controller\") | .newTag"
+
+exit $_result

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -18,8 +18,8 @@ ROOT_DIR="${0%/*}"
 # update PATH to prefer scripts relative to this one e.g. yq
 export PATH="${ROOT_DIR}:${PATH}"
 
-CHART_ROOT="${CHART_ROOT-$(readlink -f ${0%/*}/../chart)}"
-KUSTOMIZE_ROOT="${KUSTOMIZE_ROOT-$(readlink -f ${0%/*}/../config)}"
+CHART_ROOT="${CHART_ROOT-$(readlink -f ${ROOT_DIR}/../chart)}"
+KUSTOMIZE_ROOT="${KUSTOMIZE_ROOT-$(readlink -f ${ROOT_DIR}/../config)}"
 
 _result=0
 function checkVersion {


### PR DESCRIPTION
Adds a script that verifies that version tags match what the build thinks the `VERSION` should be. This fix  should help to ensure that the Helm/Kustomize/VSO versions are always in sync.

 have been updated in both the Helm chart and the Kustomize config. 
- [x] check Kustomize config
- [x] check Helm chart config