### PR TITLE
prefix all helm helper functions with vso to avoid subchart name collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Improvements:
 * Manager: setting `controller.manager.maxConcurrentReconciles` now applies to all Syncable Secret controllers. The previous flag for the manager `--max-concurrent-reconciles-vds` is now deprecated and replaced by `--max-concurrent-reconciles` which applies to all controllers. [GH-483](https://github.com/hashicorp/vault-secrets-operator/pull/483)
 
+Fix:
+* Helm: prefix all helper functions with `vso` to avoid subhart name collisions: [GH-487](https://github.com/hashicorp/vault-secrets-operator/pull/487)
+
 ## 0.4.0 (November 16th, 2023)
 
 Features:

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -6,7 +6,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "chart.name" -}}
+{{- define "vso.chart.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -15,7 +15,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "chart.fullname" -}}
+{{- define "vso.chart.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -31,16 +31,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "chart.chart" -}}
+{{- define "vso.chart.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "chart.labels" -}}
-helm.sh/chart: {{ include "chart.chart" . }}
-{{ include "chart.selectorLabels" . }}
+{{- define "vso.chart.labels" -}}
+helm.sh/chart: {{ include "vso.chart.chart" . }}
+{{ include "vso.chart.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -50,17 +50,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "chart.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "chart.name" . }}
+{{- define "vso.chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vso.chart.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "chart.serviceAccountName" -}}
+{{- define "vso.chart.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "vso.chart.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
@@ -71,7 +71,7 @@ Create the name of the service account to use
 VaultAuthMethod Spec
 ** Keep this up to date when we make changes to the VaultAuthMethod Spec **
 */}}
-{{- define "operator.vaultAuthMethod" -}}
+{{- define "vso.vaultAuthMethod" -}}
   {{- $cur := index . 0 }}
   {{- $serviceAccount := index . 1 }}
   {{- $root := index . 2 }}
@@ -149,7 +149,7 @@ VaultAuthMethod Spec
 imagePullSecrets generates pull secrets from either string or map values.
 A map value must be indexable by the key 'name'.
 */}}
-{{- define "imagePullSecrets" -}}
+{{- define "vso.imagePullSecrets" -}}
 {{ with .Values.controller.imagePullSecrets -}}
 imagePullSecrets:
 {{- range . -}}

--- a/chart/templates/default-transit-auth-method.yaml
+++ b/chart/templates/default-transit-auth-method.yaml
@@ -7,21 +7,21 @@
 apiVersion: secrets.hashicorp.com/v1beta1
 kind: VaultAuth
 metadata:
-  name: {{ include "chart.fullname" . }}-default-transit-auth
+  name: {{ include "vso.chart.fullname" . }}-default-transit-auth
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: controller-manager
     component: controller-manager
     app.kubernetes.io/component: controller-manager
     cacheStorageEncryption: "true"
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
 spec:
   vaultConnectionRef: {{ .Values.controller.manager.clientCache.storageEncryption.vaultConnectionRef }}
   namespace: {{ .Values.controller.manager.clientCache.storageEncryption.namespace }}
   method: {{ .Values.controller.manager.clientCache.storageEncryption.method }}
   mount: {{ .Values.controller.manager.clientCache.storageEncryption.mount }}
-  {{- $kubeServiceAccount := .Values.controller.manager.clientCache.storageEncryption.kubernetes.serviceAccount | default (printf "%s-controller-manager" (include "chart.fullname" .)) -}}
-  {{- include "operator.vaultAuthMethod" (list .Values.controller.manager.clientCache.storageEncryption $kubeServiceAccount . ) }}
+  {{- $kubeServiceAccount := .Values.controller.manager.clientCache.storageEncryption.kubernetes.serviceAccount | default (printf "%s-controller-manager" (include "vso.chart.fullname" .)) -}}
+  {{- include "vso.vaultAuthMethod" (list .Values.controller.manager.clientCache.storageEncryption $kubeServiceAccount . ) }}
   storageEncryption:
     keyName: {{ .Values.controller.manager.clientCache.storageEncryption.keyName }}
     mount: {{ .Values.controller.manager.clientCache.storageEncryption.transitMount }}

--- a/chart/templates/default-vault-auth-method.yaml
+++ b/chart/templates/default-vault-auth-method.yaml
@@ -13,11 +13,11 @@ metadata:
     control-plane: controller-manager
     component: controller-manager
     app.kubernetes.io/component: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
 spec:
   namespace: {{ .Values.defaultAuthMethod.namespace }}
   method: {{ .Values.defaultAuthMethod.method }}
   mount: {{ .Values.defaultAuthMethod.mount }}
   {{- $kubeServiceAccount := .Values.defaultAuthMethod.kubernetes.serviceAccount }}
-  {{- include "operator.vaultAuthMethod" (list .Values.defaultAuthMethod $kubeServiceAccount . ) }}
+  {{- include "vso.vaultAuthMethod" (list .Values.defaultAuthMethod $kubeServiceAccount . ) }}
 {{- end }}

--- a/chart/templates/default-vault-connection.yaml
+++ b/chart/templates/default-vault-connection.yaml
@@ -13,7 +13,7 @@ metadata:
     control-plane: controller-manager
     component: controller-manager
     app.kubernetes.io/component: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
 spec:
   address: {{ .Values.defaultVaultConnection.address }}
   skipTLSVerify: {{ .Values.defaultVaultConnection.skipTLSVerify }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -6,27 +6,27 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "chart.fullname" . }}-controller-manager
+  name: {{ include "vso.chart.fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-  {{- include "chart.labels" . | nindent 4 }}
-{{ include "imagePullSecrets" .}}
+  {{- include "vso.chart.labels" . | nindent 4 }}
+{{ include "vso.imagePullSecrets" .}}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "chart.fullname" . }}-controller-manager
+  name: {{ include "vso.chart.fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controller.replicas }}
   selector:
     matchLabels:
       control-plane: controller-manager
-    {{- include "chart.selectorLabels" . | nindent 6 }}
+    {{- include "vso.chart.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
@@ -34,7 +34,7 @@ spec:
       {{- if  .Values.controller.extraLabels }}
         {{- toYaml .Values.controller.extraLabels | nindent 8 }}
       {{- end }}
-      {{- include "chart.selectorLabels" . | nindent 8 }}
+      {{- include "vso.chart.selectorLabels" . | nindent 8 }}
       annotations:
         kubectl.kubernetes.io/default-container: manager
       {{- if .Values.controller.annotations }}
@@ -115,7 +115,7 @@ spec:
           name: podinfo
       securityContext:
         {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
-      serviceAccountName: {{ include "chart.fullname" . }}-controller-manager
+      serviceAccountName: {{ include "vso.chart.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
       {{- if .Values.controller.hostAliases }}
       hostAliases:
@@ -147,10 +147,10 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "chart.fullname" . }}-pre-delete-controller-cleanup
+  name: {{ include "vso.chart.fullname" . }}-pre-delete-controller-cleanup
   namespace: {{ .Release.Namespace }}
   labels:
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -159,9 +159,9 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ include "chart.fullname" . }}-pre-delete-controller-cleanup
+      name: {{ include "vso.chart.fullname" . }}-pre-delete-controller-cleanup
     spec:
-      serviceAccountName: {{ include "chart.fullname" . }}-controller-manager
+      serviceAccountName: {{ include "vso.chart.fullname" . }}-controller-manager
       securityContext:
         {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
       containers:

--- a/chart/templates/leader-election-rbac.yaml
+++ b/chart/templates/leader-election-rbac.yaml
@@ -6,11 +6,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "chart.fullname" . }}-leader-election-role
+  name: {{ include "vso.chart.fullname" . }}-leader-election-role
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""
@@ -47,16 +47,16 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "chart.fullname" . }}-leader-election-rolebinding
+  name: {{ include "vso.chart.fullname" . }}-leader-election-rolebinding
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: '{{ include "chart.fullname" . }}-leader-election-role'
+  name: '{{ include "vso.chart.fullname" . }}-leader-election-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "chart.fullname" . }}-controller-manager'
+  name: '{{ include "vso.chart.fullname" . }}-controller-manager'
   namespace: {{ .Release.Namespace }}

--- a/chart/templates/manager-config.yaml
+++ b/chart/templates/manager-config.yaml
@@ -6,11 +6,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "chart.fullname" . }}-manager-config
+  name: {{ include "vso.chart.fullname" . }}-manager-config
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
 data:
   controller_manager_config.yaml: |
     apiVersion: controller-runtime.sigs.k8s.io/v1beta1

--- a/chart/templates/manager-rbac.yaml
+++ b/chart/templates/manager-rbac.yaml
@@ -5,10 +5,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "chart.fullname" . }}-manager-role
+  name: {{ include "vso.chart.fullname" . }}-manager-role
   labels:
     app.kubernetes.io/component: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""
@@ -268,15 +268,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "chart.fullname" . }}-manager-rolebinding
+  name: {{ include "vso.chart.fullname" . }}-manager-rolebinding
   labels:
     app.kubernetes.io/component: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: '{{ include "chart.fullname" . }}-manager-role'
