### PR TITLE
VDS: fix compute static-creds rotation horizon

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -21,6 +21,8 @@ var (
 	_                      error = (*LeaseTruncatedError)(nil)
 	random                       = rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
 	requeueDurationOnError       = time.Second * 5
+	// used by monkey patching unit tests
+	nowFunc = time.Now
 )
 
 const renewalPercentCap = 90

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -41,30 +41,31 @@ func (l *LeaseTruncatedError) Error() string {
 
 // computeMaxJitter with max as 10% of the duration, and jitter a random amount
 // between 0-10%
-func computeMaxJitter(duration time.Duration) (max float64, jitter uint64) {
-	return computeMaxJitterWithPercent(duration, 0.1)
+func computeMaxJitter(duration time.Duration) (maxHorizon float64, jitter uint64) {
+	return computeMaxJitterWithPercent(duration, 0.10)
 }
 
 // computeMaxJitter with max as a percentage (percent) of the duration, and
 // jitter a random amount between 0 up to percent
-func computeMaxJitterWithPercent(duration time.Duration, percent float64) (max float64, jitter uint64) {
-	max = percent * float64(duration.Nanoseconds())
-	u := uint64(max)
+func computeMaxJitterWithPercent(duration time.Duration, percent float64) (maxHorizon float64, jitter uint64) {
+	nanos := duration.Nanoseconds()
+	maxHorizon = percent * float64(nanos)
+	u := uint64(maxHorizon)
 	if u == 0 {
 		jitter = 0
 	} else {
 		jitter = uint64(random.Int63()) % u
 	}
-	return max, jitter
+	return maxHorizon, jitter
 }
 
 // computeHorizonWithJitter returns a time.Duration minus a random offset, with an
 // additional random jitter added to reduce pressure on the Reconciler.
 // based https://github.com/hashicorp/vault/blob/03d2be4cb943115af1bcddacf5b8d79f3ec7c210/api/lifetime_watcher.go#L381
 func computeHorizonWithJitter(minDuration time.Duration) time.Duration {
-	max, jitter := computeMaxJitter(minDuration)
+	maxHorizon, jitter := computeMaxJitter(minDuration)
 
-	return minDuration - (time.Duration(max) + time.Duration(jitter))
+	return minDuration - (time.Duration(maxHorizon) + time.Duration(jitter))
 }
 
 // capRenewalPercent returns a renewalPercent capped between 0 and 90
@@ -82,12 +83,12 @@ func capRenewalPercent(renewalPercent int) (rp int) {
 }
 
 // computeDynamicHorizonWithJitter returns a time.Duration that is the specified
-// percentage of the lease duration, plus additional random jitter (up to 10% of
-// the lease), to ensure the horizon falls within the specified renewal window
+// percentage of the lease duration, minus some random jitter (up to 10% of
+// leaseDuration), to ensure the horizon falls within the specified renewal window
 func computeDynamicHorizonWithJitter(leaseDuration time.Duration, renewalPercent int) time.Duration {
-	max, jitter := computeMaxJitter(leaseDuration)
+	maxHorizon, jitter := computeMaxJitter(leaseDuration)
 
-	return computeStartRenewingAt(leaseDuration, renewalPercent) + time.Duration(max) - time.Duration(jitter)
+	return computeStartRenewingAt(leaseDuration, renewalPercent) + time.Duration(maxHorizon) - time.Duration(jitter)
 }
 
 // computeStartRenewingAt returns a time.Duration that is the specified

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -4,6 +4,7 @@
 package controllers
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,6 +31,9 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
+	if os.Getenv("SKIP_TEST_SUITE") != "" {
+		t.Skip("SKIP_TEST_SUITE is set")
+	}
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controller Suite")
 }

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -37,11 +37,11 @@ const (
 	vaultDynamicSecretFinalizer = "vaultdynamicsecret.secrets.hashicorp.com/finalizer"
 )
 
-// staticCredsMaxDurationForJitter should be used when computing the jitter
+// staticCredsJitterHorizon should be used when computing the jitter
 // duration for the static-creds rotation time horizon.
 var (
-	staticCredsMaxDurationForJitter = time.Second * 3
-	vdsJitterFactor                 = 0.05
+	staticCredsJitterHorizon = time.Second * 3
+	vdsJitterFactor          = 0.05
 )
 
 // VaultDynamicSecretReconciler reconciles a VaultDynamicSecret object
@@ -526,7 +526,7 @@ func (r *VaultDynamicSecretReconciler) computePostSyncHorizon(ctx context.Contex
 			} else {
 				horizon = time.Second * 1
 			}
-			_, jitter := computeMaxJitterWithPercent(staticCredsMaxDurationForJitter, vdsJitterFactor)
+			_, jitter := computeMaxJitterWithPercent(staticCredsJitterHorizon, vdsJitterFactor)
 			horizon += time.Duration(jitter)
 			logger.V(consts.LogLevelDebug).Info("StaticCreds",
 				"staticCredsMeta", staticCredsMeta, "horizon", horizon)
@@ -581,7 +581,7 @@ func computeRelativeHorizonWithJitter(o *secretsv1beta1.VaultDynamicSecret, minH
 		horizon = minHorizon
 	}
 	if o.Spec.AllowStaticCreds {
-		_, jitter := computeMaxJitterWithPercent(staticCredsMaxDurationForJitter, vdsJitterFactor)
+		_, jitter := computeMaxJitterWithPercent(staticCredsJitterHorizon, vdsJitterFactor)
 		horizon += time.Duration(jitter)
 	} else {
 		_, jitter := computeMaxJitterWithPercent(horizon, 0.05)

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -713,7 +713,7 @@ func Test_computeRelativeHorizonWithJitter(t *testing.T) {
 				},
 			},
 			wantMinHorizon: 30 * time.Second,
-			wantMaxHorizon: 30*time.Second + staticCredsMinDurationForJitter,
+			wantMaxHorizon: 30*time.Second + staticCredsMaxDurationForJitter,
 			wantInWindow:   true,
 		},
 		{
@@ -892,14 +892,8 @@ func TestVaultDynamicSecretReconciler_computePostSyncHorizon(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &VaultDynamicSecretReconciler{}
 			got := r.computePostSyncHorizon(ctx, tt.o)
-			if tt.o.Spec.AllowStaticCreds {
-				assert.LessOrEqualf(t, tt.wantMinHorizon, got, "computePostSyncHorizon(%v, %v)", ctx, tt.o)
-				assert.LessOrEqualf(t, got, tt.wantMaxHorizon, "computePostSyncHorizon(%v, %v)", ctx, tt.o)
-			} else {
-				assert.LessOrEqualf(t, tt.wantMinHorizon, got, "computePostSyncHorizon(%v, %v)", ctx, tt.o)
-				assert.GreaterOrEqualf(t, tt.wantMaxHorizon, got, "computePostSyncHorizon(%v, %v)", ctx, tt.o)
-
-			}
+			assert.GreaterOrEqualf(t, got, tt.wantMinHorizon, "computePostSyncHorizon(%v, %v)", ctx, tt.o)
+			assert.LessOrEqualf(t, got, tt.wantMaxHorizon, "computePostSyncHorizon(%v, %v)", ctx, tt.o)
 		})
 	}
 }

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -34,14 +34,14 @@ func Test_computeRelativeHorizon(t *testing.T) {
 					SecretLease: secretsv1beta1.VaultSecretLease{
 						LeaseDuration: 600,
 					},
-					LastRenewalTime: time.Now().Unix() - 600,
+					LastRenewalTime: nowFunc().Unix() - 600,
 				},
 				Spec: secretsv1beta1.VaultDynamicSecretSpec{
 					RenewalPercent: 67,
 				},
 			},
 			expectedInWindow: true,
