### PR TITLE
Add a configurable delay before writing a dynamic secret

### DIFF
--- a/api/v1beta1/vaultdynamicsecret_types.go
+++ b/api/v1beta1/vaultdynamicsecret_types.go
@@ -60,6 +60,11 @@ type VaultDynamicSecretSpec struct {
 	RolloutRestartTargets []RolloutRestartTarget `json:"rolloutRestartTargets,omitempty"`
 	// Destination provides configuration necessary for syncing the Vault secret to Kubernetes.
 	Destination Destination `json:"destination"`
+	// Delay adds an artifical delay between fetching the secret and writing it to Kubernetes.
+	// This is to cater for services that are eventually consistent
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Minimum=0
+	Delay int `json:"delay,omitempty"`
 }
 
 // VaultDynamicSecretStatus defines the observed state of VaultDynamicSecret

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -45,6 +45,13 @@ spec:
                   roles", or "static credentials", with a request path that contains
                   "static-creds".
                 type: boolean
+              delay:
+                default: 0
+                description: Delay adds an artifical delay between fetching the secret
+                  and writing it to Kubernetes. This is to cater for services that
+                  are eventually consistent
+                minimum: 0
+                type: integer
               destination:
                 description: Destination provides configuration necessary for syncing
                   the Vault secret to Kubernetes.

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -45,6 +45,13 @@ spec:
                   roles", or "static credentials", with a request path that contains
                   "static-creds".
                 type: boolean
+              delay:
+                default: 0
+                description: Delay adds an artifical delay between fetching the secret
+                  and writing it to Kubernetes. This is to cater for services that
+                  are eventually consistent
+                minimum: 0
+                type: integer
               destination:
                 description: Destination provides configuration necessary for syncing
                   the Vault secret to Kubernetes.

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -345,6 +345,10 @@ func (r *VaultDynamicSecretReconciler) syncSecret(ctx context.Context, c vault.C
 		}
 	}
 
+	if o.Spec.Delay > 0 {
+		sleepTime := time.Duration(o.Spec.Delay) * time.Second
+		time.Sleep(sleepTime)
+	}
 	if err := helpers.SyncSecret(ctx, r.Client, o, data); err != nil {
 		return nil, false, err
 	}

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -459,6 +459,7 @@ _Appears in:_
 | `allowStaticCreds` _boolean_ | AllowStaticCreds should be set when syncing credentials that are periodically rotated by the Vault server, rather than created upon request. These secrets are sometimes referred to as "static roles", or "static credentials", with a request path that contains "static-creds". |
 | `rolloutRestartTargets` _[RolloutRestartTarget](#rolloutrestarttarget) array_ | RolloutRestartTargets should be configured whenever the application(s) consuming the Vault secret does not support dynamically reloading a rotated secret. In that case one, or more RolloutRestartTarget(s) can be configured here. The Operator will trigger a "rollout-restart" for each target whenever the Vault secret changes between reconciliation events. See RolloutRestartTarget for more details. |
 | `destination` _[Destination](#destination)_ | Destination provides configuration necessary for syncing the Vault secret to Kubernetes. |
+| `delay` _integer_ | Delay adds an artifical delay between fetching the secret and writing it to Kubernetes. This is to cater for services that are eventually consistent |
 
 
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vault-secrets-operator/issues/271

Some services (such as AWS IAM) are eventually consistent and require some time between generating the secret, and using the secret.

Without this delay our services can't access AWS for a short while immediately after the secret rotation happens.

I'm not sure if my tests are sane. They could introduce some flakiness. 