### PR TITLE
rename max-concurrent-reconciles-vds to max-concurrent-reconciles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+Improvements:
+* Manager: setting `controller.manager.maxConcurrentReconciles` now applies to all Syncable Secret controllers. The previous flag for the manager `--max-concurrent-reconciles-vds` is now deprecated and replaced by `--max-concurrent-reconciles` which applies to all controllers. [GH-483](https://github.com/hashicorp/vault-secrets-operator/pull/483)
+
 ## 0.4.0 (November 16th, 2023)
 
 Features:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
         - --client-cache-size={{ .Values.controller.manager.clientCache.cacheSize }}
         {{- end }}
         {{- if .Values.controller.manager.maxConcurrentReconciles }}
-        - --max-concurrent-reconciles-global={{ .Values.controller.manager.maxConcurrentReconciles }}
+        - --max-concurrent-reconciles={{ .Values.controller.manager.maxConcurrentReconciles }}
         {{- end }}
         {{- if .Values.controller.manager.extraArgs }}
         {{- toYaml .Values.controller.manager.extraArgs | nindent 8 }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
         - --client-cache-size={{ .Values.controller.manager.clientCache.cacheSize }}
         {{- end }}
         {{- if .Values.controller.manager.maxConcurrentReconciles }}
-        - --max-concurrent-reconciles-vds={{ .Values.controller.manager.maxConcurrentReconciles }}
+        - --max-concurrent-reconciles-global={{ .Values.controller.manager.maxConcurrentReconciles }}
         {{- end }}
         {{- if .Values.controller.manager.extraArgs }}
         {{- toYaml .Values.controller.manager.extraArgs | nindent 8 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -307,8 +307,7 @@ controller:
         # @type:  map
         headers: {}
 
-    # Defines the maximum number of concurrent reconciles by the controller.
-    # NOTE: Currently this is only used by the reconciliation logic of dynamic secrets.
+    # Defines the maximum number of concurrent reconciles for each controller.
     #
     # default: 100
     # @type: integer

--- a/controllers/hcpvaultsecretsapp_controller.go
+++ b/controllers/hcpvaultsecretsapp_controller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -152,10 +153,11 @@ func (r *HCPVaultSecretsAppReconciler) Reconcile(ctx context.Context, req ctrl.R
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *HCPVaultSecretsAppReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *HCPVaultSecretsAppReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&secretsv1beta1.HCPVaultSecretsApp{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithOptions(opts).
 		Complete(r)
 }
 

--- a/controllers/vaultpkisecret_controller.go
+++ b/controllers/vaultpkisecret_controller.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -304,14 +305,14 @@ func (r *VaultPKISecretReconciler) addFinalizer(ctx context.Context, l logr.Logg
 	return nil
 }
 
-// SetupWithManager sets up the controller with the Manager.
-func (r *VaultPKISecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *VaultPKISecretReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&secretsv1beta1.VaultPKISecret{}).
 		// Add metrics for create/update/delete of the resource
 		Watches(&secretsv1beta1.VaultPKISecret{},
 			&handler.InstrumentedEnqueueRequestForObject{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithOptions(opts).
 		Complete(r)
 }
 

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -152,10 +153,11 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}, nil
 }
 
-func (r *VaultStaticSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *VaultStaticSecretReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&secretsv1beta1.VaultStaticSecret{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithOptions(opts).
 		Complete(r)
 }
 

--- a/main.go
+++ b/main.go
@@ -272,6 +272,7 @@ func main() {
 	// `--max-concurrent-reconciles`.
 	vdsOverrideOpts := controller.Options{}
 	if vdsOptions.MaxConcurrentReconciles != defaultVaultDynamicSecretsConcurrency {
+		setupLog.Info("The flag --max-concurrent-reconciles-vds has been deprecated, but will still be honored to set the VDS controller concurrency, please use --max-concurrent-reconciles.")
 		vdsOverrideOpts = vdsOptions
 	} else {
 		vdsOverrideOpts = controllerOptions

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	persistenceModelDirectUnencrypted := "direct-unencrypted"
 	persistenceModelDirectEncrypted := "direct-encrypted"
 	defaultPersistenceModel := persistenceModelNone
-	vdsOptions := controller.Options{}
+	controllerOptions := controller.Options{}
 	cfc := vclient.DefaultCachingClientFactoryConfig()
 	startTime := time.Now()
 
@@ -83,8 +83,8 @@ func main() {
 		fmt.Sprintf(
 			"The type of client cache persistence model that should be employed."+
 				"choices=%v", []string{persistenceModelDirectUnencrypted, persistenceModelDirectEncrypted, persistenceModelNone}))
-	flag.IntVar(&vdsOptions.MaxConcurrentReconciles, "max-concurrent-reconciles-vds", 100,
-		"Maximum number of concurrent reconciles for the VaultDynamicSecrets controller.")
+	flag.IntVar(&controllerOptions.MaxConcurrentReconciles, "max-concurrent-reconciles-global", 100,
+		"Maximum number of concurrent reconciles for each controller.")
 	flag.BoolVar(&uninstall, "uninstall", false, "Run in uninstall mode")
 	flag.IntVar(&preDeleteHookTimeoutSeconds, "pre-delete-hook-timeout-seconds", 60,
 		"Pre-delete hook timeout in seconds")
@@ -235,7 +235,7 @@ func main() {
 		Scheme:        mgr.GetScheme(),
 		ClientFactory: clientFactory,
 		Recorder:      mgr.GetEventRecorderFor("VaultPKISecret"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, controllerOptions); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "VaultPKISecret")
 		os.Exit(1)
 	}
@@ -263,7 +263,7 @@ func main() {
 		Recorder:      mgr.GetEventRecorderFor("VaultDynamicSecret"),
 		ClientFactory: clientFactory,
 		HMACValidator: hmacValidator,
-	}).SetupWithManager(mgr, vdsOptions); err != nil {
+	}).SetupWithManager(mgr, controllerOptions); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "VaultDynamicSecret")
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -43,6 +43,13 @@ var (
 	cleanupLog = ctrl.Log.WithName("cleanup")
 )
 
+const (
+	// The default MaxConcurrentReconciles for the VDS controller.
+	defaultVaultDynamicSecretsConcurrency = 100
+	// The default MaxConcurrentReconciles for Syncable Secrets controllers.
+	defaultSyncableSecretsConcurrency = 100
+)
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
@@ -56,6 +63,7 @@ func main() {
 	persistenceModelDirectEncrypted := "direct-encrypted"
 	defaultPersistenceModel := persistenceModelNone
 	controllerOptions := controller.Options{}
+	vdsOptions := controller.Options{}
 	cfc := vclient.DefaultCachingClientFactoryConfig()
 	startTime := time.Now()
 
@@ -83,7 +91,9 @@ func main() {
 		fmt.Sprintf(
 			"The type of client cache persistence model that should be employed."+
 				"choices=%v", []string{persistenceModelDirectUnencrypted, persistenceModelDirectEncrypted, persistenceModelNone}))
-	flag.IntVar(&controllerOptions.MaxConcurrentReconciles, "max-concurrent-reconciles-global", 100,
+	flag.IntVar(&vdsOptions.MaxConcurrentReconciles, "max-concurrent-reconciles-vds", defaultVaultDynamicSecretsConcurrency,
+		"Maximum number of concurrent reconciles for the VaultDynamicSecrets controller.")
+	flag.IntVar(&controllerOptions.MaxConcurrentReconciles, "max-concurrent-reconciles", defaultSyncableSecretsConcurrency,
 		"Maximum number of concurrent reconciles for each controller.")
 	flag.BoolVar(&uninstall, "uninstall", false, "Run in uninstall mode")
 	flag.IntVar(&preDeleteHookTimeoutSeconds, "pre-delete-hook-timeout-seconds", 60,
@@ -226,7 +236,7 @@ func main() {
 		SecretDataBuilder: secretDataBuilder,
 		HMACValidator:     hmacValidator,
 		ClientFactory:     clientFactory,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, controllerOptions); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "VaultStaticSecret")
 		os.Exit(1)
 	}
@@ -257,13 +267,22 @@ func main() {
 		setupLog.Error(err, "Unable to create controller", "controller", "VaultConnection")
 		os.Exit(1)
 	}
+	// This allows the user to customize VDS concurrency independently.
+	// It is mostly here to allow for backward compatibility from when we introduced the flag
+	// `--max-concurrent-reconciles`.
+	vdsOverrideOpts := controller.Options{}
+	if vdsOptions.MaxConcurrentReconciles != defaultVaultDynamicSecretsConcurrency {
+		vdsOverrideOpts = vdsOptions
+	} else {
+		vdsOverrideOpts = controllerOptions
+	}
 	if err = (&controllers.VaultDynamicSecretReconciler{
 		Client:        mgr.GetClient(),
 		Scheme:        mgr.GetScheme(),
 		Recorder:      mgr.GetEventRecorderFor("VaultDynamicSecret"),
 		ClientFactory: clientFactory,
 		HMACValidator: hmacValidator,
-	}).SetupWithManager(mgr, controllerOptions); err != nil {
+	}).SetupWithManager(mgr, vdsOverrideOpts); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "VaultDynamicSecret")
 		os.Exit(1)
 	}
@@ -281,7 +300,7 @@ func main() {
 		SecretDataBuilder: secretDataBuilder,
 		HMACValidator:     hmacValidator,
 		MinRefreshAfter:   minRefreshAfterHVSA,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, controllerOptions); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HCPVaultSecretsApp")
 		os.Exit(1)
 	}

