### PR TITLE
UBI: don't block when upgrading ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ ENTRYPOINT ["/vault-secrets-operator"]
 # ubi build image
 # -----------------------------------
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2-750.1697625013 as build-ubi
-RUN microdnf update --nodocs && microdnf install ca-certificates --nodocs
+RUN microdnf --refresh --assumeyes upgrade ca-certificates
 
 # ubi release image
 # -----------------------------------


### PR DESCRIPTION
The invocation of the microdnf command in the UBI build image was blocked waiting for user input when updating the container's RPMs. This PR fixes that, and removes the need to upgrade the the entire container, instead opting to update the ca-certificates package only.