### PR TITLE
Release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.3.3 (October 17th, 2023)
+Fix:
+
+* Important security update to address some Golang vulnerabilities [GH-414]https://github.com/hashicorp/vault-secrets-operator/pull/414
+
+Dependency Updates:
+* Upgrade kube-rbac-proxy to v0.14.4 for CVE-2023-39325 [GH-414]https://github.com/hashicorp/vault-secrets-operator/pull/414
+* Bump to Go 1.21.3 for CVE-2023-39325: [GH-408](https://github.com/hashicorp/vault-secrets-operator/pull/408)
+* Bump github.com/hashicorp/vault/sdk from 0.10.0 to 0.10.2: [GH-410](https://github.com/hashicorp/vault-secrets-operator/pull/410)
+* Bump github.com/gruntwork-io/terratest from 0.45.0 to 0.46.0: [GH-409](https://github.com/hashicorp/vault-secrets-operator/pull/409)
+* Bump golang.org/x/net from 0.14.0 to 0.17.0: [GH-407](https://github.com/hashicorp/vault-secrets-operator/pull/407)
+
 ## 0.3.2 (October 10th, 2023)
 Fix:
 * Handle invalid Client race after restoration: [GH-400](https://github.com/hashicorp/vault-secrets-operator/pull/400)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 0.3.3 (October 17th, 2023)
 Fix:
 
-* Important security update to address some Golang vulnerabilities [GH-414]https://github.com/hashicorp/vault-secrets-operator/pull/414
+* Important security update to address some Golang vulnerabilities [GH-414](https://github.com/hashicorp/vault-secrets-operator/pull/414)
 
 Dependency Updates:
-* Upgrade kube-rbac-proxy to v0.14.4 for CVE-2023-39325 [GH-414]https://github.com/hashicorp/vault-secrets-operator/pull/414
+* Upgrade kube-rbac-proxy to v0.14.4 for CVE-2023-39325 [GH-414](https://github.com/hashicorp/vault-secrets-operator/pull/414)
 * Bump to Go 1.21.3 for CVE-2023-39325: [GH-408](https://github.com/hashicorp/vault-secrets-operator/pull/408)
 * Bump github.com/hashicorp/vault/sdk from 0.10.0 to 0.10.2: [GH-410](https://github.com/hashicorp/vault-secrets-operator/pull/410)
 * Bump github.com/gruntwork-io/terratest from 0.45.0 to 0.46.0: [GH-409](https://github.com/hashicorp/vault-secrets-operator/pull/409)

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.0.0-dev
+KUBE_RBAC_PROXY_VERSION = v0.14.4
 
 GO_VERSION = $(shell cat .go-version)
 
@@ -637,4 +638,4 @@ endif
 
 .PHONY: check-versions
 check-versions:
-	VERSION=$(VERSION) ./scripts/check-versions.sh
+	VERSION=$(VERSION) KUBE_RBAC_PROXY_VERSION=$(KUBE_RBAC_PROXY_VERSION) ./scripts/check-versions.sh

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault-secrets-operator
-version: 0.3.2
-appVersion: "0.3.2"
+version: 0.3.3
+appVersion: "0.3.3"
 kubeVersion: ">=1.22.0-0"
 description: Official Vault Secrets Operator Chart
 type: application

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -61,7 +61,7 @@ controller:
     # Image sets the repo and tag of the kube-rbac-proxy image to use for the controller.
     image:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.14.1
+      tag: v0.14.4
 
     # Configures the default resources for the kube rbac proxy container.
     # For more information on configuring resources, see the K8s documentation:
@@ -100,7 +100,7 @@ controller:
     # Image sets the repo and tag of the vault-secrets-operator image to use for the controller.
     image:
       repository: hashicorp/vault-secrets-operator
-      tag: 0.3.2
+      tag: 0.3.3
 
     # Configures the client cache which is used by the controller to cache (and potentially persist) vault tokens that
     # are the result of using the VaultAuthMethod. This enables re-use of Vault Tokens

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,7 +19,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.4
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,4 +16,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: hashicorp/vault-secrets-operator
-  newTag: 0.3.2
+  newTag: 0.3.3

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -40,6 +40,8 @@ function checkVersion {
  fi
 
  local doc="$(cat ${filename})"
+ local actual
+ local maybe_tag
  echo "* Checking version ${version} in ${filename}"
  for query in "${@:3}"
  do

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -15,6 +15,13 @@ case "${VERSION}" in
     ;;
 esac
 
+case "{KUBE_RBAC_PROXY_VERSION}" in
+  "")
+    echo "KUBE_RBAC_PROXY_VERSION variable must be set" >&2
+    exit 1
+    ;;
+esac
+
 ROOT_DIR="${0%/*}"
 # update PATH to prefer scripts relative to this one e.g. yq
 export PATH="${ROOT_DIR}:${PATH}"
@@ -25,6 +32,7 @@ KUSTOMIZE_ROOT="${KUSTOMIZE_ROOT-$(readlink -f ${ROOT_DIR}/../config)}"
 _result=0
 function checkVersion {
  local filename="${1}"
+ local version="${2}"
  if ! [ -e ${filename} ]; then
    echo "${filename} file does not exist'" >&2
    _result=1
@@ -32,19 +40,30 @@ function checkVersion {
  fi
 
  local doc="$(cat ${filename})"
- echo "* Checking version(s) in ${filename}"
- for query in "${@:2}"
+ echo "* Checking version ${version} in ${filename}"
+ for query in "${@:3}"
  do
    actual="$(echo "${doc}" | yq "${query}")"
-   if [ "${actual}" != "${VERSION}" ]; then
-        echo "yq-expr '${query}' does not match expected '${VERSION}', actual='${actual}'" >&2
+   # sometimes the value might be for an image+tag
+   # e.g: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.4,
+   # in which case we only want the image's version/tag.
+   maybe_tag="$(echo "${actual}" | awk -F: '/.+:.+/{print $NF}')"
+   [ -n "${maybe_tag}" ] && actual="${maybe_tag}"
+   if [ "${actual}" != "${version}" ]; then
+        echo "yq-expr '${query}' does not match expected '${version}', actual='${actual}'" >&2
         _result=1
    fi
  done
 }
 
-checkVersion "${CHART_ROOT}/Chart.yaml" .version .appVersion
-checkVersion "${CHART_ROOT}/values.yaml" .controller.manager.image.tag
-checkVersion "${KUSTOMIZE_ROOT}/manager/kustomization.yaml" ".images.[] | select(.name == \"controller\") | .newTag"
+checkVersion "${CHART_ROOT}/Chart.yaml" "${VERSION}" .version .appVersion
+checkVersion "${CHART_ROOT}/values.yaml" "${VERSION}" .controller.manager.image.tag
+checkVersion "${KUSTOMIZE_ROOT}/manager/kustomization.yaml" "${VERSION}" \
+  ".images.[] | select(.name == \"controller\") | .newTag"
+
+# check RBAC proxy version/image
+checkVersion "${CHART_ROOT}/values.yaml" "${KUBE_RBAC_PROXY_VERSION}" .controller.kubeRbacProxy.image.tag
+checkVersion "${KUSTOMIZE_ROOT}/default/manager_auth_proxy_patch.yaml" \
+  "${KUBE_RBAC_PROXY_VERSION}"  ".spec.template.spec.containers.[] | select(.name == \"kube-rbac-proxy\") | .image"
 
 exit $_result


### PR DESCRIPTION
Includes important security patches applied to Golang and related dependencies.

- critically addresses: CVE-2023-39325

- upgrades kube-rbac-proxy to v0.14.4 addresses the issues mentioned above.