### PR TITLE
tests: make assertDynamicSecretRotation() more robust.

### DIFF
--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -569,45 +569,75 @@ func assertDynamicSecretNewGeneration(t *testing.T,
 	t.Helper()
 
 	objKey := ctrlclient.ObjectKeyFromObject(vdsObjOrig)
-	vdsObjLatest := &secretsv1beta1.VaultDynamicSecret{}
-	if assert.NoError(t, client.Get(ctx, objKey, vdsObjLatest)) {
-		vdsObjLatest.Spec.Destination.Name += "-new"
-		var vdsObjUpdated secretsv1beta1.VaultDynamicSecret
-		if assert.NoError(t, client.Update(ctx, vdsObjLatest)) {
-			// await last generation updated after update
-			assert.NoError(t, backoff.Retry(func() error {
-				if err := client.Get(ctx, objKey, &vdsObjUpdated); err != nil {
-					return backoff.Permanent(err)
-				}
 
-				if vdsObjUpdated.GetGeneration() < vdsObjOrig.GetGeneration() {
-					return backoff.Permanent(fmt.Errorf(
-						"unexpected, the updated's generation was less than the original's"))
-				}
-
-				if vdsObjUpdated.GetGeneration() == vdsObjOrig.GetGeneration() {
-					return fmt.Errorf("generation has not been updated")
-				}
-
-				if vdsObjUpdated.GetGeneration() != vdsObjUpdated.Status.LastGeneration {
-					return fmt.Errorf("last generation %d, does match current %d",
-						vdsObjUpdated.Status.LastGeneration, vdsObjUpdated.GetGeneration())
-				}
-				return nil
-			},
-				backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond*500), 20)),
-			)
-
-			if !t.Failed() {
-				if vdsObjUpdated.Spec.AllowStaticCreds {
-					assert.Empty(t, vdsObjUpdated.Status.SecretLease.ID)
-				} else {
-					assert.NotEmpty(t, vdsObjUpdated.Status.SecretLease.ID)
-					assert.NotEqual(t, vdsObjUpdated.Status.SecretLease.ID, vdsObjOrig.Status.SecretLease.ID)
-				}
+	// try and update the object, sometimes there are update races, so we want to
+	// retry this operation.
+	err := backoff.RetryNotify(
+		func() error {
+			var obj secretsv1beta1.VaultDynamicSecret
+			if err := client.Get(ctx, objKey, &obj); err != nil {
+				return backoff.Permanent(err)
 			}
-		}
+
+			obj.Spec.Destination.Name = vdsObjOrig.Spec.Destination.Name + "-new"
+			if err := client.Update(ctx, &obj); err != nil {
+				return err
+			}
+			return nil
+		},
+		backoff.WithMaxRetries(
+			backoff.NewConstantBackOff(time.Millisecond*500),
+			4),
+		func(err error, d time.Duration) {
+			t.Logf(
+				"Retrying client.Update() of %s, err=%s, delay=%s", objKey, err, d)
+		},
+	)
+
+	if !assert.NoError(t, err) {
+		return
 	}
+
+	// wait for the object ot be reconciled
+	err = backoff.RetryNotify(func() error {
+		var obj secretsv1beta1.VaultDynamicSecret
+		if err := client.Get(ctx, objKey, &obj); err != nil {
+			return backoff.Permanent(err)
+		}
+		if obj.GetGeneration() < vdsObjOrig.GetGeneration() {
+			return backoff.Permanent(fmt.Errorf(
+				"unexpected, the updated's generation was less than the original's"))
+		}
+
+		if obj.GetGeneration() == vdsObjOrig.GetGeneration() {
+			return fmt.Errorf("generation has not been updated")
+		}
+
+		if obj.GetGeneration() != obj.Status.LastGeneration {
+			return fmt.Errorf(
+				"last generation %d, does not match current %d: obj=%#v",
+				obj.Status.LastGeneration, obj.GetGeneration(), obj)
+		}
+
+		// check updated destination secret exists
+		_, exists, err := helpers.GetSyncableSecret(ctx, client, &obj)
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+
+		assert.True(t, exists)
+		return nil
+	},
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond*500), 20),
+		func(err error, d time.Duration) {
+			if withExtraVerbosity {
+				t.Logf(
+					"Retrying wait reonciliation of %s, err=%s, delay=%s", objKey, err, d)
+			}
+		},
+	)
+
+	assert.NoError(t, err)
 }
 
 // assertDynamicSecretRotation revokes the lease of vdsObjFinal,


### PR DESCRIPTION
Previously, assertDynamicSecretRotation() would fail when updating the VDS object, due to the updated instance not being the latest. The update should be retried a few times before giving up.