--- a/test/unit/deployment.bats
+++ b/test/unit/deployment.bats
@@ -162,7 +162,7 @@ load _helpers
       . | tee /dev/stderr |
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
-   local actual=$(echo "$object" | yq 'contains(["--max-concurrent-reconciles-vds"])' | tee /dev/stderr)
+   local actual=$(echo "$object" | yq 'contains(["--max-concurrent-reconciles-global"])' | tee /dev/stderr)
     [ "${actual}" = "false" ]
 }
 
@@ -174,7 +174,7 @@ load _helpers
       . | tee /dev/stderr |
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
-   local actual=$(echo "$object" | yq 'contains(["--max-concurrent-reconciles-vds=5"])' | tee /dev/stderr)
+   local actual=$(echo "$object" | yq 'contains(["--max-concurrent-reconciles-global=5"])' | tee /dev/stderr)
     [ "${actual}" = "true" ]
 }
 

--- a/test/unit/deployment.bats
+++ b/test/unit/deployment.bats
@@ -162,7 +162,7 @@ load _helpers
       . | tee /dev/stderr |
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
-   local actual=$(echo "$object" | yq 'contains(["--max-concurrent-reconciles-global"])' | tee /dev/stderr)
+   local actual=$(echo "$object" | yq 'contains(["--max-concurrent-reconciles"])' | tee /dev/stderr)
     [ "${actual}" = "false" ]
 }
 
@@ -174,7 +174,7 @@ load _helpers
       . | tee /dev/stderr |
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
-   local actual=$(echo "$object" | yq 'contains(["--max-concurrent-reconciles-global=5"])' | tee /dev/stderr)
+   local actual=$(echo "$object" | yq 'contains(["--max-concurrent-reconciles=5"])' | tee /dev/stderr)
     [ "${actual}" = "true" ]
 }
 


### PR DESCRIPTION
Renames the controller manager flag `--max-concurrent-reconciles-vds` to `--max-concurrent-reconciles` and applies it to VPS, VSS, VHCPSA and VDS controllers.
This has the effect of enabling the all Syncable Secret controllers to process in parallel which we've tested at scale successfully and was causing scaling issues in the current architecture.

The original flag `--max-concurrent-reconciles-vds` is preserved for backward compatibility and will override the new flag for the VDS controller only.

The helm `values.yaml` is updated to reflect the new behaviour of `controller.manager.maxConcurrentReconciles`.