### PR TITLE
image/ubi: add separate target and build job for RedHat

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -173,13 +173,50 @@ jobs:
           tags: |
             docker.io/hashicorp/${{env.repo}}:${{env.image_tag}}
             public.ecr.aws/hashicorp/${{env.repo}}:${{env.image_tag}}
+
+      - name: Check binary version in container
+        shell: bash
+        run: |
+          version_output=$(docker run hashicorp/${{env.repo}}:${{env.image_tag}} --version --output=json)
+          echo $version_output
+          git_version=$(echo $version_output | jq -r .gitVersion)
+
+          if [ "$git_version" != "${{ env.version }}" ]; then
+            echo "$gitVersion expected to be ${{ env.version }}"
+            exit 1
+          fi
+
+  build-docker-ubi-redhat:
+    name: UBI ${{ matrix.arch }} RedHat build
+    needs: [get-product-version, build-pre-checks, build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Building only amd64 for the RedHat registry for now
+        arch: ["amd64"]
+    env:
+      repo: ${{github.event.repository.name}}
+      version: ${{needs.get-product-version.outputs.product-version}}
+      image_tag: ${{needs.get-product-version.outputs.product-version}}-ubi
+
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Docker Build (Action)
+        uses: hashicorp/actions-docker-build@v1
+        env:
+          VERSION: ${{ needs.get-product-version.outputs.product-version }}
+          GO_VERSION: ${{ needs.build-pre-checks.outputs.go-version }}
+        with:
+          version: ${{env.version}}
+          target: release-ubi-redhat
+          arch: ${{matrix.arch}}
           # The quay id here corresponds to the project id on RedHat's portal
           redhat_tag: quay.io/redhat-isv-containers/64b072322e2773c28d30d988:${{env.image_tag}}
 
       - name: Check binary version in container
         shell: bash
         run: |
-          version_output=$(docker run hashicorp/${{env.repo}}:${{env.image_tag}} --version --output=json)
+          version_output=$(docker run quay.io/redhat-isv-containers/64b072322e2773c28d30d988:${{env.image_tag}} --version --output=json)
           echo $version_output
           git_version=$(echo $version_output | jq -r .gitVersion)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,10 @@ USER 65532:65532
 
 ENTRYPOINT ["/vault-secrets-operator"]
 
+# Duplicate ubi release image target for RedHat registry builds
+# -------------------------------------------------------------
+FROM release-ubi as release-ubi-redhat
+
 # ===================================
 #
 #   Set default target to 'dev'.


### PR DESCRIPTION
Adds a separate ubi image build target and job for the RedHat container registry, that only builds amd64, until we get around our multi-arch issues there.