### PR TITLE
Take ownership of an existing destination secret

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -14,7 +14,12 @@ type Destination struct {
 	Name string `json:"name"`
 	// Create the destination Secret.
 	// If the Secret already exists this should be set to false.
-	Create bool `json:"create,omitempty"`
+	// +kubebuilder:default=false
+	Create bool `json:"create"`
+	// Overwrite the destination Secret if it exists and Create is true. This is
+	// useful when migrating to VSO from a previous secret deployment strategy.
+	// +kubebuilder:default=false
+	Overwrite bool `json:"overwrite"`
 	// Labels to apply to the Secret. Requires Create to be set to true.
 	Labels map[string]string `json:"labels,omitempty"`
 	// Annotations to apply to the Secret. Requires Create to be set to true.

--- a/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -53,6 +53,7 @@ spec:
                       to be set to true.
                     type: object
                   create:
+                    default: false
                     description: Create the destination Secret. If the Secret already
                       exists this should be set to false.
                     type: boolean
@@ -65,12 +66,20 @@ spec:
                   name:
                     description: Name of the Secret
                     type: string
+                  overwrite:
+                    default: false
+                    description: Overwrite the destination Secret if it exists and
+                      Create is true. This is useful when migrating to VSO from a
+                      previous secret deployment strategy.
+                    type: boolean
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be
                       set to true. Defaults to Opaque.
                     type: string
                 required:
+                - create
                 - name
+                - overwrite
                 type: object
               hcpAuthRef:
                 description: 'HCPAuthRef to the HCPAuth resource, can be prefixed

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -56,6 +56,7 @@ spec:
                       to be set to true.
                     type: object
                   create:
+                    default: false
                     description: Create the destination Secret. If the Secret already
                       exists this should be set to false.
                     type: boolean
@@ -68,12 +69,20 @@ spec:
                   name:
                     description: Name of the Secret
                     type: string
+                  overwrite:
+                    default: false
+                    description: Overwrite the destination Secret if it exists and
+                      Create is true. This is useful when migrating to VSO from a
+                      previous secret deployment strategy.
+                    type: boolean
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be
                       set to true. Defaults to Opaque.
                     type: string
                 required:
+                - create
                 - name
+                - overwrite
                 type: object
               mount:
                 description: Mount path of the secret's engine in Vault.

--- a/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -65,6 +65,7 @@ spec:
                       to be set to true.
                     type: object
                   create:
+                    default: false
                     description: Create the destination Secret. If the Secret already
                       exists this should be set to false.
                     type: boolean
@@ -77,12 +78,20 @@ spec:
                   name:
                     description: Name of the Secret
                     type: string
+                  overwrite:
+                    default: false
+                    description: Overwrite the destination Secret if it exists and
+                      Create is true. This is useful when migrating to VSO from a
+                      previous secret deployment strategy.
+                    type: boolean
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be
                       set to true. Defaults to Opaque.
                     type: string
                 required:
+                - create
                 - name
+                - overwrite
                 type: object
               excludeCNFromSans:
                 description: 'ExcludeCNFromSans from DNS or Email Subject Alternate

--- a/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -48,6 +48,7 @@ spec:
                       to be set to true.
                     type: object
                   create:
+                    default: false
                     description: Create the destination Secret. If the Secret already
                       exists this should be set to false.
                     type: boolean
@@ -60,12 +61,20 @@ spec:
                   name:
                     description: Name of the Secret
                     type: string
+                  overwrite:
+                    default: false
+                    description: Overwrite the destination Secret if it exists and
+                      Create is true. This is useful when migrating to VSO from a
+                      previous secret deployment strategy.
+                    type: boolean
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be
                       set to true. Defaults to Opaque.
                     type: string
                 required:
+                - create
                 - name
+                - overwrite
                 type: object
               hmacSecretData:
                 default: true

--- a/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -53,6 +53,7 @@ spec:
                       to be set to true.
                     type: object
                   create:
+                    default: false
                     description: Create the destination Secret. If the Secret already
                       exists this should be set to false.
                     type: boolean
@@ -65,12 +66,20 @@ spec:
                   name:
                     description: Name of the Secret
                     type: string
+                  overwrite:
+                    default: false
+                    description: Overwrite the destination Secret if it exists and
+                      Create is true. This is useful when migrating to VSO from a
+                      previous secret deployment strategy.
+                    type: boolean
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be
                       set to true. Defaults to Opaque.
                     type: string
                 required:
+                - create
                 - name
+                - overwrite
                 type: object
               hcpAuthRef:
                 description: 'HCPAuthRef to the HCPAuth resource, can be prefixed

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -56,6 +56,7 @@ spec:
                       to be set to true.
                     type: object
                   create:
+                    default: false
                     description: Create the destination Secret. If the Secret already
                       exists this should be set to false.
                     type: boolean
@@ -68,12 +69,20 @@ spec:
                   name:
                     description: Name of the Secret
                     type: string
+                  overwrite:
+                    default: false
+                    description: Overwrite the destination Secret if it exists and
+                      Create is true. This is useful when migrating to VSO from a
+                      previous secret deployment strategy.
+                    type: boolean
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be
                       set to true. Defaults to Opaque.
                     type: string
                 required:
+                - create
                 - name
+                - overwrite
                 type: object
               mount:
                 description: Mount path of the secret's engine in Vault.

--- a/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -65,6 +65,7 @@ spec:
                       to be set to true.
                     type: object
                   create:
+                    default: false
                     description: Create the destination Secret. If the Secret already
                       exists this should be set to false.
                     type: boolean
@@ -77,12 +78,20 @@ spec:
                   name:
                     description: Name of the Secret
                     type: string
+                  overwrite:
+                    default: false
+                    description: Overwrite the destination Secret if it exists and
+                      Create is true. This is useful when migrating to VSO from a
+                      previous secret deployment strategy.
+                    type: boolean
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be
                       set to true. Defaults to Opaque.
                     type: string
                 required:
+                - create
                 - name
+                - overwrite
                 type: object
               excludeCNFromSans:
                 description: 'ExcludeCNFromSans from DNS or Email Subject Alternate

--- a/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -48,6 +48,7 @@ spec:
                       to be set to true.
                     type: object
                   create:
+                    default: false
                     description: Create the destination Secret. If the Secret already
                       exists this should be set to false.
                     type: boolean
@@ -60,12 +61,20 @@ spec:
                   name:
                     description: Name of the Secret
                     type: string
+                  overwrite:
+                    default: false
+                    description: Overwrite the destination Secret if it exists and
+                      Create is true. This is useful when migrating to VSO from a
+                      previous secret deployment strategy.
+                    type: boolean
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be
                       set to true. Defaults to Opaque.
                     type: string
                 required:
+                - create
                 - name
+                - overwrite
                 type: object
               hmacSecretData:
                 default: true

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -42,6 +42,7 @@ _Appears in:_
 | --- | --- |
 | `name` _string_ | Name of the Secret |
 | `create` _boolean_ | Create the destination Secret. If the Secret already exists this should be set to false. |
+| `overwrite` _boolean_ | Overwrite the destination Secret if it exists and Create is true. This is useful when migrating to VSO from a previous secret deployment strategy. |
 | `labels` _object (keys:string, values:string)_ | Labels to apply to the Secret. Requires Create to be set to true. |
 | `annotations` _object (keys:string, values:string)_ | Annotations to apply to the Secret. Requires Create to be set to true. |
 | `type` _[SecretType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secrettype-v1-core)_ | Type of Kubernetes Secret. Requires Create to be set to true. Defaults to Opaque. |

--- a/internal/helpers/secrets.go
+++ b/internal/helpers/secrets.go
@@ -373,12 +373,7 @@ func checkSecretIsOwnedByObj(dest *corev1.Secret, references []metav1.OwnerRefer
 	// checking for Secret ownership relies on first checking the Secret's labels,
 	// then verifying that its OwnerReferences match the SyncableSecret.
 	errs := checkOwnerLabels(dest)
-	for k, v := range OwnerLabels {
-		if o, ok := dest.Labels[k]; o != v || !ok {
-			errs = errors.Join(errs, fmt.Errorf(
-				"invalid owner label, key=%s, present=%t", k, ok))
-		}
-	}
+
 	// check that obj is the Secret's true Owner
 	key := ctrlclient.ObjectKeyFromObject(dest)
 	if len(dest.OwnerReferences) > 0 {

--- a/internal/helpers/secrets.go
+++ b/internal/helpers/secrets.go
@@ -150,14 +150,9 @@ func SyncSecret(ctx context.Context, client ctrlclient.Client, obj ctrlclient.Ob
 		return fmt.Errorf("invalid Destination, err=%w", err)
 	}
 
-	var dest corev1.Secret
-	exists := true
-	if err := client.Get(ctx, key, &dest); err != nil {
-		if apierrors.IsNotFound(err) {
-			exists = false
-		} else {
-			return err
-		}
+	dest, exists, err := getSecretExists(ctx, client, key)
+	if err != nil {
+		return err
 	}
 
 	pruneOrphans := func() {
@@ -186,7 +181,7 @@ func SyncSecret(ctx context.Context, client ctrlclient.Client, obj ctrlclient.Ob
 		// syncable-secret's Status, but...
 		dest.Data = data
 		logger.V(consts.LogLevelDebug).Info("Updating secret")
-		if err := client.Update(ctx, &dest); err != nil {
+		if err := client.Update(ctx, dest); err != nil {
 			return err
 		}
 
@@ -213,21 +208,28 @@ func SyncSecret(ctx context.Context, client ctrlclient.Client, obj ctrlclient.Ob
 	}
 	if exists {
 		logger.V(consts.LogLevelDebug).Info("Found pre-existing secret",
-			"secret", ctrlclient.ObjectKeyFromObject(&dest))
-		if err := checkSecretIsOwnedByObj(&dest, references); err != nil {
-			return err
+			"secret", ctrlclient.ObjectKeyFromObject(dest))
+
+		checkOwnerShip := true
+		if meta.Destination.Overwrite {
+			checkOwnerShip = hasOwnerLabels(dest)
 		}
 
+		if checkOwnerShip {
+			if err := checkSecretIsOwnedByObj(dest, references); err != nil {
+				return err
+			}
+		}
 	} else {
 		// secret does not exist, so we are going to create it.
-		dest = corev1.Secret{
+		dest = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      meta.Destination.Name,
 				Namespace: obj.GetNamespace(),
 			},
 		}
 		logger.V(consts.LogLevelDebug).Info("Creating new secret",
-			"secret", ctrlclient.ObjectKeyFromObject(&dest))
+			"secret", ctrlclient.ObjectKeyFromObject(dest))
 	}
 
 	// common setup/updates
@@ -257,12 +259,12 @@ func SyncSecret(ctx context.Context, client ctrlclient.Client, obj ctrlclient.Ob
 
 	if exists {
 		logger.V(consts.LogLevelDebug).Info("Updating secret")
-		if err := client.Update(ctx, &dest); err != nil {
+		if err := client.Update(ctx, dest); err != nil {
 			return err
 		}
 	} else {
 		logger.V(consts.LogLevelDebug).Info("Creating secret")
-		if err := client.Create(ctx, &dest); err != nil {
+		if err := client.Create(ctx, dest); err != nil {
 			return err
 		}
 	}
@@ -298,16 +300,16 @@ func pruneOrphanSecrets(ctx context.Context, client ctrlclient.Client, obj ctrlc
 //
 // See NewSyncableSecretMetaData for the supported types for obj.
 func CheckSecretExists(ctx context.Context, client ctrlclient.Client, obj ctrlclient.Object) (bool, error) {
-	_, ok, err := getSecretExists(ctx, client, obj)
+	_, ok, err := getSecretExistsForObj(ctx, client, obj)
 	return ok, err
 }
 
 // GetSyncableSecret
 func GetSyncableSecret(ctx context.Context, client ctrlclient.Client, obj ctrlclient.Object) (*corev1.Secret, bool, error) {
-	return getSecretExists(ctx, client, obj)
+	return getSecretExistsForObj(ctx, client, obj)
 }
 
-func getSecretExists(ctx context.Context, client ctrlclient.Client, obj ctrlclient.Object) (*corev1.Secret, bool, error) {
+func getSecretExistsForObj(ctx context.Context, client ctrlclient.Client, obj ctrlclient.Object) (*corev1.Secret, bool, error) {
 	meta, err := common.NewSyncableSecretMetaData(obj)
 	if err != nil {
 		return nil, false, err
@@ -316,18 +318,14 @@ func getSecretExists(ctx context.Context, client ctrlclient.Client, obj ctrlclie
 	logger := log.FromContext(ctx).WithName("syncSecret").WithValues(
 		"secretName", meta.Destination.Name, "create", meta.Destination.Create)
 	objKey := ctrlclient.ObjectKey{Namespace: obj.GetNamespace(), Name: meta.Destination.Name}
-	s, err := GetSecret(ctx, client, objKey)
+	s, exists, err := getSecretExists(ctx, client, objKey)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.V(consts.LogLevelDebug).Info("Secret does not exist")
-			return nil, false, nil
-		}
 		// let the caller log the error
 		return nil, false, err
 	}
 
 	logger.V(consts.LogLevelDebug).Info("Secret exists")
-	return s, true, nil
+	return s, exists, nil
 }
 
 func GetSecret(ctx context.Context, client ctrlclient.Client, objKey ctrlclient.ObjectKey) (*corev1.Secret, error) {
@@ -337,15 +335,44 @@ func GetSecret(ctx context.Context, client ctrlclient.Client, objKey ctrlclient.
 	return &s, err
 }
 
-// checkSecretIsOwnedByObj validates the Secret is owned by obj by checking its Labels and OwnerReferences.
-func checkSecretIsOwnedByObj(dest *corev1.Secret, references []metav1.OwnerReference) error {
-	var errs error
-	// checking for Secret ownership relies on first checking the Secret's labels,
-	// then verifying that its OwnerReferences match the SyncableSecret.
+func getSecretExists(ctx context.Context, client ctrlclient.Client, objKey ctrlclient.ObjectKey) (*corev1.Secret, bool, error) {
+	s, err := GetSecret(ctx, client, objKey)
+	var exists bool
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			err = nil
+		}
+	} else {
+		exists = true
+	}
+	return s, exists, err
+}
 
+func hasOwnerLabels(obj ctrlclient.Object) bool {
+	return checkOwnerLabels(obj) == nil
+}
+
+func checkOwnerLabels(obj ctrlclient.Object) error {
 	// check that all owner labels are present and valid, if not return an error
 	// this may cause issues if we ever add new "owner" labels, but for now this check should be good enough.
-	key := ctrlclient.ObjectKeyFromObject(dest)
+	var errs error
+
+	labels := obj.GetLabels()
+	for k, v := range OwnerLabels {
+		if o, ok := labels[k]; o != v || !ok {
+			errs = errors.Join(errs, fmt.Errorf(
+				"invalid owner label, key=%s, present=%t", k, ok))
+		}
+	}
+
+	return errs
+}
+
+// checkSecretIsOwnedByObj validates the Secret is owned by obj by checking its Labels and OwnerReferences.
+func checkSecretIsOwnedByObj(dest *corev1.Secret, references []metav1.OwnerReference) error {
+	// checking for Secret ownership relies on first checking the Secret's labels,
+	// then verifying that its OwnerReferences match the SyncableSecret.
+	errs := checkOwnerLabels(dest)
 	for k, v := range OwnerLabels {
 		if o, ok := dest.Labels[k]; o != v || !ok {
 			errs = errors.Join(errs, fmt.Errorf(
@@ -353,6 +380,7 @@ func checkSecretIsOwnedByObj(dest *corev1.Secret, references []metav1.OwnerRefer
 		}
 	}
 	// check that obj is the Secret's true Owner
+	key := ctrlclient.ObjectKeyFromObject(dest)
 	if len(dest.OwnerReferences) > 0 {
 		if !equality.Semantic.DeepEqual(dest.OwnerReferences, references) {
 			// we are not the owner, perhaps another syncable-secret resource owns this secret?

--- a/internal/helpers/secrets_test.go
+++ b/internal/helpers/secrets_test.go
@@ -185,10 +185,7 @@ func TestFindSecretsOwnedByObj(t *testing.T) {
 
 func TestSyncSecret(t *testing.T) {
 	ctx := context.Background()
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(secretsv1beta1.AddToScheme(scheme))
-	clientBuilder := fake.NewClientBuilder().WithScheme(scheme)
+	clientBuilder := newClientBuilder()
 
 	defaultOwner := &secretsv1beta1.VaultDynamicSecret{
 		TypeMeta: metav1.TypeMeta{
@@ -217,6 +214,15 @@ func TestSyncSecret(t *testing.T) {
 	ownerWithDestNoCreate := &secretsv1beta1.VaultDynamicSecret{}
 	ownerWithDest.DeepCopyInto(ownerWithDestNoCreate)
 	ownerWithDestNoCreate.Spec.Destination.Create = false
+
+	ownerWithDestNoCreateClobber := &secretsv1beta1.VaultDynamicSecret{}
+	ownerWithDest.DeepCopyInto(ownerWithDestNoCreateClobber)
+	ownerWithDestNoCreateClobber.Spec.Destination.Create = false
+	ownerWithDestNoCreateClobber.Spec.Destination.Overwrite = true
+
+	ownerWithDestClobber := &secretsv1beta1.VaultDynamicSecret{}
+	ownerWithDest.DeepCopyInto(ownerWithDestClobber)
+	ownerWithDestClobber.Spec.Destination.Overwrite = true
 
 	invalidNoDest := &secretsv1beta1.VaultDynamicSecret{
 		TypeMeta:   defaultOwner.TypeMeta,
@@ -254,6 +260,7 @@ func TestSyncSecret(t *testing.T) {
 		data               map[string][]byte
 		orphans            int
 		createDest         bool
+		destLabels         map[string]string
 		expectSecretsCount int
 		opts               []SyncOptions
 		wantErr            assert.ErrorAssertionFunc
@@ -393,6 +400,37 @@ func TestSyncSecret(t *testing.T) {
 					"not the owner of the destination Secret foo/baz")
 			},
 		},
+		{
+			name:               "invalid-dest-exists-no-create-overwrite",
+			client:             clientBuilder.Build(),
+			obj:                ownerWithDestNoCreateClobber,
+			createDest:         false,
+			expectSecretsCount: 0,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err,
+					"destination secret foo/baz does not exist, and create=false")
+			},
+		},
+		{
+			name:               "dest-exists-not-owned-overwrite-true",
+			client:             clientBuilder.Build(),
+			obj:                ownerWithDestClobber,
+			createDest:         true,
+			expectSecretsCount: 1,
+			wantErr:            assert.NoError,
+		},
+		{
+			name:               "dest-exists-owned-overwrite-true",
+			client:             clientBuilder.Build(),
+			obj:                ownerWithDestClobber,
+			createDest:         true,
+			destLabels:         OwnerLabels,
+			expectSecretsCount: 1,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err,
+					"not the owner of the destination Secret foo/baz")
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -404,6 +442,7 @@ func TestSyncSecret(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      tt.obj.Spec.Destination.Name,
 						Namespace: tt.obj.GetNamespace(),
+						Labels:    tt.destLabels,
 					},
 				}
 				require.NoError(t, tt.client.Create(ctx, s))

--- a/internal/helpers/secrets_test.go
+++ b/internal/helpers/secrets_test.go
@@ -215,14 +215,14 @@ func TestSyncSecret(t *testing.T) {
 	ownerWithDest.DeepCopyInto(ownerWithDestNoCreate)
 	ownerWithDestNoCreate.Spec.Destination.Create = false
 
-	ownerWithDestNoCreateClobber := &secretsv1beta1.VaultDynamicSecret{}
-	ownerWithDest.DeepCopyInto(ownerWithDestNoCreateClobber)
-	ownerWithDestNoCreateClobber.Spec.Destination.Create = false
-	ownerWithDestNoCreateClobber.Spec.Destination.Overwrite = true
+	ownerWithDestNoCreateOverwrite := &secretsv1beta1.VaultDynamicSecret{}
+	ownerWithDest.DeepCopyInto(ownerWithDestNoCreateOverwrite)
+	ownerWithDestNoCreateOverwrite.Spec.Destination.Create = false
+	ownerWithDestNoCreateOverwrite.Spec.Destination.Overwrite = true
 
-	ownerWithDestClobber := &secretsv1beta1.VaultDynamicSecret{}
-	ownerWithDest.DeepCopyInto(ownerWithDestClobber)
-	ownerWithDestClobber.Spec.Destination.Overwrite = true
+	ownerWithDestOverwrite := &secretsv1beta1.VaultDynamicSecret{}
+	ownerWithDest.DeepCopyInto(ownerWithDestOverwrite)
+	ownerWithDestOverwrite.Spec.Destination.Overwrite = true
 
 	invalidNoDest := &secretsv1beta1.VaultDynamicSecret{
 		TypeMeta:   defaultOwner.TypeMeta,
@@ -403,7 +403,7 @@ func TestSyncSecret(t *testing.T) {
 		{
 			name:               "invalid-dest-exists-no-create-overwrite",
 			client:             clientBuilder.Build(),
-			obj:                ownerWithDestNoCreateClobber,
+			obj:                ownerWithDestNoCreateOverwrite,
 			createDest:         false,
 			expectSecretsCount: 0,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
@@ -414,7 +414,7 @@ func TestSyncSecret(t *testing.T) {
 		{
 			name:               "dest-exists-not-owned-overwrite-true",
 			client:             clientBuilder.Build(),
-			obj:                ownerWithDestClobber,
+			obj:                ownerWithDestOverwrite,
 			createDest:         true,
 			expectSecretsCount: 1,
 			wantErr:            assert.NoError,
@@ -422,7 +422,7 @@ func TestSyncSecret(t *testing.T) {
 		{
 			name:               "dest-exists-owned-overwrite-true",
 			client:             clientBuilder.Build(),
-			obj:                ownerWithDestClobber,
+			obj:                ownerWithDestOverwrite,
 			createDest:         true,
 			destLabels:         OwnerLabels,
 			expectSecretsCount: 1,


### PR DESCRIPTION
Adds a new configuration option `spec.destination.overwrite` that when set to true VSO will replace an existing destination secret that it does not currently own. VSO will then take ownership of the destination secret's life-cycle.

Closes #337