### PR TITLE
Add vault-1.15 to the test matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -226,9 +226,9 @@ jobs:
     steps:
       - run: echo "setting vault versions"
     outputs:
-      VAULT_N_2: 1.12.9
-      VAULT_N_1: 1.13.5
-      VAULT_N: 1.14.1
+      VAULT_N_2: 1.13.8
+      VAULT_N_1: 1.14.4
+      VAULT_N: 1.15.0
 
   k8s-versions:
     runs-on: ubuntu-latest

--- a/test/integration/infra/locals.tf
+++ b/test/integration/infra/locals.tf
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+locals {
+  vault_image_tag        = var.vault_image_tag
+  vault_image_repository = var.vault_enterprise ? var.vault_image_repo_ent : var.vault_image_repo
+  vault_license          = var.vault_enterprise ? (var.vault_license != "" ? var.vault_license : file(var.vault_license_path)) : ""
+}

--- a/test/integration/infra/main.tf
+++ b/test/integration/infra/main.tf
@@ -14,12 +14,6 @@ terraform {
   }
 }
 
-locals {
-  vault_image_tag        = var.vault_image_tag
-  vault_image_repository = var.vault_enterprise ? var.vault_image_repo_ent : var.vault_image_repo
-  vault_license          = var.vault_enterprise ? (var.vault_license != "" ? var.vault_license : file(var.vault_license_path)) : ""
-}
-
 provider "helm" {
   kubernetes {
     config_context = var.k8s_config_context

--- a/test/integration/infra/variables.tf
+++ b/test/integration/infra/variables.tf
@@ -30,11 +30,11 @@ variable "vault_image_repo_ent" {
 }
 
 variable "vault_image_tag" {
-  default = "1.13"
+  default = "1.15"
 }
 
 variable "vault_image_tag_ent" {
-  default = "1.13-ent"
+  default = "1.15-ent"
 }
 
 variable "vault_enterprise" {


### PR DESCRIPTION
additional changes to the test matrix:
- cycle out vault-1.12
- update vault-1.13.5 to 1.13.8
- update vault-1.14.1 to 1.14.4

other fixes:
- factor out locals from vault/main.tf to locals.tf, making it consistent with the other TF code.
- bump the default vault image tag to 1.15 in vault/variables.tf