+  name: '{{ include "vso.chart.fullname" . }}-manager-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "chart.fullname" . }}-controller-manager'
+  name: '{{ include "vso.chart.fullname" . }}-controller-manager'
   namespace: {{ .Release.Namespace }}

--- a/chart/templates/metrics-reader-rbac.yaml
+++ b/chart/templates/metrics-reader-rbac.yaml
@@ -6,10 +6,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "chart.fullname" . }}-metrics-reader
+  name: {{ include "vso.chart.fullname" . }}-metrics-reader
   labels:
     app.kubernetes.io/component: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
 rules:
 - nonResourceURLs:
   - /metrics

--- a/chart/templates/metrics-service.yaml
+++ b/chart/templates/metrics-service.yaml
@@ -6,16 +6,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "chart.fullname" . }}-metrics-service
+  name: {{ include "vso.chart.fullname" . }}-metrics-service
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: controller-manager
     control-plane: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.metricsService.type }}
   selector:
     control-plane: controller-manager
-  {{- include "chart.selectorLabels" . | nindent 4 }}
+  {{- include "vso.chart.selectorLabels" . | nindent 4 }}
   ports:
 	{{- .Values.metricsService.ports | toYaml | nindent 2 -}}

--- a/chart/templates/prometheus-servicemonitor.yaml
+++ b/chart/templates/prometheus-servicemonitor.yaml
@@ -8,12 +8,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "chart.fullname" . }}-controller-manager-metrics-monitor
+  name: {{ include "vso.chart.fullname" . }}-controller-manager-metrics-monitor
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: controller-manager
     app.kubernetes.io/component: controller-manager
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "vso.chart.labels" . | nindent 4 }}
     {{- /* update the selectors docs in values.yaml whenever the defaults below change. */ -}}
     {{- $selectors := .Values.telemetry.serviceMonitor.selectors }}
     {{- if $selectors }}

