### PR TITLE
Remove unneeded instantiation of the VSO ConfigMap watcher

### DIFF
--- a/internal/vault/configmap.go
+++ b/internal/vault/configmap.go
@@ -113,6 +113,12 @@ func GetManagerConfigMap(ctx context.Context, c client.Client) (*corev1.ConfigMa
 }
 
 func WatchManagerConfigMap(ctx context.Context, c client.WithWatch) (watch.Interface, error) {
+	// This function is no longer being used, as we look at alternative approaches to
+	// the token cache revocation on termination use-case. Seems to cause a spike in
+	// CPU usage after VSO has been running for an hour or so. The time spent in
+	// epoll_wait and nanosleep syscalls increases by a factor of 20 over a period of
+	// ~1h compare to the nominal state.
+	// TODO: leaving this here as reminder to re-evaluate the approach.
 	list, err := getManagerConfigMapList(ctx, c)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -215,14 +215,6 @@ func main() {
 			setupLog.Error(err, "Failed to setup the Vault ClientFactory")
 			os.Exit(1)
 		}
-
-		watcher, err := vclient.WatchManagerConfigMap(ctx, defaultClient)
-		if err != nil {
-			setupLog.Error(err, "Failed to setup the manager ConfigMap watcher")
-			os.Exit(1)
-		}
-
-		go vclient.WaitForManagerConfigMapModified(ctx, watcher, defaultClient, vclient.OnShutDown(clientFactory))
 	}
 
 	hmacValidator := helpers.NewHMACValidator(cfc.StorageConfig.HMACSecretObjKey)


### PR DESCRIPTION
In #202 we added a feature that revoked the client cache on VSO termination (deployment deletion). The watcher seems to cause a CPU usage spike after VSO has been running for ~1hr. From an strace of an affected VSO process we see that time in `epoll_wait` and `nanosleep` jump 20x from their initial values.

In this PR, we no longer instantiate the ConfigMap watcher.

Partial revert of 8459895c6cf7a7775b8ec14f8dd7a334ef822fa3

Closes #398