### PR TITLE
build: bump the kube-rbac-proxy version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.0.0-dev
-KUBE_RBAC_PROXY_VERSION = v0.14.4
+KUBE_RBAC_PROXY_VERSION = v0.15.0
 
 GO_VERSION = $(shell cat .go-version)
 


### PR DESCRIPTION
Make make `check-versions` happy, again.