### PR TITLE
Make kubeRbacProxy optional in Helm chart

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
       {{- end }}
     spec:
       containers:
+      {{- if .Values.controller.kubeRbacProxy.enabled }}
       - name: kube-rbac-proxy
         args:
         - --secure-listen-address=0.0.0.0:8443
@@ -59,10 +60,13 @@ spec:
         resources: {{- toYaml .Values.controller.kubeRbacProxy.resources | nindent 10 }}
         securityContext:
           {{- toYaml .Values.controller.securityContext | nindent 10 }}
+      {{- end }}
       - name: manager
         args:
+        {{- if .Values.controller.kubeRbacProxy.enabled }}
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
+        {{- end }}
         - --leader-elect
         {{- if .Values.controller.manager.clientCache.persistenceModel }}
         - --client-cache-persistence-model={{ .Values.controller.manager.clientCache.persistenceModel }}

--- a/chart/templates/metrics-reader-rbac.yaml
+++ b/chart/templates/metrics-reader-rbac.yaml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 */}}
 
+{{- if .Values.controller.kubeRbacProxy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -15,3 +16,4 @@ rules:
   - /metrics
   verbs:
   - get
+{{- end }}

--- a/chart/templates/metrics-service.yaml
+++ b/chart/templates/metrics-service.yaml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 */}}
 
+{{- if .Values.controller.kubeRbacProxy.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,3 +20,4 @@ spec:
   {{- include "vso.chart.selectorLabels" . | nindent 4 }}
   ports:
 	{{- .Values.metricsService.ports | toYaml | nindent 2 -}}
+{{- end }}

--- a/chart/templates/proxy-rbac.yaml
+++ b/chart/templates/proxy-rbac.yaml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 */}}
 
