### PR TITLE
Handle invalid Client race after restoration

### DIFF
--- a/internal/vault/client_factory.go
+++ b/internal/vault/client_factory.go
@@ -471,6 +471,11 @@ func (m *cachingClientFactory) restoreClient(ctx context.Context, client ctrlcli
 
 	c, err := NewClientFromStorageEntry(ctx, client, entry, nil)
 	if err != nil {
+		// remove the Client storage entry if its restoration failed for any reason
+		if _, err := m.pruneStorage(ctx, client, entry.CacheKey); err != nil {
+			m.logger.Error(err, "Failed to prune cache storage", "entry", entry)
+		}
+
 		return nil, err
 	}
 

--- a/internal/vault/client_test.go
+++ b/internal/vault/client_test.go
@@ -747,3 +747,64 @@ func Test_defaultClient_Read(t *testing.T) {
 		})
 	}
 }
+
+func Test_defaultClient_Close(t *testing.T) {
+	handlerFunc := func(t *testHandler, w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}
+
+	tests := []struct {
+		name           string
+		revoke         bool
+		handler        *testHandler
+		expectRequests int
+		expectParams   []map[string]interface{}
+		expectPaths    []string
+	}{
+		{
+			name:   "ensure-closed",
+			revoke: false,
+			handler: &testHandler{
+				handlerFunc: handlerFunc,
+			},
+		},
+		{
+			name:   "ensure-closed-with-revoke",
+			revoke: true,
+			handler: &testHandler{
+				handlerFunc: handlerFunc,
+			},
+			expectPaths:    []string{"/v1/auth/token/revoke-self"},
+			expectRequests: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, l := NewTestHTTPServer(t, tt.handler.handler())
+			t.Cleanup(func() {
+				l.Close()
+			})
+
+			client, err := api.NewClient(config)
+			require.NoError(t, err)
+
+			c := &defaultClient{
+				client: client,
+			}
+
+			c.Close(tt.revoke)
+
+			assert.Equal(t, tt.expectPaths, tt.handler.paths)
+			assert.Equal(t, tt.expectParams, tt.handler.params)
+			assert.Equal(t, tt.expectRequests, tt.handler.requestCount)
+
+			assert.True(t, c.closed)
+			assert.NotNil(t, c.client)
+		})
+	}
+}

