### PR TITLE
Drop metadata.replaces from clusterserviceversion

### DIFF
--- a/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
@@ -128,7 +128,6 @@ spec:
   provider:
     name: HashiCorp
     url: https://www.hashicorp.com/
-  replaces: vault-secrets-operator.v0.4.0
   skips:
   - vault-secrets-operator.v0.4.1
   version: 0.0.0-dev


### PR DESCRIPTION
This PR puts us in line with the currently published OLM. We believe the directive caused the OLM PR to be rejected by Red Hat.