-			expectedHorizon: time.Until(time.Unix(time.Now().Unix()-600, 0).Add(
+			expectedHorizon: time.Until(time.Unix(nowFunc().Unix()-600, 0).Add(
 				computeStartRenewingAt(time.Second*600, 67))),
 		},
 		"two thirds elapsed": {
@@ -50,15 +50,15 @@ func Test_computeRelativeHorizon(t *testing.T) {
 					SecretLease: secretsv1beta1.VaultSecretLease{
 						LeaseDuration: 600,
 					},
-					LastRenewalTime: time.Now().Unix() - 450,
+					LastRenewalTime: nowFunc().Unix() - 450,
 				},
 				Spec: secretsv1beta1.VaultDynamicSecretSpec{
 					RenewalPercent: 67,
 				},
 			},
 			expectedInWindow: true,
-			expectedHorizon: time.Unix(time.Now().Unix()-450, 0).Add(
-				computeStartRenewingAt(time.Second*600, 67)).Sub(time.Now()),
+			expectedHorizon: time.Unix(nowFunc().Unix()-450, 0).Add(
+				computeStartRenewingAt(time.Second*600, 67)).Sub(nowFunc()),
 		},
 		"one third elapsed": {
 			vds: &secretsv1beta1.VaultDynamicSecret{
@@ -66,15 +66,15 @@ func Test_computeRelativeHorizon(t *testing.T) {
 					SecretLease: secretsv1beta1.VaultSecretLease{
 						LeaseDuration: 600,
 					},
-					LastRenewalTime: time.Now().Unix() - 200,
+					LastRenewalTime: nowFunc().Unix() - 200,
 				},
 				Spec: secretsv1beta1.VaultDynamicSecretSpec{
 					RenewalPercent: 67,
 				},
 			},
 			expectedInWindow: false,
-			expectedHorizon: time.Unix(time.Now().Unix()-200, 0).Add(
-				computeStartRenewingAt(time.Second*600, 67)).Sub(time.Now()),
+			expectedHorizon: time.Unix(nowFunc().Unix()-200, 0).Add(
+				computeStartRenewingAt(time.Second*600, 67)).Sub(nowFunc()),
 		},
 		"past end of lease": {
 			vds: &secretsv1beta1.VaultDynamicSecret{
@@ -82,15 +82,15 @@ func Test_computeRelativeHorizon(t *testing.T) {
 					SecretLease: secretsv1beta1.VaultSecretLease{
 						LeaseDuration: 600,
 					},
-					LastRenewalTime: time.Now().Unix() - 800,
+					LastRenewalTime: nowFunc().Unix() - 800,
 				},
 				Spec: secretsv1beta1.VaultDynamicSecretSpec{
 					RenewalPercent: 67,
 				},
 			},
 			expectedInWindow: true,
-			expectedHorizon: time.Unix(time.Now().Unix()-800, 0).Add(
-				computeStartRenewingAt(time.Second*600, 67)).Sub(time.Now()),
+			expectedHorizon: time.Unix(nowFunc().Unix()-800, 0).Add(
+				computeStartRenewingAt(time.Second*600, 67)).Sub(nowFunc()),
 		},
 		"renewalPercent is 0": {
 			vds: &secretsv1beta1.VaultDynamicSecret{
@@ -98,15 +98,15 @@ func Test_computeRelativeHorizon(t *testing.T) {
 					SecretLease: secretsv1beta1.VaultSecretLease{
 						LeaseDuration: 600,
 					},
-					LastRenewalTime: time.Now().Unix() - 400,
+					LastRenewalTime: nowFunc().Unix() - 400,
 				},
 				Spec: secretsv1beta1.VaultDynamicSecretSpec{
 					RenewalPercent: 0,
 				},
 			},
 			expectedInWindow: true,
-			expectedHorizon: time.Unix(time.Now().Unix()-400, 0).Add(
-				computeStartRenewingAt(time.Second*600, 0)).Sub(time.Now()),
+			expectedHorizon: time.Unix(nowFunc().Unix()-400, 0).Add(
+				computeStartRenewingAt(time.Second*600, 0)).Sub(nowFunc()),
 		},
 		"renewalPercent is cap": {
 			vds: &secretsv1beta1.VaultDynamicSecret{
@@ -114,15 +114,15 @@ func Test_computeRelativeHorizon(t *testing.T) {
 					SecretLease: secretsv1beta1.VaultSecretLease{
 						LeaseDuration: 600,
 					},
-					LastRenewalTime: time.Now().Unix() - 400,
+					LastRenewalTime: nowFunc().Unix() - 400,
 				},
 				Spec: secretsv1beta1.VaultDynamicSecretSpec{
 					RenewalPercent: renewalPercentCap,
 				},
 			},
 			expectedInWindow: false,
-			expectedHorizon: time.Unix(time.Now().Unix()-400, 0).Add(
-				computeStartRenewingAt(time.Second*600, renewalPercentCap)).Sub(time.Now()),
+			expectedHorizon: time.Unix(nowFunc().Unix()-400, 0).Add(
+				computeStartRenewingAt(time.Second*600, renewalPercentCap)).Sub(nowFunc()),
 		},
 		"renewalPercent exceeds cap": {
 			vds: &secretsv1beta1.VaultDynamicSecret{
@@ -130,15 +130,15 @@ func Test_computeRelativeHorizon(t *testing.T) {
 					SecretLease: secretsv1beta1.VaultSecretLease{
 						LeaseDuration: 600,
 					},
-					LastRenewalTime: time.Now().Unix() - 400,
+					LastRenewalTime: nowFunc().Unix() - 400,
 				},
 				Spec: secretsv1beta1.VaultDynamicSecretSpec{
 					RenewalPercent: renewalPercentCap + 1,
 				},
 			},
 			expectedInWindow: false,
-			expectedHorizon: time.Unix(time.Now().Unix()-400, 0).Add(
-				computeStartRenewingAt(time.Second*600, renewalPercentCap+1)).Sub(time.Now()),
+			expectedHorizon: time.Unix(nowFunc().Unix()-400, 0).Add(
+				computeStartRenewingAt(time.Second*600, renewalPercentCap+1)).Sub(nowFunc()),
 		},
 	}
 