--- a/internal/vault/client_test.go
+++ b/internal/vault/client_test.go
@@ -761,7 +761,6 @@ func Test_defaultClient_Close(t *testing.T) {
 	tests := []struct {
 		name           string
 		revoke         bool
-		handler        *testHandler
 		expectRequests int
 		expectParams   []map[string]interface{}
 		expectPaths    []string
@@ -769,23 +768,20 @@ func Test_defaultClient_Close(t *testing.T) {
 		{
 			name:   "ensure-closed",
 			revoke: false,
-			handler: &testHandler{
-				handlerFunc: handlerFunc,
-			},
 		},
 		{
-			name:   "ensure-closed-with-revoke",
-			revoke: true,
-			handler: &testHandler{
-				handlerFunc: handlerFunc,
-			},
+			name:           "ensure-closed-with-revoke",
+			revoke:         true,
 			expectPaths:    []string{"/v1/auth/token/revoke-self"},
 			expectRequests: 1,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config, l := NewTestHTTPServer(t, tt.handler.handler())
+			h := &testHandler{
+				handlerFunc: handlerFunc,
+			}
+			config, l := NewTestHTTPServer(t, h.handler())
 			t.Cleanup(func() {
 				l.Close()
 			})
@@ -799,9 +795,9 @@ func Test_defaultClient_Close(t *testing.T) {
 
 			c.Close(tt.revoke)
 
-			assert.Equal(t, tt.expectPaths, tt.handler.paths)
-			assert.Equal(t, tt.expectParams, tt.handler.params)
-			assert.Equal(t, tt.expectRequests, tt.handler.requestCount)
+			assert.Equal(t, tt.expectPaths, h.paths)
+			assert.Equal(t, tt.expectParams, h.params)
+			assert.Equal(t, tt.expectRequests, h.requestCount)
 
 			assert.True(t, c.closed)
 			assert.NotNil(t, c.client)


### PR DESCRIPTION
During the VSO restart the Vault Client is restored from the storage cache, but it’s LifetimeWatcher has not yet renewed the client token, which can lead to the next fetch from cache getting an invalid Client (token expired) error. In this situation, the ClientFactory will evict the client from the cache, which in turns calls client.Close(), which has the negative side-effect of setting it’s wrapped api.Client to nil thereby breaking any current Client references that are handling any in-flight requests.

FIxes:
- do not set the wrapped `api.Client` to nil on `Client.Close()`
- attempt to renew the token before starting the `LifetimeWatcher` in `Client.Restore()`
- always wait for the `LiftiemeWatcher` to be started

A work around for this issue is to delete the offending client cache Secret from the K8s cluster.

To delete a single client-cache secret  (update the VSO namespace accordingly) do:
```
kubectl delete -n vault-secrets-operator-system secrets vso-cc-kubernetes-ea76f66f79516c9dcae523
```

To delete all client-cache secrets do (update the VSO namespace accordingly):
```
$ kubectl delete -n vault-secrets-operator-system secrets -l app.kubernetes.io/component=client-cache-storage
```

Restart the operator:
```
$ kubectl -n vault-secrets-operator-system rollout restart deployment -l control-plane=controller-manager
```

Example panic:

```
2023-10-07T16:16:18Z    INFO    Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference        {"controller": "vaultdynamicsecret", "controllerGroup": "secrets.hash
icorp.com", "controllerKind": "VaultDynamicSecret", "VaultDynamicSecret": {"name":"mixed-create-static-creds-8","namespace":"vds-sn3h1sj0sw-k8s-ns"}, "namespace": "vds-sn3h1sj0sw-k8s-ns", "name": "mixed-cr
eate-static-creds-8", "reconcileID": "d73e761a-2b86-4bb6-bf7a-14a2ee3bd2c7"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x18cd976]

goroutine 310 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:116 +0x1fa
panic({0x1b01960, 0x3000210})
        /usr/local/go/src/runtime/panic.go:884 +0x213
github.com/hashicorp/vault/api.(*Client).ClientTimeout(0x0)
        /go/pkg/mod/github.com/hashicorp/vault/api@v1.10.0/client.go:891 +0x36
github.com/hashicorp/vault/api.(*Client).withConfiguredTimeout(0xc000b0b860?, {0x21de930, 0xc000bed9b0})
        /go/pkg/mod/github.com/hashicorp/vault/api@v1.10.0/client.go:1663 +0x25
github.com/hashicorp/vault/api.(*Logical).ReadWithDataWithContext(0xc000b0b870, {0x21de930?, 0xc000bed9b0?}, {0xc000a0fd40, 0x32}, 0x1910bf8?)
        /go/pkg/mod/github.com/hashicorp/vault/api@v1.10.0/logical.go:68 +0x6a
github.com/hashicorp/vault-secrets-operator/internal/vault.(*defaultClient).Read(0xc000282320, {0x21de930, 0xc000bed9b0}, {0x21cb218?, 0xc000b115a8})
        /workspace/internal/vault/client.go:519 +0x1c5
github.com/hashicorp/vault-secrets-operator/controllers.(*VaultDynamicSecretReconciler).syncSecret(0xc000813140, {0x21de930, 0xc000bed9b0}, {0x4027f64b18, 0xc000282320}, 0xc000a75180)
        /workspace/controllers/vaultdynamicsecret_controller.go:298 +0x362
github.com/hashicorp/vault-secrets-operator/controllers.(*VaultDynamicSecretReconciler).Reconcile(0xc000813140, {0x21de930, 0xc000bed9b0}, {{{0xc000019e48?, 0x5?}, {0xc0000c7e20?, 0xc000840d48?}}})
        /workspace/controllers/vaultdynamicsecret_controller.go:187 +0x108d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x21e1030?, {0x21de930?, 0xc000bed9b0?}, {{{0xc000019e48?, 0xb?}, {0xc0000c7e20?, 0x0?}}})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:119 +0xc8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0004c4960, {0x21de888, 0xc0007587d0}, {0x1baa0c0?, 0xc0000a6f60?})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:316 +0x3ca
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0004c4960, {0x21de888, 0xc0007587d0})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:266 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:227 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:223 +0x587
I1007 16:16:37.900859       1 leaderelection.go:260] successfully acquired l
```