### PR TITLE
Update remaining integration tests to use the VSO TF Helm module

### DIFF
--- a/test/integration/modules/vso-helm/main.tf
+++ b/test/integration/modules/vso-helm/main.tf
@@ -96,6 +96,13 @@ resource "helm_release" "vault-secrets-operator" {
     name  = "controller.manager.clientCache.storageEncryption.kubernetes.tokenAudiences"
     value = var.client_cache_config.storage_encryption.kubernetes_auth_token_audiences
   }
+  dynamic "set" {
+    for_each = var.client_cache_config.revoke_client_cache_on_uninstall ? [""] : []
+    content {
+      name  = "controller.manager.clientCache.revokeClientCacheOnUninstall"
+      value = var.client_cache_config.revoke_client_cache_on_uninstall
+    }
+  }
   set_list {
     name  = "controller.manager.extraArgs"
     value = var.manager_extra_args

--- a/test/integration/modules/vso-helm/variables.tf
+++ b/test/integration/modules/vso-helm/variables.tf
@@ -50,7 +50,8 @@ variable "vault_test_namespace" {
 
 variable "client_cache_config" {
   type = object({
-    persistence_model = string
+    persistence_model                = string
+    revoke_client_cache_on_uninstall = bool
     storage_encryption = object({
       enabled                         = bool
       vault_connection_ref            = string
@@ -66,7 +67,8 @@ variable "client_cache_config" {
   })
 
   default = {
-    persistence_model = ""
+    persistence_model                = ""
+    revoke_client_cache_on_uninstall = false
     storage_encryption = {
       enabled                         = false
       vault_connection_ref            = ""

--- a/test/integration/revocation/terraform/main.tf
+++ b/test/integration/revocation/terraform/main.tf
@@ -104,39 +104,29 @@ resource "vault_kubernetes_auth_backend_role" "default" {
 }
 
 # VSO Helm chart
-resource "helm_release" "vault-secrets-operator" {
-  name             = "test"
-  namespace        = var.operator_namespace
-  create_namespace = true
-  wait             = true
-  chart            = var.operator_helm_chart_path
-
-  set {
-    name  = "controller.manager.image.repository"
-    value = var.operator_image_repo
-  }
-  set {
-    name  = "controller.manager.image.tag"
-    value = var.operator_image_tag
-  }
-
-  # Connection Configuration
-  set {
-    name  = "defaultVaultConnection.enabled"
-    value = "true"
-  }
-  set {
-    name  = "defaultVaultConnection.address"
-    value = var.k8s_vault_connection_address
-  }
-
-  set {
-    name  = "controller.manager.clientCache.revokeClientCacheOnUninstall"
-    value = "true"
-  }
-
-  set {
-    name  = "controller.manager.clientCache.persistenceModel"
-    value = "direct-unencrypted"
+module "vso-helm" {
+  source                       = "../../modules/vso-helm"
+  operator_namespace           = var.operator_namespace
+  operator_image_repo          = var.operator_image_repo
+  operator_image_tag           = var.operator_image_tag
+  enable_default_connection    = true
+  enable_default_auth_method   = false
+  operator_helm_chart_path     = var.operator_helm_chart_path
+  k8s_vault_connection_address = var.k8s_vault_connection_address
+  client_cache_config = {
+    persistence_model                = "direct-unencrypted"
+    revoke_client_cache_on_uninstall = true
+    storage_encryption = {
+      enabled                         = false
+      vault_connection_ref            = ""
+      namespace                       = ""
+      mount                           = ""
+      transit_mount                   = ""
+      key_name                        = ""
+      method                          = ""
+      kubernetes_auth_role            = ""
+      kubernetes_auth_service_account = ""
+      kubernetes_auth_token_audiences = ""
+    }
   }
 }

--- a/test/integration/vaultdynamicsecret/terraform/main.tf
+++ b/test/integration/vaultdynamicsecret/terraform/main.tf
@@ -98,7 +98,8 @@ module "vso-helm" {
   k8s_vault_connection_address     = var.k8s_vault_connection_address
   vault_test_namespace             = local.namespace
   client_cache_config = {
-    persistence_model = "direct-encrypted"
+    persistence_model                = "direct-encrypted"
+    revoke_client_cache_on_uninstall = false
     storage_encryption = {
       enabled                         = true
       vault_connection_ref            = ""

--- a/test/integration/vaultpkisecret/terraform/main.tf
+++ b/test/integration/vaultpkisecret/terraform/main.tf
@@ -126,46 +126,18 @@ path "${vault_mount.pki.path}/*" {
 EOT
 }
 
-resource "helm_release" "vault-secrets-operator" {
-  count            = var.deploy_operator_via_helm ? 1 : 0
-  name             = "test"
-  namespace        = var.operator_namespace
-  create_namespace = true
-  wait             = true
-  chart            = var.operator_helm_chart_path
-
-  # Connection Configuration
-  set {
-    name  = "defaultVaultConnection.enabled"
-    value = "true"
-  }
-  set {
-    name  = "defaultVaultConnection.address"
-    value = var.k8s_vault_connection_address
-  }
-  # Auth Method Configuration
-  set {
-    name  = "defaultAuthMethod.enabled"
-    value = "true"
-  }
-  set {
-    name  = "defaultAuthMethod.namespace"
-    value = var.vault_test_namespace
-  }
-  set {
-    name  = "defaultAuthMethod.kubernetes.role"
-    value = vault_kubernetes_auth_backend_role.default.role_name
-  }
-  set {
-    name  = "defaultAuthMethod.kubernetes.tokenAudiences"
-    value = "{${vault_kubernetes_auth_backend_role.default.audience}}"
-  }
-  set {
-    name  = "controller.manager.image.repository"
-    value = var.operator_image_repo
-  }
-  set {
-    name  = "controller.manager.image.tag"
-    value = var.operator_image_tag
-  }
+module "vso-helm" {
+  count                            = var.deploy_operator_via_helm ? 1 : 0
+  source                           = "../../modules/vso-helm"
+  operator_namespace               = var.operator_namespace
+  operator_image_repo              = var.operator_image_repo
+  operator_image_tag               = var.operator_image_tag
+  enable_default_auth_method       = var.enable_default_auth_method
+  enable_default_connection        = var.enable_default_connection
+  operator_helm_chart_path         = var.operator_helm_chart_path
+  k8s_auth_default_mount           = vault_kubernetes_auth_backend_role.default.backend
+  k8s_auth_default_role            = vault_kubernetes_auth_backend_role.default.role_name
+  k8s_auth_default_token_audiences = [vault_kubernetes_auth_backend_role.default.audience]
+  k8s_vault_connection_address     = var.k8s_vault_connection_address
+  vault_test_namespace             = var.vault_test_namespace
 }

--- a/test/integration/vaultpkisecret/terraform/variables.tf
+++ b/test/integration/vaultpkisecret/terraform/variables.tf
@@ -5,7 +5,6 @@ variable "k8s_test_namespace" {
   default = "testing"
 }
 
-variable "k8s_vault_connection_address" {}
 
 variable "k8s_config_context" {
   default = "kind-kind"
@@ -44,6 +43,20 @@ variable "deploy_operator_via_helm" {
 
 variable "operator_namespace" {
   default = "vault-secrets-operator-system"
+}
+
+variable "enable_default_connection" {
+  type    = bool
+  default = false
+}
+
+variable "enable_default_auth_method" {
+  type    = bool
+  default = false
+}
+
+variable "k8s_vault_connection_address" {
+  default = ""
 }
 
 variable "operator_image_repo" {

--- a/test/integration/vaultstaticsecret/terraform/main.tf
+++ b/test/integration/vaultstaticsecret/terraform/main.tf
@@ -122,46 +122,18 @@ path "${vault_mount.kv.path}/*" {
 EOT
 }
 
-resource "helm_release" "vault-secrets-operator" {
-  count            = var.deploy_operator_via_helm ? 1 : 0
-  name             = "test"
-  namespace        = var.operator_namespace
-  create_namespace = true
-  wait             = true
-  chart            = var.operator_helm_chart_path
-
-  # Connection Configuration
-  set {
-    name  = "defaultVaultConnection.enabled"
-    value = "true"
-  }
-  set {
-    name  = "defaultVaultConnection.address"
-    value = var.k8s_vault_connection_address
-  }
-  # Auth Method Configuration
-  set {
-    name  = "defaultAuthMethod.enabled"
-    value = "true"
-  }
-  set {
-    name  = "defaultAuthMethod.namespace"
-    value = var.vault_test_namespace
-  }
-  set {
-    name  = "defaultAuthMethod.kubernetes.role"
-    value = vault_kubernetes_auth_backend_role.default.role_name
-  }
-  set {
-    name  = "defaultAuthMethod.kubernetes.tokenAudiences"
-    value = "{${vault_kubernetes_auth_backend_role.default.audience}}"
-  }
-  set {
-    name  = "controller.manager.image.repository"
-    value = var.operator_image_repo
-  }
-  set {
-    name  = "controller.manager.image.tag"
-    value = var.operator_image_tag
-  }
+module "vso-helm" {
+  count                            = var.deploy_operator_via_helm ? 1 : 0
+  source                           = "../../modules/vso-helm"
+  operator_namespace               = var.operator_namespace
+  operator_image_repo              = var.operator_image_repo
+  operator_image_tag               = var.operator_image_tag
+  enable_default_auth_method       = var.enable_default_auth_method
+  enable_default_connection        = var.enable_default_connection
+  operator_helm_chart_path         = var.operator_helm_chart_path
+  k8s_auth_default_mount           = vault_kubernetes_auth_backend_role.default.backend
+  k8s_auth_default_role            = vault_kubernetes_auth_backend_role.default.role_name
+  k8s_auth_default_token_audiences = [vault_kubernetes_auth_backend_role.default.audience]
+  k8s_vault_connection_address     = var.k8s_vault_connection_address
+  vault_test_namespace             = var.vault_test_namespace
 }

--- a/test/integration/vaultstaticsecret/terraform/variables.tf
+++ b/test/integration/vaultstaticsecret/terraform/variables.tf
@@ -5,7 +5,6 @@ variable "k8s_test_namespace" {
   default = "testing"
 }
 
-variable "k8s_vault_connection_address" {}
 
 variable "k8s_config_context" {
   default = "kind-kind"
@@ -48,6 +47,20 @@ variable "deploy_operator_via_helm" {
 
 variable "operator_namespace" {
   default = "vault-secrets-operator-system"
+}
+
+variable "enable_default_connection" {
+  type    = bool
+  default = false
+}
+
+variable "enable_default_auth_method" {
+  type    = bool
+  default = false
+}
+
+variable "k8s_vault_connection_address" {
+  default = ""
 }
 
 variable "operator_image_repo" {


### PR DESCRIPTION
Updates the following integration tests to use the VSO TF Hem module:

- TestVaultAuthMethods
- TestVaultPKISecret
- TestVaultStaticSecret
- TestRevocation (tested locally, since it is disabled)