@@ -557,18 +557,18 @@ func TestVaultDynamicSecretReconciler_syncSecret(t *testing.T) {
 	}
 }
 
-// Test_isStaticCreds tests that we can appropriately identify if a vault
-// credential is "static" by checking the LastVaultRotation, RotationPeriod,
-// and RotationSchedule fields
-func Test_isStaticCreds(t *testing.T) {
+// TestVaultDynamicSecretReconciler_isStaticCreds tests that we can appropriately
+// identify if a vault credential is "static" by checking the LastVaultRotation,
+// RotationPeriod, and RotationSchedule fields
+func TestVaultDynamicSecretReconciler_isStaticCreds(t *testing.T) {
 	tests := []struct {
 		name     string
-		metaData v1beta1.VaultStaticCredsMetaData
+		metaData *v1beta1.VaultStaticCredsMetaData
 		want     bool
 	}{
 		{
 			name: "static-cred-with-rotation-period",
-			metaData: v1beta1.VaultStaticCredsMetaData{
+			metaData: &v1beta1.VaultStaticCredsMetaData{
 				LastVaultRotation: 1695430611,
 				RotationPeriod:    300,
 			},
@@ -576,7 +576,7 @@ func Test_isStaticCreds(t *testing.T) {
 		},
 		{
 			name: "not-static-cred-with-rotation-period",
-			metaData: v1beta1.VaultStaticCredsMetaData{
+			metaData: &v1beta1.VaultStaticCredsMetaData{
 				LastVaultRotation: 0,
 				RotationPeriod:    0,
 			},
@@ -584,7 +584,7 @@ func Test_isStaticCreds(t *testing.T) {
 		},
 		{
 			name: "static-cred-with-rotation-schedule",
-			metaData: v1beta1.VaultStaticCredsMetaData{
+			metaData: &v1beta1.VaultStaticCredsMetaData{
 				LastVaultRotation: 1695430611,
 				RotationSchedule:  "1 0 * * *",
 			},
@@ -592,7 +592,7 @@ func Test_isStaticCreds(t *testing.T) {
 		},
 		{
 			name: "not-static-cred-with-rotation-schedule",
-			metaData: v1beta1.VaultStaticCredsMetaData{
+			metaData: &v1beta1.VaultStaticCredsMetaData{
 				LastVaultRotation: 0,
 				RotationSchedule:  "",
 			},
@@ -602,25 +602,16 @@ func Test_isStaticCreds(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &VaultDynamicSecretReconciler{
-				Client: fake.NewClientBuilder().Build(),
-			}
-
-			got := r.isStaticCreds(&tt.metaData)
-			assert.Equal(t, tt.want, got)
+			r := &VaultDynamicSecretReconciler{}
+			got := r.isStaticCreds(tt.metaData)
+			assert.Equalf(t, tt.want, got, "isStaticCreds(%v)", tt.metaData)
 		})
 	}
 }
 
-type mockRequest struct {
-	method string
-	path   string
-	params map[string]any
-}
-
 func Test_computeRotationTime(t *testing.T) {
 	// time without nanos, for ease of comparison
-	then := time.Unix(time.Now().Unix(), 0)
+	then := time.Unix(nowFunc().Unix(), 0)
 	tests := []struct {
 		name string
 		vds  *secretsv1beta1.VaultDynamicSecret
@@ -691,6 +682,155 @@ func Test_computeRotationTime(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			actual := computeRotationTime(tt.vds)
 			assert.Equalf(t, tt.want, actual, "computeRotationTime(%v)", tt.vds)
+		})
+	}
+}
+
+func Test_computeRelativeHorizonWithJitter(t *testing.T) {
+	staticNow := time.Unix(nowFunc().Unix(), 0)
+	defaultNowFunc := func() time.Time { return staticNow }
+
+	tests := []struct {
+		name           string
+		o              *secretsv1beta1.VaultDynamicSecret
+		minHorizon     time.Duration
+		wantMinHorizon time.Duration
+		wantMaxHorizon time.Duration
+		wantInWindow   bool
+	}{
+		{
+			// in rotation, will enqueue with a new time horizon
+			name: "static-creds-in-window",
+			o: &secretsv1beta1.VaultDynamicSecret{
+				Spec: secretsv1beta1.VaultDynamicSecretSpec{
+					AllowStaticCreds: true,
+				},
+				Status: secretsv1beta1.VaultDynamicSecretStatus{
+					StaticCredsMetaData: secretsv1beta1.VaultStaticCredsMetaData{
+						LastVaultRotation: defaultNowFunc().Unix(),
+						TTL:               30,
+					},
+				},
+			},
+			wantMinHorizon: 30 * time.Second,
+			wantMaxHorizon: 30*time.Second + staticCredsMinDurationForJitter,
+			wantInWindow:   true,
+		},
+		{
+			// not in Vault rotation window, will rotate.
+			name: "static-creds-not-in-rotation-window",
+			o: &secretsv1beta1.VaultDynamicSecret{
+				Spec: secretsv1beta1.VaultDynamicSecretSpec{
+					AllowStaticCreds: true,
+				},
+				Status: secretsv1beta1.VaultDynamicSecretStatus{
+					StaticCredsMetaData: secretsv1beta1.VaultStaticCredsMetaData{
+						TTL:               30,
+						LastVaultRotation: defaultNowFunc().Add(-29 * time.Second).Unix(),
+					},
+				},
+			},
+			minHorizon:     1 * time.Second,
+			wantMinHorizon: 1 * time.Second,
+			wantMaxHorizon: time.Duration(1.2 * float64(time.Second)),
+			wantInWindow:   true,
+		},
+		{
+			// not in Vault rotation window, will rotate.
+			name: "static-creds-in-rotation-window-no-min-horizon",
+			o: &secretsv1beta1.VaultDynamicSecret{
+				Spec: secretsv1beta1.VaultDynamicSecretSpec{
+					AllowStaticCreds: true,
+				},
+				Status: secretsv1beta1.VaultDynamicSecretStatus{
+					StaticCredsMetaData: secretsv1beta1.VaultStaticCredsMetaData{
+						TTL:               30,
+						LastVaultRotation: defaultNowFunc().Unix() - 29,
+					},
+				},
+			},
+			wantMinHorizon: 1 * time.Second,
+			wantMaxHorizon: time.Duration(1.2 * float64(time.Second)),
+			wantInWindow:   true,
+		},
+		{
+			// not in Vault rotation window, will rotate.
+			name: "static-creds-not-in-rotation-window",
+			o: &secretsv1beta1.VaultDynamicSecret{
+				Spec: secretsv1beta1.VaultDynamicSecretSpec{
+					AllowStaticCreds: true,
+				},
+				Status: secretsv1beta1.VaultDynamicSecretStatus{
+					StaticCredsMetaData: secretsv1beta1.VaultStaticCredsMetaData{
+						TTL:               30,
+						LastVaultRotation: defaultNowFunc().Unix() - 30,
+					},
+				},
+			},
+			minHorizon:     1 * time.Second,
+			wantMinHorizon: 1 * time.Second,
+			wantMaxHorizon: time.Duration(1.2 * float64(time.Second)),
+			wantInWindow:   false,
+		},
+		{
+			name: "lease-not-in-window-now",
+			o: &secretsv1beta1.VaultDynamicSecret{
+				Spec: secretsv1beta1.VaultDynamicSecretSpec{
+					RenewalPercent: 90,
+				},
+				Status: secretsv1beta1.VaultDynamicSecretStatus{
+					LastRenewalTime: defaultNowFunc().Unix(),
+					SecretLease: secretsv1beta1.VaultSecretLease{
+						LeaseDuration: 100,
+					},
+				},
+			},
+			minHorizon:     1 * time.Second,
+			wantMinHorizon: time.Duration(85.5 * float64(time.Second)),
+			wantMaxHorizon: 90 * time.Second,
+			wantInWindow:   false,
+		},
+		{
+			name: "lease-in-window",
+			o: &secretsv1beta1.VaultDynamicSecret{
+				Spec: secretsv1beta1.VaultDynamicSecretSpec{
+					RenewalPercent: 89,
+				},
+				Status: secretsv1beta1.VaultDynamicSecretStatus{
+					LastRenewalTime: defaultNowFunc().Unix() - 90,
+					SecretLease: secretsv1beta1.VaultSecretLease{
+						LeaseDuration: 100,
+					},
+				},
+			},
+			minHorizon:     1 * time.Second,
+			wantMinHorizon: time.Duration(.8 * float64(time.Second)),
+			wantMaxHorizon: time.Duration(1 * time.Second),
+			wantInWindow:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nowFuncOrig := nowFunc
+			t.Cleanup(func() {
+				nowFunc = nowFuncOrig
+			})
+
+			isStatic := tt.o.Status.StaticCredsMetaData.TTL > 0
+			nowFunc = defaultNowFunc
+			gotHorizon, gotInWindow := computeRelativeHorizonWithJitter(tt.o, tt.minHorizon)
+			assert.Equalf(t, tt.wantInWindow, gotInWindow, "computeRelativeHorizonWithJitter(%v, %v)", tt.o, tt.minHorizon)
+			if isStatic {
+				assert.LessOrEqualf(t, tt.wantMinHorizon, gotHorizon,
+					"computeRelativeHorizonWithJitter(%v, %v)", tt.o, tt.minHorizon)
+				assert.GreaterOrEqualf(t, tt.wantMaxHorizon, gotHorizon,
+					"computeRelativeHorizonWithJitter(%v, %v)", tt.o, tt.minHorizon)
+			} else {
+				assert.LessOrEqualf(t, gotHorizon, tt.wantMaxHorizon,
+					"computeRelativeHorizonWithJitter(%v, %v)", tt.o, tt.minHorizon)
+				assert.GreaterOrEqualf(t, gotHorizon, tt.wantMinHorizon,
+					"computeRelativeHorizonWithJitter(%v, %v)", tt.o, tt.minHorizon)
+			}
 		})
 	}
 }

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -713,7 +713,7 @@ func Test_computeRelativeHorizonWithJitter(t *testing.T) {
 				},
 			},
 			wantMinHorizon: 30 * time.Second,
-			wantMaxHorizon: 30*time.Second + staticCredsMaxDurationForJitter,
+			wantMaxHorizon: 30*time.Second + staticCredsJitterHorizon,
 			wantInWindow:   true,
 		},
 		{

--- a/test/integration/hcpvaultsecretsapp/terraform/main.tf
+++ b/test/integration/hcpvaultsecretsapp/terraform/main.tf
@@ -60,5 +60,8 @@ module "vso-helm" {
   operator_helm_chart_path   = var.operator_helm_chart_path
   operator_image_repo        = var.operator_image_repo
   operator_image_tag         = var.operator_image_tag
-  manager_extra_args         = ["-min-refresh-after-hvsa=3s"]
+  manager_extra_args = [
+    "-min-refresh-after-hvsa=3s",
+    "-zap-log-level=5"
+  ]
 }

--- a/test/integration/modules/vso-helm/variables.tf
+++ b/test/integration/modules/vso-helm/variables.tf
@@ -85,6 +85,8 @@ variable "client_cache_config" {
 }
 
 variable "manager_extra_args" {
-  type    = list(string)
-  default = []
+  type = list(string)
+  default = [
+    "-zap-log-level=5"
+  ]
 }


### PR DESCRIPTION
Previously the jitter was a percentage on the static-creds rotation time horizon. In the case where the rotation period/TTL was large e.g. 24h, this would cause the rotation horizon extend beyond the rotation period. This fix ensures that the added jitter is 5% of the constant time duration of 3s.

Closes #466 