### PR TITLE
CCS: ensure invalid storage objects are deleted

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -24,6 +24,7 @@ const (
 	OperationRestore    = "restore"
 	OperationRestoreAll = "restore_all"
 	OperationPrune      = "prune"
+	OperationDelete     = "delete"
 	OperationPurge      = "purge"
 	OperationLogin      = "login"
 	OperationRenew      = "renew"

--- a/internal/vault/cache_storage.go
+++ b/internal/vault/cache_storage.go
@@ -58,6 +58,10 @@ var commonMatchingLabels = ctrlclient.MatchingLabels{
 	"app.kubernetes.io/component":  "client-cache-storage",
 }
 
+func IsStorageEntryNotFoundErr(err error) bool {
+	return apierrors.IsNotFound(err)
+}
+
 type ClientCacheStorageStoreRequest struct {
 	OwnerReferences     []metav1.OwnerReference
 	Client              Client

--- a/internal/vault/cache_storage.go
+++ b/internal/vault/cache_storage.go
@@ -49,7 +49,14 @@ const (
 	labelProviderNamespace    = "provider/namespace"
 )
 
-var EncryptionRequiredError = fmt.Errorf("encryption required")
+// commonMatchingLabels are included in all stored Clients. They are used for
+// nearly all client cache functions. Ideally they should never be altered,
+// since it could lead to orphaned cache entries and possibly other issues.
+var commonMatchingLabels = ctrlclient.MatchingLabels{
+	"app.kubernetes.io/name":       "vault-secrets-operator",
+	"app.kubernetes.io/managed-by": "vso",
+	"app.kubernetes.io/component":  "client-cache-storage",
+}
 
 type ClientCacheStorageStoreRequest struct {
 	OwnerReferences     []metav1.OwnerReference
@@ -72,11 +79,15 @@ type ClientCacheStorageRestoreRequest struct {
 	CacheKey            ClientCacheKey
 	DecryptionClient    Client
 	DecryptionVaultAuth *secretsv1beta1.VaultAuth
+	// NoPruneOnError preserves the storage entry on restoration error.
+	NoPruneOnError bool
 }
 
 type ClientCacheStorageRestoreAllRequest struct {
 	DecryptionClient    Client
 	DecryptionVaultAuth *secretsv1beta1.VaultAuth
+	// NoPruneOnError preserves the storage entry on restoration error.
+	NoPruneOnError bool
 }
 
 // clientCacheStorageEntry represents a single Vault Client.
@@ -260,8 +271,8 @@ func (c *defaultClientCacheStorage) Store(ctx context.Context, client ctrlclient
 	s.Data[fieldMACMessage] = messageMAC
 	if e := client.Create(ctx, s); e != nil {
 		if apierrors.IsAlreadyExists(e) {
-			// since the Secret is immutable we need to always recreate it.
-			err = client.Delete(ctx, s)
+			// since the Secret is immutable we need to always recreate it
+			err = c.delete(ctx, client, s)
 			if err != nil {
 				return nil, err
 			}
@@ -305,7 +316,7 @@ func (c *defaultClientCacheStorage) Restore(ctx context.Context, client ctrlclie
 	}
 
 	var entry *clientCacheStorageEntry
-	entry, err = c.restore(ctx, req, secret)
+	entry, err = c.restore(ctx, client, req, secret)
 	return entry, err
 }
 
@@ -318,18 +329,28 @@ func (c *defaultClientCacheStorage) Len(ctx context.Context, client ctrlclient.C
 	return len(found), nil
 }
 
-func (c *defaultClientCacheStorage) restore(ctx context.Context, req ClientCacheStorageRestoreRequest, s *corev1.Secret) (*clientCacheStorageEntry, error) {
+func (c *defaultClientCacheStorage) restore(ctx context.Context, client ctrlclient.Client,
+	req ClientCacheStorageRestoreRequest, s *corev1.Secret,
+) (*clientCacheStorageEntry, error) {
 	var err error
 	defer func() {
-		c.incrementOperationCounter(metrics.OperationRestore, err)
+		var errs error
+		if err != nil {
+			errs = errors.Join(errs, err)
+			if !req.NoPruneOnError {
+				errs = errors.Join(errs, c.delete(ctx, client, s))
+			}
+		}
+
+		c.incrementOperationCounter(metrics.OperationRestore, errs)
 	}()
 
+	var secret *api.Secret
 	err = c.validateSecretMAC(req, s)
 	if err != nil {
 		return nil, err
 	}
 
-	var secret *api.Secret
 	if b, ok := s.Data[fieldCachedSecret]; ok {
 		transitRef := s.Labels["vaultTransitRef"]
 		if transitRef != "" {
@@ -417,25 +438,37 @@ func (c *defaultClientCacheStorage) Prune(ctx context.Context, client ctrlclient
 			continue
 		}
 
-		if err := client.Delete(ctx, &item); err != nil {
-			if err != nil {
-				c.incrementOperationCounter(metrics.OperationPrune, err)
-			}
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-
+		if err := c.delete(ctx, client, &item); err != nil {
 			errs = errors.Join(errs, err)
 			continue
 		}
 
-		c.incrementOperationCounter(metrics.OperationPrune, nil)
 		count++
 	}
 
 	c.logger.V(consts.LogLevelDebug).Info("Pruned storage cache", "count", count, "total", len(secrets))
 
 	return count, errs
+}
+
+func (c *defaultClientCacheStorage) delete(ctx context.Context, client ctrlclient.Client, secret *corev1.Secret) error {
+	var errs error
+	defer func() {
+		c.incrementRequestCounter(metrics.OperationDelete, errs)
+	}()
+
+	if secret == nil {
+		errs = errors.Join(errs, fmt.Errorf("secret cannot be nil"))
+		return errs
+	}
+
+	if err := client.Delete(ctx, secret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			errs = errors.Join(errs, err)
+		}
+	}
+
+	return errs
 }
 
 func (c *defaultClientCacheStorage) listSecrets(ctx context.Context, client ctrlclient.Client, listOptions ...ctrlclient.ListOption) ([]corev1.Secret, error) {
@@ -483,11 +516,13 @@ func (c *defaultClientCacheStorage) RestoreAll(ctx context.Context, client ctrlc
 			CacheKey:            cacheKey,
 			DecryptionClient:    req.DecryptionClient,
 			DecryptionVaultAuth: req.DecryptionVaultAuth,
+			NoPruneOnError:      req.NoPruneOnError,
 		}
 
-		entry, err := c.restore(ctx, req, &s)
+		entry, err := c.restore(ctx, client, req, &s)
 		if err != nil {
 			errs = errors.Join(errs, err)
+			continue
 		}
 
 		result = append(result, entry)
@@ -497,19 +532,24 @@ func (c *defaultClientCacheStorage) RestoreAll(ctx context.Context, client ctrlc
 }
 
 func (c *defaultClientCacheStorage) validateSecretMAC(req ClientCacheStorageRestoreRequest, s *corev1.Secret) error {
-	var err error
+	if s == nil {
+		return fmt.Errorf("secret is nil")
+	}
+
+	var missingFields []string
 	b, ok := s.Data[fieldCachedSecret]
 	if !ok {
-		err = errors.Join(err, fmt.Errorf("entry missing required %q field", fieldCachedSecret))
+		missingFields = append(missingFields, fieldCachedSecret)
 	}
 
 	messageMAC, ok := s.Data[fieldMACMessage]
 	if !ok {
-		err = errors.Join(err, fmt.Errorf("entry missing required %q field", fieldCachedSecret))
+		missingFields = append(missingFields, fieldMACMessage)
 	}
 
-	if err != nil {
-		return err
+	if len(missingFields) > 0 {
+		return fmt.Errorf("secret data for %q missing required fields: %v",
+			ctrlclient.ObjectKeyFromObject(s), missingFields)
 	}
 
 	message, err := c.message(s.Name, req.CacheKey.String(), b)
@@ -523,7 +563,8 @@ func (c *defaultClientCacheStorage) validateSecretMAC(req ClientCacheStorageRest
 	}
 
 	if !ok {
-		return fmt.Errorf("storage entry message MAC is invalid")
+		return fmt.Errorf("invalid message MAC for secret %q",
+			ctrlclient.ObjectKeyFromObject(s))
 	}
 
 	return nil
@@ -531,7 +572,7 @@ func (c *defaultClientCacheStorage) validateSecretMAC(req ClientCacheStorageRest
 
 func (c *defaultClientCacheStorage) message(name, cacheKey string, secretData []byte) ([]byte, error) {
 	if name == "" || cacheKey == "" {
-		return nil, fmt.Errorf("invalid empty name and cacheKey")
+		return nil, fmt.Errorf("invalid empty name or cacheKey")
 	}
 
 	return append([]byte(name+cacheKey), secretData...), nil
@@ -555,11 +596,7 @@ func (c *defaultClientCacheStorage) listOptions() []ctrlclient.ListOption {
 }
 
 func (c *defaultClientCacheStorage) commonMatchingLabels() ctrlclient.MatchingLabels {
-	return ctrlclient.MatchingLabels{
-		"app.kubernetes.io/name":       "vault-secrets-operator",
-		"app.kubernetes.io/managed-by": "vso",
-		"app.kubernetes.io/component":  "client-cache-storage",
-	}
+	return commonMatchingLabels
 }
 
 func (c *defaultClientCacheStorage) addCommonMatchingLabels(labels ctrlclient.MatchingLabels) ctrlclient.MatchingLabels {
@@ -592,6 +629,9 @@ type ClientCacheStorageConfig struct {
 	EnforceEncryption bool
 	HMACSecretObjKey  ctrlclient.ObjectKey
 	OwnerRefs         []metav1.OwnerReference
+	// skipHMACSecret is used for unit tests, which need to control various aspects
+	// of HMAC secret creation.
+	skipHMACSecret bool
 }
 
 func DefaultClientCacheStorageConfig() *ClientCacheStorageConfig {
@@ -607,30 +647,17 @@ func DefaultClientCacheStorageConfig() *ClientCacheStorageConfig {
 func NewDefaultClientCacheStorage(ctx context.Context, client ctrlclient.Client,
 	config *ClientCacheStorageConfig, metricsRegistry prometheus.Registerer,
 ) (ClientCacheStorage, error) {
+	return newDefaultClientCacheStorage(ctx, client, config, metricsRegistry)
+}
+
+func newDefaultClientCacheStorage(ctx context.Context, client ctrlclient.Client,
+	config *ClientCacheStorageConfig, metricsRegistry prometheus.Registerer,
+) (*defaultClientCacheStorage, error) {
 	if config == nil {
 		config = DefaultClientCacheStorageConfig()
 	}
 
-	if err := common.ValidateObjectKey(config.HMACSecretObjKey); err != nil {
-		return nil, err
-	}
-
-	s, err := helpers.CreateHMACKeySecret(ctx, client, config.HMACSecretObjKey)
-	if err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return nil, err
-		}
-	}
-
-	if s == nil {
-		s, err = helpers.GetHMACKeySecret(ctx, client, config.HMACSecretObjKey)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	cacheStorage := &defaultClientCacheStorage{
-		hmacKey:           s.Data[helpers.HMACKeyName],
 		enforceEncryption: config.EnforceEncryption,
 		logger:            zap.New().WithName("ClientCacheStorage"),
 		requestCounterVec: prometheus.NewCounterVec(
@@ -665,6 +692,28 @@ func NewDefaultClientCacheStorage(ctx context.Context, client ctrlclient.Client,
 				metrics.LabelOperation,
 			},
 		),
+	}
+
+	if !config.skipHMACSecret {
+		if err := common.ValidateObjectKey(config.HMACSecretObjKey); err != nil {
+			return nil, err
+		}
+
+		s, err := helpers.CreateHMACKeySecret(ctx, client, config.HMACSecretObjKey)
+		if err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				return nil, err
+			}
+		}
+
+		if s == nil {
+			s, err = helpers.GetHMACKeySecret(ctx, client, config.HMACSecretObjKey)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		cacheStorage.hmacKey = s.Data[helpers.HMACKeyName]
 	}
 
 	if metricsRegistry != nil {

--- a/internal/vault/cache_storage_test.go
+++ b/internal/vault/cache_storage_test.go
@@ -1,0 +1,291 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/hashicorp/vault-secrets-operator/internal/common"
+	"github.com/hashicorp/vault-secrets-operator/internal/helpers"
+)
+
+func Test_defaultClientCacheStorage_Purge(t *testing.T) {
+	ctx := context.Background()
+
+	builder := fake.NewClientBuilder()
+	tests := []struct {
+		name    string
+		config  *ClientCacheStorageConfig
+		create  int
+		client  ctrlclient.Client
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "zero",
+			config:  DefaultClientCacheStorageConfig(),
+			create:  0,
+			client:  builder.Build(),
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "five",
+			config:  DefaultClientCacheStorageConfig(),
+			create:  5,
+			client:  builder.Build(),
+			wantErr: assert.NoError,
+		},
+		{
+			// use an empty runtime.Scheme to induce an error on corev1.Secret creation, etc.
+			name: "error-empty-scheme",
+			config: &ClientCacheStorageConfig{
+				skipHMACSecret: true,
+			},
+			client: builder.WithScheme(&runtime.Scheme{}).Build(),
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err,
+					`no kind is registered for the type v1.Secret in scheme ""`, i...)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := newDefaultClientCacheStorage(ctx, tt.client, tt.config, nil)
+			require.NoError(t, err)
+
+			for i := 0; i < tt.create; i++ {
+				o := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("entry-%d", i),
+						Namespace: common.OperatorNamespace,
+						Labels:    commonMatchingLabels,
+					},
+				}
+				require.NoError(t, tt.client.Create(ctx, o))
+			}
+
+			if tt.create > 0 {
+				// check secrets list secrets before purge
+				assertCacheSecretLen(t, ctx, tt.client, tt.create)
+			}
+
+			err = c.Purge(ctx, tt.client)
+			if !tt.wantErr(t, err, fmt.Sprintf("Purge(%v, %v)", ctx, tt.client)) || err != nil {
+				return
+			}
+
+			// check secrets list secrets after purge
+			assertCacheSecretLen(t, ctx, tt.client, 0, "Purge(%v, %v)", ctx, tt.client)
+
+			// ensure that the purge did not delete the secret holding the HMAC key that is
+			// created in NewDefaultClientCacheStorage()
+			var f corev1.SecretList
+			require.NoError(t, tt.client.List(ctx, &f, ctrlclient.InNamespace(common.OperatorNamespace)))
+			require.Len(t, f.Items, 1)
+
+			hmacSecret := f.Items[0]
+			assert.Equal(t,
+				tt.config.HMACSecretObjKey,
+				ctrlclient.ObjectKey{
+					Namespace: hmacSecret.GetNamespace(),
+					Name:      hmacSecret.GetName(),
+				})
+		})
+	}
+}
+
+func Test_defaultClientCacheStorage_RestoreAll(t *testing.T) {
+	ctx := context.Background()
+	sec := &api.Secret{
+		Auth: &api.SecretAuth{
+			ClientToken: "baz",
+		},
+	}
+
+	secretData, err := json.Marshal(sec)
+	require.NoError(t, err)
+
+	builder := fake.NewClientBuilder()
+	tests := []struct {
+		name       string
+		config     *ClientCacheStorageConfig
+		create     int
+		req        ClientCacheStorageRestoreAllRequest
+		client     ctrlclient.Client
+		secretData []byte
+		messageMAC []byte
+		want       []*clientCacheStorageEntry
+		wantErr    assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "none",
+			config:  DefaultClientCacheStorageConfig(),
+			client:  builder.Build(),
+			wantErr: assert.NoError,
+		},
+		{
+			name:       "one",
+			config:     DefaultClientCacheStorageConfig(),
+			client:     builder.Build(),
+			create:     1,
+			secretData: secretData,
+			want: []*clientCacheStorageEntry{
+				{
+					CacheKey:    "entry-0",
+					VaultSecret: sec,
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name:       "three",
+			config:     DefaultClientCacheStorageConfig(),
+			client:     builder.Build(),
+			create:     3,
+			secretData: secretData,
+			want: []*clientCacheStorageEntry{
+				{
+					CacheKey:    "entry-0",
+					VaultSecret: sec,
+				},
+				{
+					CacheKey:    "entry-1",
+					VaultSecret: sec,
+				},
+				{
+					CacheKey:    "entry-2",
+					VaultSecret: sec,
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name:   "invalid-missing-required-data",
+			create: 1,
+			config: DefaultClientCacheStorageConfig(),
+			client: builder.Build(),
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err,
+					fmt.Sprintf(`secret data for %q missing required fields: %v`,
+						ctrlclient.ObjectKey{Namespace: common.OperatorNamespace, Name: "entry-0"},
+						[]string{fieldCachedSecret, fieldMACMessage}), i...)
+			},
+		},
+		{
+			name:       "invalid-message-MAC",
+			create:     1,
+			config:     DefaultClientCacheStorageConfig(),
+			messageMAC: []byte(`bogus`),
+			secretData: secretData,
+			client:     builder.Build(),
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err,
+					fmt.Sprintf("invalid message MAC for secret %q",
+						ctrlclient.ObjectKey{Namespace: common.OperatorNamespace, Name: "entry-0"}),
+					i...)
+			},
+		},
+		{
+			name:       "invalid-message-MAC-no-prune-on-error",
+			create:     1,
+			config:     DefaultClientCacheStorageConfig(),
+			messageMAC: []byte(`bogus`),
+			secretData: secretData,
+			client:     builder.Build(),
+			req: ClientCacheStorageRestoreAllRequest{
+				NoPruneOnError: true,
+			},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err,
+					fmt.Sprintf("invalid message MAC for secret %q",
+						ctrlclient.ObjectKey{Namespace: common.OperatorNamespace, Name: "entry-0"}),
+					i...)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := newDefaultClientCacheStorage(ctx, tt.client, tt.config, nil)
+			require.NoError(t, err)
+
+			if tt.create > 0 {
+				for i := 0; i < tt.create; i++ {
+					name := fmt.Sprintf("entry-%d", i)
+					labels := maps.Clone(commonMatchingLabels)
+					labels[labelCacheKey] = name
+					o := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      name,
+							Namespace: common.OperatorNamespace,
+							Labels:    labels,
+						},
+					}
+					o.ObjectMeta.Labels[labelCacheKey] = o.ObjectMeta.Name
+					if tt.secretData != nil {
+						message, err := c.message(name, name, tt.secretData)
+						require.NoError(t, err)
+						messageMAC := tt.messageMAC
+						if messageMAC == nil {
+							messageMAC, err = helpers.MACMessage(c.hmacKey, message)
+							if err != nil {
+								require.NoError(t, err)
+							}
+						}
+						o.Data = map[string][]byte{
+							fieldCachedSecret: tt.secretData,
+							fieldMACMessage:   messageMAC,
+						}
+					}
+					require.NoError(t, tt.client.Create(ctx, o))
+				}
+				// check secrets list secrets before purge
+				assertCacheSecretLen(t, ctx, tt.client, tt.create)
+			}
+
+			got, err := c.RestoreAll(ctx, tt.client, tt.req)
+			if !tt.wantErr(t, err, fmt.Sprintf("RestoreAll(%v, %v, %v)", ctx, tt.client, tt.req)) {
+				return
+			}
+
+			assert.Equalf(t, tt.want, got, "RestoreAll(%v, %v, %v)", ctx, tt.client, tt.req)
+
+			expectedLen := tt.create
+			if err != nil {
+				if tt.req.NoPruneOnError {
+					expectedLen = tt.create
+				} else {
+					expectedLen = 0
+				}
+			}
+
+			assertCacheSecretLen(t, ctx, tt.client, expectedLen,
+				"RestoreAll(%v, %v, %v)", ctx, tt.client, tt.req)
+		})
+	}
+}
+
+func assertCacheSecretLen(t *testing.T, ctx context.Context, client ctrlclient.Client, length int, i ...any) bool {
+	t.Helper()
+
+	listOptions := []ctrlclient.ListOption{
+		commonMatchingLabels,
+		ctrlclient.InNamespace(common.OperatorNamespace),
+	}
+
+	var so corev1.SecretList
+	require.NoError(t, client.List(ctx, &so, listOptions...))
+	return assert.Len(t, so.Items, length, i...)
+}

--- a/internal/vault/client_factory.go
+++ b/internal/vault/client_factory.go
@@ -363,11 +363,13 @@ func (m *cachingClientFactory) Get(ctx context.Context, client ctrlclient.Client
 	if !ok && m.storageEnabled() {
 		// try and restore from Client storage cache, if properly configured to do so.
 		restored, err := m.restoreClientFromCacheKey(ctx, client, cacheKey)
-		if err == nil {
+		if restored != nil {
 			return namespacedClient(restored)
 		}
 
-		logger.Error(err, "Failed to restore client from storage")
+		if !IsStorageEntryNotFoundErr(err) {
+			logger.Error(err, "Failed to restore client from storage")
+		}
 	}
 
 	// if we couldn't produce a valid Client, create a new one, log it in, and cache it

--- a/internal/vault/client_factory.go
+++ b/internal/vault/client_factory.go
@@ -218,7 +218,7 @@ func (m *cachingClientFactory) RestoreAll(ctx context.Context, client ctrlclient
 		errs = err
 		return errs
 	}
-	if entries == nil {
+	if len(entries) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
Previously, it was possible for invalid client cache storage objects to live forever. This could cause the ClientFactory to fail for valid Client requests. This was most noticeable on a call to RestoreAll() when VSO was first coming up.

Whenever an invalid cached client is found in storage it should be discarded and replaced with a valid client instance.

Other fixes:
- Add more granular metrics for tracking storage deletions which are performed during storage pruning.
- Increase test coverage for cache_storage
- Remove unused EncryptionRequiredError

Closes #364