### PR TITLE
Upgrade kube-rbac-proxy to v0.15.0

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -61,7 +61,7 @@ controller:
     # Image sets the repo and tag of the kube-rbac-proxy image to use for the controller.
     image:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.14.4
+      tag: v0.15.0
 
     # Configures the default resources for the kube rbac proxy container.
     # For more information on configuring resources, see the K8s documentation:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,7 +19,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.4
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
Since we are releasing v0.4.0 imminently, it might be a good time to update to the latest kube-rbac-proxy release: https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.15.0