### PR TITLE
Release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.4 (October 19th, 2023)
+Fix:
+
+* UBI image: Include the tls-ca-bundle.pem from ubi-minimal: [GH-415](https://github.com/hashicorp/vault-secrets-operator/pull/415)
+
 ## 0.3.3 (October 17th, 2023)
 Fix:
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault-secrets-operator
-version: 0.3.3
-appVersion: "0.3.3"
+version: 0.3.4
+appVersion: "0.3.4"
 kubeVersion: ">=1.22.0-0"
 description: Official Vault Secrets Operator Chart
 type: application

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -100,7 +100,7 @@ controller:
     # Image sets the repo and tag of the vault-secrets-operator image to use for the controller.
     image:
       repository: hashicorp/vault-secrets-operator
-      tag: 0.3.3
+      tag: 0.3.4
 
     # Configures the client cache which is used by the controller to cache (and potentially persist) vault tokens that
     # are the result of using the VaultAuthMethod. This enables re-use of Vault Tokens

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,4 +16,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: hashicorp/vault-secrets-operator
-  newTag: 0.3.3
+  newTag: 0.3.4


### PR DESCRIPTION
Fix:

* UBI image: Include the tls-ca-bundle.pem from ubi-minimal: [GH-415](https://github.com/hashicorp/vault-secrets-operator/pull/415)