+{{- if .Values.controller.kubeRbacProxy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -39,3 +40,4 @@ subjects:
 - kind: ServiceAccount
   name: '{{ include "vso.chart.fullname" . }}-controller-manager'
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -58,6 +58,9 @@ controller:
   # Settings related to the kubeRbacProxy container. This container is an HTTP proxy for the
   # controller manager which performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
   kubeRbacProxy:
+    # toggles the use of kubeRbacProxy to control access to metrics endpoint
+    # @type: boolean
+    enabled: true
     # Image sets the repo and tag of the kube-rbac-proxy image to use for the controller.
     image:
       repository: gcr.io/kubebuilder/kube-rbac-proxy

--- a/test/unit/metrics-service.bats
+++ b/test/unit/metrics-service.bats
@@ -65,3 +65,24 @@ load _helpers
     [ "${actual}" = "http" ]
 }
 
+#--------------------------------------------------------------------
+# kubeRbacProxy enable
+@test "metrics/Service: created by default" {
+    cd `chart_dir`
+    local actual=$( (helm template \
+        --show-only templates/metrics-service.yaml  \
+        . || echo "---") | tee /dev/stderr |
+        yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "true" ]
+  }
+
+
+  @test "metrics/Service: not created if kubeRbacProxy is not enabled" {
+    cd `chart_dir`
+    local actual=$( (helm template \
+        --show-only templates/metrics-service.yaml  \
+        --set 'controller.kubeRbacProxy.enabled=false' \
+        . || echo "---") | tee /dev/stderr |
+        yq 'length > 0' | tee /dev/stderr)
+    [ "${actual}" = "false" ]
+  }


### PR DESCRIPTION
This provides an option in the Helm chart values to toggle using kubeRbacProxy to control access to the metrics endpoint.

This mirrors the strategic merge patches in kustomize: https://github.com/hashicorp/vault-secrets-operator/blob/main/config/default/kustomization.yaml#L32 https://github.com/hashicorp/vault-secrets-operator/blob/main/config/rbac/kustomization.yaml#L15

We have a new requirement to expose these metrics to a collector that cannot provide the k8s service account token anymore. We deploy from the Helm chart and would like this functionality exposed there.

The default option leaves the rendered helm template unchanged. If the setting is toggled, you get output similar to commenting out the kustomize patches.

The diff of the rendered templates with `enabled: false`

```
< # Source: vault-secrets-operator/templates/metrics-reader-rbac.yaml
< apiVersion: rbac.authorization.k8s.io/v1
< kind: ClusterRole
< metadata:
<   name: release-name-vault-secrets-operator-metrics-reader
<   labels:
<     app.kubernetes.io/component: controller-manager
<     helm.sh/chart: vault-secrets-operator-0.4.1
<     app.kubernetes.io/name: vault-secrets-operator
<     app.kubernetes.io/instance: release-name
<     app.kubernetes.io/version: "0.4.1"
<     app.kubernetes.io/managed-by: Helm
< rules:
< - nonResourceURLs:
<   - /metrics
<   verbs:
<   - get
< ---
< # Source: vault-secrets-operator/templates/proxy-rbac.yaml
< apiVersion: rbac.authorization.k8s.io/v1
< kind: ClusterRole
< metadata:
<   name: release-name-vault-secrets-operator-proxy-role
<   labels:
<     app.kubernetes.io/component: controller-manager
<     helm.sh/chart: vault-secrets-operator-0.4.1
<     app.kubernetes.io/name: vault-secrets-operator
<     app.kubernetes.io/instance: release-name
<     app.kubernetes.io/version: "0.4.1"
<     app.kubernetes.io/managed-by: Helm
< rules:
< - apiGroups:
<   - authentication.k8s.io
<   resources:
<   - tokenreviews
<   verbs:
<   - create
< - apiGroups:
<   - authorization.k8s.io
<   resources:
<   - subjectaccessreviews
<   verbs:
<   - create
< ---
375,395d330
< # Source: vault-secrets-operator/templates/proxy-rbac.yaml
< apiVersion: rbac.authorization.k8s.io/v1
< kind: ClusterRoleBinding
< metadata:
<   name: release-name-vault-secrets-operator-proxy-rolebinding
<   labels:
<     app.kubernetes.io/component: controller-manager
<     helm.sh/chart: vault-secrets-operator-0.4.1
<     app.kubernetes.io/name: vault-secrets-operator
<     app.kubernetes.io/instance: release-name
<     app.kubernetes.io/version: "0.4.1"
<     app.kubernetes.io/managed-by: Helm
< roleRef:
<   apiGroup: rbac.authorization.k8s.io
<   kind: ClusterRole
<   name: 'release-name-vault-secrets-operator-proxy-role'
< subjects:
< - kind: ServiceAccount
<   name: 'release-name-vault-secrets-operator-controller-manager'
<   namespace: vault
< ---
464,489d398
< # Source: vault-secrets-operator/templates/metrics-service.yaml
< apiVersion: v1
< kind: Service
< metadata:
<   name: release-name-vault-secrets-operator-metrics-service
<   namespace: vault
<   labels:
<     app.kubernetes.io/component: controller-manager
<     control-plane: controller-manager
<     helm.sh/chart: vault-secrets-operator-0.4.1
<     app.kubernetes.io/name: vault-secrets-operator
<     app.kubernetes.io/instance: release-name
<     app.kubernetes.io/version: "0.4.1"
<     app.kubernetes.io/managed-by: Helm
< spec:
<   type: ClusterIP
<   selector:
<     control-plane: controller-manager
<     app.kubernetes.io/name: vault-secrets-operator
<     app.kubernetes.io/instance: release-name
<   ports:
<   - name: https
<     port: 8443
<     protocol: TCP
<     targetPort: https
< ---
521,543d429
<       - name: kube-rbac-proxy
<         args:
<         - --secure-listen-address=0.0.0.0:8443
<         - --upstream=http://127.0.0.1:8080/
<         - --logtostderr=true
<         - --v=0
<         env:
<         - name: KUBERNETES_CLUSTER_DOMAIN
<           value: cluster.local
<         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
<         ports:
<         - containerPort: 8443
<           name: https
<           protocol: TCP
<         resources:
<           limits:
<             cpu: 500m
<             memory: 128Mi
<           requests:
<             cpu: 5m
<             memory: 64Mi
<         securityContext:
<           allowPrivilegeEscalation: false
546,547d431
<         - --health-probe-bind-address=:8081
<         - --metrics-bind-address=127.0.0.1:8080
```