### PR TITLE
VDS: remediate deleted destination secret

### DIFF
--- a/test/integration/hcpvaultsecretsapp_integration_test.go
+++ b/test/integration/hcpvaultsecretsapp_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -332,6 +333,12 @@ func TestHCPVaultSecretsApp(t *testing.T) {
 						}
 					}
 				}
+			}
+
+			d, err := time.ParseDuration(obj.Spec.RefreshAfter)
+			if assert.NoError(t, err, "time.ParseDuration(%v)", obj.Spec.RefreshAfter) {
+				assertRemediationOnDestinationDeletion(t, ctx, crdClient, obj,
+					time.Millisecond*500, uint64(d.Seconds()*3))
 			}
 		})
 	}

--- a/test/integration/vaultdynamicsecret/terraform/outputs.tf
+++ b/test/integration/vaultdynamicsecret/terraform/outputs.tf
@@ -52,3 +52,15 @@ output "k8s_config_context" {
 output "namespace" {
   value = local.namespace
 }
+
+output "static_rotation_period" {
+  value = vault_database_secret_backend_static_role.postgres.rotation_period
+}
+
+output "default_lease_ttl_seconds" {
+  value = vault_database_secrets_mount.db.default_lease_ttl_seconds
+}
+
+output "non_renewable_k8s_token_ttl" {
+  value = vault_kubernetes_secret_backend_role.k8s_secrets.token_default_ttl
+}

--- a/test/integration/vaultpkisecret_integration_test.go
+++ b/test/integration/vaultpkisecret_integration_test.go
@@ -268,7 +268,7 @@ func TestVaultPKISecret(t *testing.T) {
 						CommonName:   fmt.Sprintf("%s.example.com", dest),
 						Format:       "pem",
 						Revoke:       true,
-						ExpiryOffset: "1s",
+						ExpiryOffset: "2s",
 						TTL:          "10s",
 						VaultAuthRef: testVaultAuthMethodName,
 						AltNames:     []string{"alt1.example.com", "alt2.example.com"},
@@ -331,6 +331,14 @@ func TestVaultPKISecret(t *testing.T) {
 
 					if len(vpsObj.Spec.RolloutRestartTargets) > 0 {
 						awaitRolloutRestarts(t, ctx, crdClient, vpsObj, vpsObj.Spec.RolloutRestartTargets)
+					}
+
+					if vpsObj.Spec.Destination.Create && !t.Failed() {
+						d, err := time.ParseDuration(vpsObj.Spec.TTL)
+						if assert.NoError(t, err) {
+							assertRemediationOnDestinationDeletion(t, ctx, crdClient, vpsObj,
+								time.Millisecond*500, uint64(d.Seconds()*3))
+						}
 					}
 				})
 			}

--- a/test/integration/vaultstaticsecret_integration_test.go
+++ b/test/integration/vaultstaticsecret_integration_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/hashicorp/vault-secrets-operator/internal/vault"
 )
 
-func TestVaultStaticSecret_kv(t *testing.T) {
+func TestVaultStaticSecret(t *testing.T) {
 	testID := strings.ToLower(random.UniqueId())
 	testK8sNamespace := "k8s-tenant-" + testID
 	testK8sNamespace2 := testK8sNamespace + "-test"
@@ -468,6 +468,14 @@ func TestVaultStaticSecret_kv(t *testing.T) {
 
 						assertSync(t, vssObj, expected, true)
 						assertSync(t, vssObj, expected, false)
+
+						if vssObj.Spec.RefreshAfter != "" && !t.Failed() {
+							d, err := time.ParseDuration(vssObj.Spec.RefreshAfter)
+							if assert.NoError(t, err, "time.ParseDuration(%v)", vssObj.Spec.RefreshAfter) {
+								assertRemediationOnDestinationDeletion(t, ctx, crdClient, vssObj,
+									time.Millisecond*500, uint64(d.Seconds()*3))
+							}
+						}
 					})
 				}
 			}


### PR DESCRIPTION
Previously, the VDS controller did not detect when the destination secret had been deleted after it had initially created it.

Fixes:
- ensure a deleted destination secret that is owned by the VDS controller results in a re-sync.
- add integration test to test this use-case
- update all other controller integration tests to test for destination deletion

Closes #228 