### PR TITLE
Fix AppRole secret reference

### DIFF
--- a/internal/credentials/vault/approle.go
+++ b/internal/credentials/vault/approle.go
@@ -38,7 +38,7 @@ func (l *AppRoleCredentialProvider) Init(ctx context.Context, client ctrlclient.
 
 	// We use the UID of the secret which holds the AppRole Role's secret_id for the provider UID
 	key := ctrlclient.ObjectKey{
-		Namespace: l.providerNamespace,
+		Namespace: l.authObj.Namespace,
 		Name:      l.authObj.Spec.AppRole.SecretRef,
 	}
 	secret, err := helpers.GetSecret(ctx, client, key)
@@ -56,7 +56,7 @@ func (l *AppRoleCredentialProvider) GetCreds(ctx context.Context, client ctrlcli
 	// GetCreds in case the SecretID has changed since the last time the client token was
 	// generated. In the case of AppRole this is assumed to be common.
 	key := ctrlclient.ObjectKey{
-		Namespace: l.providerNamespace,
+		Namespace: l.authObj.Namespace,
 		Name:      l.authObj.Spec.AppRole.SecretRef,
 	}
 	secret, err := helpers.GetSecret(ctx, client, key)


### PR DESCRIPTION
Hi!

AppRole has `SecretRef` field, which contains name of the k8s secret. When i create AuthStatic in different namespace, i can't get secret, because operator try to get secret from current namespace.

For example:
VaultAuth with name `default` placed in vault-secrets-operator namespace, also i've created k8s secret in this namespace. When i create AuthStatic with `vault-secrets-operator/default` auth reference in different namespace, i've got an error `Failed to get secret ` because it try to get secret from namespace StaticAuth CR.