### PR TITLE
Include the tls-ca-bundle.pem from ubi-minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ ENTRYPOINT ["/vault-secrets-operator"]
 
 # ubi build image
 # -----------------------------------
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as build-ubi
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2-750.1697625013 as build-ubi
 RUN microdnf update --nodocs && microdnf install ca-certificates --nodocs
 
 # ubi release image

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,11 @@ USER 65532:65532
 
 ENTRYPOINT ["/vault-secrets-operator"]
 
+# ubi build image
+# -----------------------------------
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as build-ubi
+RUN microdnf update --nodocs && microdnf install ca-certificates --nodocs
+
 # ubi release image
 # -----------------------------------
 FROM registry.access.redhat.com/ubi9/ubi-micro:9.2-15.1696515526 as release-ubi
@@ -90,6 +95,7 @@ WORKDIR /
 
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /
 COPY LICENSE /licenses/copyright.txt
+COPY --from=build-ubi /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 
 USER 65532:65532
 


### PR DESCRIPTION
The ubi-micro base image does not include a trusted ca-bundle. This PR adds support for copying the latest bundle from `ubi-minimal:latest` into the target UBI VSO image.

Closes: #412 