### PR TITLE
VSS: Ensure all resource updates are synced.

### DIFF
--- a/api/v1beta1/vaultstaticsecret_types.go
+++ b/api/v1beta1/vaultstaticsecret_types.go
@@ -56,6 +56,8 @@ type VaultStaticSecretSpec struct {
 
 // VaultStaticSecretStatus defines the observed state of VaultStaticSecret
 type VaultStaticSecretStatus struct {
+	// LastGeneration is the Generation of the last reconciled resource.
+	LastGeneration int64 `json:"lastGeneration"`
 	// SecretMAC used when deciding whether new Vault secret data should be synced.
 	//
 	// The controller will compare the "new" Vault secret data to this value using HMAC,

--- a/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -151,6 +151,11 @@ spec:
           status:
             description: VaultStaticSecretStatus defines the observed state of VaultStaticSecret
             properties:
+              lastGeneration:
+                description: LastGeneration is the Generation of the last reconciled
+                  resource.
+                format: int64
+                type: integer
               secretMAC:
                 description: "SecretMAC used when deciding whether new Vault secret
                   data should be synced. \n The controller will compare the \"new\"
@@ -159,6 +164,8 @@ spec:
                   is also used to detect drift in the Destination Secret's Data. If
                   drift is detected the data will be synced to the Destination."
                 type: string
+            required:
+            - lastGeneration
             type: object
         type: object
     served: true

--- a/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -151,6 +151,11 @@ spec:
           status:
             description: VaultStaticSecretStatus defines the observed state of VaultStaticSecret
             properties:
+              lastGeneration:
+                description: LastGeneration is the Generation of the last reconciled
+                  resource.
+                format: int64
+                type: integer
               secretMAC:
                 description: "SecretMAC used when deciding whether new Vault secret
                   data should be synced. \n The controller will compare the \"new\"
@@ -159,6 +164,8 @@ spec:
                   is also used to detect drift in the Destination Secret's Data. If
                   drift is detected the data will be synced to the Destination."
                 type: string
+            required:
+            - lastGeneration
             type: object
         type: object
     served: true


### PR DESCRIPTION
Previously, whenever HMACSecretData was set to true and no data drift was detected, the reconciler would skip destination updates, like annotations, labels etc. This change adds tracking of a resource's generation to determine when the reconciler is handling a resource update.