### PR TITLE
VDS: Log and record Vault request failures

### DIFF
--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -210,8 +210,11 @@ func (r *VaultDynamicSecretReconciler) Reconcile(ctx context.Context, req ctrl.R
 	secretLease, staticCredsUpdated, err := r.syncSecret(ctx, vClient, o)
 	if err != nil {
 		_, jitter := computeMaxJitterWithPercent(requeueDurationOnError, 0.5)
+		horizon := requeueDurationOnError + time.Duration(jitter)
+		r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonSecretSyncError,
+			"Failed to sync the secret, horizon=%s, err=%s", horizon, err)
 		return ctrl.Result{
-			RequeueAfter: requeueDurationOnError + time.Duration(jitter),
+			RequeueAfter: horizon,
 		}, nil
 	}
 
@@ -274,9 +277,10 @@ func (r *VaultDynamicSecretReconciler) syncSecret(ctx context.Context, c vault.C
 	}
 
 	method := o.Spec.RequestHTTPMethod
+	logger := log.FromContext(ctx).WithName("syncSecret")
 	if params != nil {
 		if !(method == http.MethodPost || method == http.MethodPut) {
-			log.FromContext(ctx).V(consts.LogLevelWarning).Info(
+			logger.V(consts.LogLevelWarning).Info(
 				"Params provided, ignoring specified method",
 				"requestHTTPMethod", o.Spec.RequestHTTPMethod)
 		}
@@ -286,6 +290,7 @@ func (r *VaultDynamicSecretReconciler) syncSecret(ctx context.Context, c vault.C
 		method = http.MethodGet
 	}
 
+	logger = logger.WithValues("path", path, "method", method)
 	switch method {
 	case http.MethodPut, http.MethodPost:
 		resp, err = c.Write(ctx, vault.NewWriteRequest(path, params))
@@ -296,6 +301,7 @@ func (r *VaultDynamicSecretReconciler) syncSecret(ctx context.Context, c vault.C
 	}
 
 	if err != nil {
+		logger.Error(err, "Vault request failed")
 		return nil, false, err
 	}
 
@@ -360,6 +366,7 @@ func (r *VaultDynamicSecretReconciler) syncSecret(ctx context.Context, c vault.C
 	}
 
 	if err := helpers.SyncSecret(ctx, r.Client, o, data); err != nil {
+		logger.Error(err, "Destination sync failed")
 		return nil, false, err
 	}
 


### PR DESCRIPTION
The VDS controller failed to report whenever a secret sync action had failed. With this PR all secret failures are recorded to the event recorder and logged.

Sample log output:
```
2023-12-08T13:26:25Z    ERROR   syncSecret      Vault request failed    {"controller": "vaultdynamicsecret", "controllerGroup": "secrets.hashicorp.com", "controllerKind": "VaultDynamicSecret", "VaultDynamicSecret": {"name":"create-static-create-static-creds-0","namespace":"vds-a1xdxdsw4y-k8s-ns"}, "namespace": "vds-a1xdxdsw4y-k8s-ns", "name": "create-static-create-static-creds-0", "reconcileID": "24d2a885-2123-4295-a2f3-98333ff59f10", "path": "vds-a1xdxdsw4y-db/static-creds/dev-postgres-static", "method": "GET", "error": "Error making API request.\n\nURL: GET http://vault.vault.svc.cluster.local:8200/v1/vds-a1xdxdsw4y-db/static-creds/dev-postgres-static\nCode: 403. Errors:\n\n* 1 error occurred:\n\t* permission denied\n\n"}
github.com/hashicorp/vault-secrets-operator/controllers.(*VaultDynamicSecretReconciler).syncSecret
        /workspace/controllers/vaultdynamicsecret_controller.go:304
github.com/hashicorp/vault-secrets-operator/controllers.(*VaultDynamicSecretReconciler).Reconcile
        /workspace/controllers/vaultdynamicsecret_controller.go:210
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:119
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:316
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:227

```

Sample event:
```
6m34s       Warning   SecretSyncError   vaultdynamicsecret/create-static-create-static-creds-0   Failed to sync the secret, horizon=6.60288929s, err=Error making API request....
```

Fixes #507 