### PR TITLE
Drop the editor/viewer ClusterRole name truncation

### DIFF
--- a/chart/templates/hcpauth_editor_role.yaml
+++ b/chart/templates/hcpauth_editor_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "hcpauth-editor-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "hcpauth-editor-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/chart/templates/hcpauth_viewer_role.yaml
+++ b/chart/templates/hcpauth_viewer_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "hcpauth-viewer-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "hcpauth-viewer-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/chart/templates/hcpvaultsecretsapp_editor_role.yaml
+++ b/chart/templates/hcpvaultsecretsapp_editor_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "hcpsecretsapp-editor-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "hcpsecretsapp-editor-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/chart/templates/hcpvaultsecretsapp_viewer_role.yaml
+++ b/chart/templates/hcpvaultsecretsapp_viewer_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "hcpsecretsapp-viewer-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "hcpsecretsapp-viewer-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/chart/templates/vaultauth_editor_role.yaml
+++ b/chart/templates/vaultauth_editor_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultauth-editor-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultauth-editor-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/chart/templates/vaultauth_viewer_role.yaml
+++ b/chart/templates/vaultauth_viewer_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultauth-viewer-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultauth-viewer-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/chart/templates/vaultconnection_editor_role.yaml
+++ b/chart/templates/vaultconnection_editor_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultconnection-editor-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultconnection-editor-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/chart/templates/vaultconnection_viewer_role.yaml
+++ b/chart/templates/vaultconnection_viewer_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultconnection-viewer-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultconnection-viewer-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/chart/templates/vaultdynamicsecret_editor_role.yaml
+++ b/chart/templates/vaultdynamicsecret_editor_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultdynamicsecret-editor-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultdynamicsecret-editor-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/chart/templates/vaultdynamicsecret_viewer_role.yaml
+++ b/chart/templates/vaultdynamicsecret_viewer_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultdynamicsecret-viewer-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultdynamicsecret-viewer-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/chart/templates/vaultpkisecret_editor_role.yaml
+++ b/chart/templates/vaultpkisecret_editor_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultpki-editor-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultpki-editor-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/chart/templates/vaultpkisecret_viewer_role.yaml
+++ b/chart/templates/vaultpkisecret_viewer_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultpki-viewer-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultpki-viewer-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/chart/templates/vaultstaticsecret_editor_role.yaml
+++ b/chart/templates/vaultstaticsecret_editor_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultstaticsecret-editor-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultstaticsecret-editor-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/chart/templates/vaultstaticsecret_viewer_role.yaml
+++ b/chart/templates/vaultstaticsecret_viewer_role.yaml
@@ -8,7 +8,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultstaticsecret-viewer-role" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "vaultstaticsecret-viewer-role" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name

--- a/scripts/sync-rbac.sh
+++ b/scripts/sync-rbac.sh
@@ -52,7 +52,7 @@ function mungeIt {
 apiVersion: ${apiVersion}
 kind: ${kind}
 metadata:
-  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "${metadataName}" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "${metadataName}" }}
   labels:
     app.kubernetes.io/component: rbac
     # allow for selecting on the canonical name


### PR DESCRIPTION
There was no need to truncate the ClusterRole names to 63 chars. That limitation is only for label keys. Resource names can be up to 253 chars in length.