### PR TITLE
VC: provide default value for spec.skipTLSVerify

### DIFF
--- a/api/v1beta1/vaultconnection_types.go
+++ b/api/v1beta1/vaultconnection_types.go
@@ -21,7 +21,8 @@ type VaultConnectionSpec struct {
 	// CACertSecretRef is the name of a Kubernetes secret containing the trusted PEM encoded CA certificate chain as `ca.crt`.
 	CACertSecretRef string `json:"caCertSecretRef,omitempty"`
 	// SkipTLSVerify for TLS connections.
-	SkipTLSVerify bool `json:"skipTLSVerify,omitempty"`
+	// +kubebuilder:default=false
+	SkipTLSVerify bool `json:"skipTLSVerify"`
 }
 
 // VaultConnectionStatus defines the observed state of VaultConnection

--- a/chart/crds/secrets.hashicorp.com_vaultconnections.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultconnections.yaml
@@ -50,6 +50,7 @@ spec:
                 description: Headers to be included in all Vault requests.
                 type: object
               skipTLSVerify:
+                default: false
                 description: SkipTLSVerify for TLS connections.
                 type: boolean
               tlsServerName:
@@ -57,6 +58,7 @@ spec:
                 type: string
             required:
             - address
+            - skipTLSVerify
             type: object
           status:
             description: VaultConnectionStatus defines the observed state of VaultConnection

--- a/config/crd/bases/secrets.hashicorp.com_vaultconnections.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultconnections.yaml
@@ -50,6 +50,7 @@ spec:
                 description: Headers to be included in all Vault requests.
                 type: object
               skipTLSVerify:
+                default: false
                 description: SkipTLSVerify for TLS connections.
                 type: boolean
               tlsServerName:
@@ -57,6 +58,7 @@ spec:
                 type: string
             required:
             - address
+            - skipTLSVerify
             type: object
           status:
             description: VaultConnectionStatus defines the observed state of VaultConnection


### PR DESCRIPTION
Some K8s distros like Rancher do their own Helm chart diff to the running state of a given K8s cluster. For the default VaultConnection provided by Helm chart, the value for spec.skipTLSVerify would always trigger a diff in the case where the corresponding chart value was false, since runtime configuration did not include spec.skipTLSVerify.

Interestingly enough, if the default VaultConnection.spec.skipTLSVerify was added/set to false using 'kubectl edit', the value would persist in the cluster.

Solution:

Update VaultConnectionSpec.SkipTLSVerify to use a default value for rather than setting its JSON flag to omitempty. This will ensure that comparisons between the Helm chart's default VaultConnection's spec.skipTLSVerify can be reliably made, even when the default VC is updated outside of Helm.

Closes #278