--- a/chart/templates/proxy-rbac.yaml
+++ b/chart/templates/proxy-rbac.yaml
@@ -6,10 +6,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "chart.fullname" . }}-proxy-role
+  name: {{ include "vso.chart.fullname" . }}-proxy-role
   labels:
     app.kubernetes.io/component: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -27,15 +27,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "chart.fullname" . }}-proxy-rolebinding
+  name: {{ include "vso.chart.fullname" . }}-proxy-rolebinding
   labels:
     app.kubernetes.io/component: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "vso.chart.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: '{{ include "chart.fullname" . }}-proxy-role'
+  name: '{{ include "vso.chart.fullname" . }}-proxy-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "chart.fullname" . }}-controller-manager'
+  name: '{{ include "vso.chart.fullname" . }}-controller-manager'
   namespace: {{ .Release.Namespace }}

--- a/chart/templates/tests/test-runner.yaml
+++ b/chart/templates/tests/test-runner.yaml
@@ -6,11 +6,11 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ template "chart.fullname" . }}-test
+  name: {{ template "vso.chart.fullname" . }}-test
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "chart.name" . }}
-    chart: {{ template "chart.chart" . }}
+    app: {{ template "vso.chart.name" . }}
+    chart: {{ template "vso.chart.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:


### PR DESCRIPTION
prefix all helm helper functions with vso to avoid subchart name collision, also renames the function `operator.vaultAuthMethod` to `vso.vaultAuthMethod`.

There seems to be some precedent in other charts, for example the [wordpress chart](https://github.com/bitnami/charts/tree/main/bitnami/wordpress) has a mariadb sub chart, and all of the helpers are prefixed e.g: [https://github.com/bitnami/charts/blob/4caf014953a4f310368b68bcfb4edc576081ea9f/bitnami/wordpress/templates/_helpers.tpl#L12C9-L12](https://github.com/bitnami/charts/blob/4caf014953a4f310368b68bcfb4edc576081ea9f/bitnami/wordpress/templates/_helpers.tpl#L12C9-L12C9)

Fixes #484
Fixes #395 