### PR TITLE
update api docs to include namespace requirements for auth components

### DIFF
--- a/api/v1beta1/hcpvaultsecretsapp_types.go
+++ b/api/v1beta1/hcpvaultsecretsapp_types.go
@@ -14,8 +14,8 @@ type HCPVaultSecretsAppSpec struct {
 	// HCPAuthRef to the HCPAuth resource, can be prefixed with a namespace, eg:
 	// `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default
 	// to the namespace of the HCPAuth CR. If no value is specified for HCPAuthRef the
-	// Operator will default to the `default` HCPAuth, configured in its own
-	// Kubernetes namespace. HCPAuthRef string `json:"hcpAuthRef,omitempty"`
+	// Operator will default to the `default` HCPAuth, configured in the operators
+	// namespace. HCPAuthRef string `json:"hcpAuthRef,omitempty"`
 	HCPAuthRef string `json:"hcpAuthRef,omitempty"`
 	// RefreshAfter a period of time, in duration notation e.g. 30s, 1m, 24h
 	// +kubebuilder:validation:Type=string

--- a/api/v1beta1/hcpvaultsecretsapp_types.go
+++ b/api/v1beta1/hcpvaultsecretsapp_types.go
@@ -14,8 +14,8 @@ type HCPVaultSecretsAppSpec struct {
 	// HCPAuthRef to the HCPAuth resource, can be prefixed with a namespace, eg:
 	// `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default
 	// to the namespace of the HCPAuth CR. If no value is specified for HCPAuthRef the
-	// Operator will default to the `default` HCPAuth, configured in the operators
-	// namespace. HCPAuthRef string `json:"hcpAuthRef,omitempty"`
+	// Operator will default to the `default` HCPAuth, configured in the operator's
+	// namespace.
 	HCPAuthRef string `json:"hcpAuthRef,omitempty"`
 	// RefreshAfter a period of time, in duration notation e.g. 30s, 1m, 24h
 	// +kubebuilder:validation:Type=string

--- a/api/v1beta1/vaultauth_types.go
+++ b/api/v1beta1/vaultauth_types.go
@@ -14,8 +14,8 @@ import (
 type VaultAuthConfigKubernetes struct {
 	// Role to use for authenticating to Vault.
 	Role string `json:"role"`
-	// ServiceAccount to use when authenticating to Vault's kubernetes
-	// authentication backend.
+	// ServiceAccount to use when authenticating to Vault's
+	// authentication backend. This must reside in the consuming secret's (VDS/VSS/PKI) namespace.
 	ServiceAccount string `json:"serviceAccount"`
 	// TokenAudiences to include in the ServiceAccount token.
 	TokenAudiences []string `json:"audiences,omitempty"`
@@ -78,8 +78,8 @@ type VaultAuthConfigAWS struct {
 	// The IAM endpoint to use; if not set will use the default
 	IAMEndpoint string `json:"iamEndpoint,omitempty"`
 
-	// SecretRef is the name of a Kubernetes Secret which holds credentials for
-	// AWS. Expected keys include `access_key_id`, `secret_access_key`,
+	// SecretRef is the name of a Kubernetes Secret in the consumer's (VDS/VSS/PKI) namespace
+	// which holds credentials for AWS. Expected keys include `access_key_id`, `secret_access_key`,
 	// `session_token`
 	SecretRef string `json:"secretRef,omitempty"`
 
@@ -120,7 +120,7 @@ type VaultAuthSpec struct {
 	// VaultConnectionRef to the VaultConnection resource, can be prefixed with a namespace,
 	// eg: `namespaceA/vaultConnectionRefB`. If no namespace prefix is provided it will default to
 	// namespace of the VaultConnection CR. If no value is specified for VaultConnectionRef the
-	// Operator will default to	`default` VaultConnection, configured in its own Kubernetes namespace.
+	// Operator will default to the `default` VaultConnection, configured in the operators namespace.
 	VaultConnectionRef string `json:"vaultConnectionRef,omitempty"`
 	// Namespace to auth to in Vault
 	Namespace string `json:"namespace,omitempty"`

--- a/api/v1beta1/vaultauth_types.go
+++ b/api/v1beta1/vaultauth_types.go
@@ -120,7 +120,7 @@ type VaultAuthSpec struct {
 	// VaultConnectionRef to the VaultConnection resource, can be prefixed with a namespace,
 	// eg: `namespaceA/vaultConnectionRefB`. If no namespace prefix is provided it will default to
 	// namespace of the VaultConnection CR. If no value is specified for VaultConnectionRef the
-	// Operator will default to the `default` VaultConnection, configured in the operators namespace.
+	// Operator will default to the `default` VaultConnection, configured in the operator's namespace.
 	VaultConnectionRef string `json:"vaultConnectionRef,omitempty"`
 	// Namespace to auth to in Vault
 	Namespace string `json:"namespace,omitempty"`

--- a/api/v1beta1/vaultdynamicsecret_types.go
+++ b/api/v1beta1/vaultdynamicsecret_types.go
@@ -13,7 +13,7 @@ type VaultDynamicSecretSpec struct {
 	// VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,
 	// eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to
 	// namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will
-	// default to the `default` VaultAuth, configured in the operators namespace.
+	// default to the `default` VaultAuth, configured in the operator's namespace.
 	VaultAuthRef string `json:"vaultAuthRef,omitempty"`
 	// Namespace where the secrets engine is mounted in Vault.
 	Namespace string `json:"namespace,omitempty"`

--- a/api/v1beta1/vaultdynamicsecret_types.go
+++ b/api/v1beta1/vaultdynamicsecret_types.go
@@ -13,7 +13,7 @@ type VaultDynamicSecretSpec struct {
 	// VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,
 	// eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to
 	// namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will
-	// default to the `default` VaultAuth, configured in its own Kubernetes namespace.
+	// default to the `default` VaultAuth, configured in the operators namespace.
 	VaultAuthRef string `json:"vaultAuthRef,omitempty"`
 	// Namespace where the secrets engine is mounted in Vault.
 	Namespace string `json:"namespace,omitempty"`

--- a/api/v1beta1/vaultpkisecret_types.go
+++ b/api/v1beta1/vaultpkisecret_types.go
@@ -17,7 +17,7 @@ type VaultPKISecretSpec struct {
 	// VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,
 	// eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to
 	// namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will
-	// default to the `default` VaultAuth, configured in its own Kubernetes namespace.
+	// default to the `default` VaultAuth, configured in the operators namespace.
 	VaultAuthRef string `json:"vaultAuthRef,omitempty"`
 
 	// Namespace to get the secret from in Vault

--- a/api/v1beta1/vaultpkisecret_types.go
+++ b/api/v1beta1/vaultpkisecret_types.go
@@ -17,7 +17,7 @@ type VaultPKISecretSpec struct {
 	// VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,
 	// eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to
 	// namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will
-	// default to the `default` VaultAuth, configured in the operators namespace.
+	// default to the `default` VaultAuth, configured in the operator's namespace.
 	VaultAuthRef string `json:"vaultAuthRef,omitempty"`
 
 	// Namespace to get the secret from in Vault

--- a/api/v1beta1/vaultstaticsecret_types.go
+++ b/api/v1beta1/vaultstaticsecret_types.go
@@ -15,7 +15,7 @@ type VaultStaticSecretSpec struct {
 	// VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,
 	// eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to
 	// namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will
-	// default to the `default` VaultAuth, configured in the operators namespace.
+	// default to the `default` VaultAuth, configured in the operator's namespace.
 	VaultAuthRef string `json:"vaultAuthRef,omitempty"`
 	// Namespace to get the secret from in Vault
 	Namespace string `json:"namespace,omitempty"`

--- a/api/v1beta1/vaultstaticsecret_types.go
+++ b/api/v1beta1/vaultstaticsecret_types.go
@@ -15,7 +15,7 @@ type VaultStaticSecretSpec struct {
 	// VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace,
 	// eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to
 	// namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will
-	// default to the `default` VaultAuth, configured in its own Kubernetes namespace.
+	// default to the `default` VaultAuth, configured in the operators namespace.
 	VaultAuthRef string `json:"vaultAuthRef,omitempty"`
 	// Namespace to get the secret from in Vault
 	Namespace string `json:"namespace,omitempty"`

--- a/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -77,8 +77,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to the namespace of the HCPAuth
                   CR. If no value is specified for HCPAuthRef the Operator will default
-                  to the `default` HCPAuth, configured in the operators namespace.
-                  HCPAuthRef string `json:"hcpAuthRef,omitempty"`'
+                  to the `default` HCPAuth, configured in the operator''s namespace.'
                 type: string
               refreshAfter:
                 default: 600s

--- a/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -77,7 +77,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to the namespace of the HCPAuth
                   CR. If no value is specified for HCPAuthRef the Operator will default
-                  to the `default` HCPAuth, configured in its own Kubernetes namespace.
+                  to the `default` HCPAuth, configured in the operators namespace.
                   HCPAuthRef string `json:"hcpAuthRef,omitempty"`'
                 type: string
               refreshAfter:

--- a/chart/crds/secrets.hashicorp.com_vaultauths.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultauths.yaml
@@ -251,7 +251,7 @@ spec:
                   If no namespace prefix is provided it will default to namespace
                   of the VaultConnection CR. If no value is specified for VaultConnectionRef
                   the Operator will default to the `default` VaultConnection, configured
-                  in the operators namespace.'
+                  in the operator''s namespace.'
                 type: string
             required:
             - method

--- a/chart/crds/secrets.hashicorp.com_vaultauths.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultauths.yaml
@@ -94,9 +94,10 @@ spec:
                     description: Vault role to use for authenticating
                     type: string
                   secretRef:
-                    description: SecretRef is the name of a Kubernetes Secret which
-                      holds credentials for AWS. Expected keys include `access_key_id`,
-                      `secret_access_key`, `session_token`
+                    description: SecretRef is the name of a Kubernetes Secret in the
+                      consumer's (VDS/VSS/PKI) namespace which holds credentials for
+                      AWS. Expected keys include `access_key_id`, `secret_access_key`,
+                      `session_token`
                     type: string
                   sessionName:
                     description: The role session name to use when creating a webidentity
@@ -190,7 +191,8 @@ spec:
                     type: string
                   serviceAccount:
                     description: ServiceAccount to use when authenticating to Vault's
-                      kubernetes authentication backend.
+                      authentication backend. This must reside in the consuming secret's
+                      (VDS/VSS/PKI) namespace.
                     type: string
                   tokenExpirationSeconds:
                     default: 600
@@ -244,12 +246,12 @@ spec:
                 - mount
                 type: object
               vaultConnectionRef:
-                description: "VaultConnectionRef to the VaultConnection resource,
+                description: 'VaultConnectionRef to the VaultConnection resource,
                   can be prefixed with a namespace, eg: `namespaceA/vaultConnectionRefB`.
                   If no namespace prefix is provided it will default to namespace
                   of the VaultConnection CR. If no value is specified for VaultConnectionRef
-                  the Operator will default to\t`default` VaultConnection, configured
-                  in its own Kubernetes namespace."
+                  the Operator will default to the `default` VaultConnection, configured
+                  in the operators namespace.'
                 type: string
             required:
             - method

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -154,7 +154,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to namespace of the VaultAuth
                   CR. If no value is specified for VaultAuthRef the Operator will
-                  default to the `default` VaultAuth, configured in its own Kubernetes
+                  default to the `default` VaultAuth, configured in the operators
                   namespace.'
                 type: string
             required:

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -154,7 +154,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to namespace of the VaultAuth
                   CR. If no value is specified for VaultAuthRef the Operator will
-                  default to the `default` VaultAuth, configured in the operators
+                  default to the `default` VaultAuth, configured in the operator''s
                   namespace.'
                 type: string
             required:

--- a/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -190,7 +190,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to namespace of the VaultAuth
                   CR. If no value is specified for VaultAuthRef the Operator will
-                  default to the `default` VaultAuth, configured in the operators
+                  default to the `default` VaultAuth, configured in the operator''s
                   namespace.'
                 type: string
             required:

--- a/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -190,7 +190,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to namespace of the VaultAuth
                   CR. If no value is specified for VaultAuthRef the Operator will
-                  default to the `default` VaultAuth, configured in its own Kubernetes
+                  default to the `default` VaultAuth, configured in the operators
                   namespace.'
                 type: string
             required:

--- a/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -134,7 +134,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to namespace of the VaultAuth
                   CR. If no value is specified for VaultAuthRef the Operator will
-                  default to the `default` VaultAuth, configured in its own Kubernetes
+                  default to the `default` VaultAuth, configured in the operators
                   namespace.'
                 type: string
               version:

--- a/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -134,7 +134,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to namespace of the VaultAuth
                   CR. If no value is specified for VaultAuthRef the Operator will
-                  default to the `default` VaultAuth, configured in the operators
+                  default to the `default` VaultAuth, configured in the operator''s
                   namespace.'
                 type: string
               version:

--- a/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -77,8 +77,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to the namespace of the HCPAuth
                   CR. If no value is specified for HCPAuthRef the Operator will default
-                  to the `default` HCPAuth, configured in the operators namespace.
-                  HCPAuthRef string `json:"hcpAuthRef,omitempty"`'
+                  to the `default` HCPAuth, configured in the operator''s namespace.'
                 type: string
               refreshAfter:
                 default: 600s

--- a/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -77,7 +77,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to the namespace of the HCPAuth
                   CR. If no value is specified for HCPAuthRef the Operator will default
-                  to the `default` HCPAuth, configured in its own Kubernetes namespace.
+                  to the `default` HCPAuth, configured in the operators namespace.
                   HCPAuthRef string `json:"hcpAuthRef,omitempty"`'
                 type: string
               refreshAfter:

--- a/config/crd/bases/secrets.hashicorp.com_vaultauths.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultauths.yaml
@@ -251,7 +251,7 @@ spec:
                   If no namespace prefix is provided it will default to namespace
                   of the VaultConnection CR. If no value is specified for VaultConnectionRef
                   the Operator will default to the `default` VaultConnection, configured
-                  in the operators namespace.'
+                  in the operator''s namespace.'
                 type: string
             required:
             - method

--- a/config/crd/bases/secrets.hashicorp.com_vaultauths.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultauths.yaml
@@ -94,9 +94,10 @@ spec:
                     description: Vault role to use for authenticating
                     type: string
                   secretRef:
-                    description: SecretRef is the name of a Kubernetes Secret which
-                      holds credentials for AWS. Expected keys include `access_key_id`,
-                      `secret_access_key`, `session_token`
+                    description: SecretRef is the name of a Kubernetes Secret in the
+                      consumer's (VDS/VSS/PKI) namespace which holds credentials for
+                      AWS. Expected keys include `access_key_id`, `secret_access_key`,
+                      `session_token`
                     type: string
                   sessionName:
                     description: The role session name to use when creating a webidentity
@@ -190,7 +191,8 @@ spec:
                     type: string
                   serviceAccount:
                     description: ServiceAccount to use when authenticating to Vault's
-                      kubernetes authentication backend.
+                      authentication backend. This must reside in the consuming secret's
+                      (VDS/VSS/PKI) namespace.
                     type: string
                   tokenExpirationSeconds:
                     default: 600
@@ -244,12 +246,12 @@ spec:
                 - mount
                 type: object
               vaultConnectionRef:
-                description: "VaultConnectionRef to the VaultConnection resource,
+                description: 'VaultConnectionRef to the VaultConnection resource,
                   can be prefixed with a namespace, eg: `namespaceA/vaultConnectionRefB`.
                   If no namespace prefix is provided it will default to namespace
                   of the VaultConnection CR. If no value is specified for VaultConnectionRef
-                  the Operator will default to\t`default` VaultConnection, configured
-                  in its own Kubernetes namespace."
+                  the Operator will default to the `default` VaultConnection, configured
+                  in the operators namespace.'
                 type: string
             required:
             - method

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -154,7 +154,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to namespace of the VaultAuth
                   CR. If no value is specified for VaultAuthRef the Operator will
-                  default to the `default` VaultAuth, configured in its own Kubernetes
+                  default to the `default` VaultAuth, configured in the operators
                   namespace.'
                 type: string
             required:

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -154,7 +154,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to namespace of the VaultAuth
                   CR. If no value is specified for VaultAuthRef the Operator will
-                  default to the `default` VaultAuth, configured in the operators
+                  default to the `default` VaultAuth, configured in the operator''s
                   namespace.'
                 type: string
             required:

--- a/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -190,7 +190,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to namespace of the VaultAuth
                   CR. If no value is specified for VaultAuthRef the Operator will
-                  default to the `default` VaultAuth, configured in the operators
+                  default to the `default` VaultAuth, configured in the operator''s
                   namespace.'
                 type: string
             required:

--- a/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -190,7 +190,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to namespace of the VaultAuth
                   CR. If no value is specified for VaultAuthRef the Operator will
-                  default to the `default` VaultAuth, configured in its own Kubernetes
+                  default to the `default` VaultAuth, configured in the operators
                   namespace.'
                 type: string
             required:

--- a/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -134,7 +134,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to namespace of the VaultAuth
                   CR. If no value is specified for VaultAuthRef the Operator will
-                  default to the `default` VaultAuth, configured in its own Kubernetes
+                  default to the `default` VaultAuth, configured in the operators
                   namespace.'
                 type: string
               version:

--- a/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -134,7 +134,7 @@ spec:
                   with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace
                   prefix is provided it will default to namespace of the VaultAuth
                   CR. If no value is specified for VaultAuthRef the Operator will
-                  default to the `default` VaultAuth, configured in the operators
+                  default to the `default` VaultAuth, configured in the operator''s
                   namespace.'
                 type: string
               version:

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -159,7 +159,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `appName` _string_ | AppName of the Vault Secrets Application that is to be synced. |
-| `hcpAuthRef` _string_ | HCPAuthRef to the HCPAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to the namespace of the HCPAuth CR. If no value is specified for HCPAuthRef the Operator will default to the `default` HCPAuth, configured in its own Kubernetes namespace. HCPAuthRef string `json:"hcpAuthRef,omitempty"` |
+| `hcpAuthRef` _string_ | HCPAuthRef to the HCPAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to the namespace of the HCPAuth CR. If no value is specified for HCPAuthRef the Operator will default to the `default` HCPAuth, configured in the operators namespace. HCPAuthRef string `json:"hcpAuthRef,omitempty"` |
 | `refreshAfter` _string_ | RefreshAfter a period of time, in duration notation e.g. 30s, 1m, 24h |
 | `rolloutRestartTargets` _[RolloutRestartTarget](#rolloutrestarttarget) array_ | RolloutRestartTargets should be configured whenever the application(s) consuming the HCP Vault Secrets App does not support dynamically reloading a rotated secret. In that case one, or more RolloutRestartTarget(s) can be configured here. The Operator will trigger a "rollout-restart" for each target whenever the Vault secret changes between reconciliation events. See RolloutRestartTarget for more details. |
 | `destination` _[Destination](#destination)_ | Destination provides configuration necessary for syncing the HCP Vault Application secrets to Kubernetes. |
@@ -235,7 +235,7 @@ _Appears in:_
 | `sessionName` _string_ | The role session name to use when creating a webidentity provider |
 | `stsEndpoint` _string_ | The STS endpoint to use; if not set will use the default |
 | `iamEndpoint` _string_ | The IAM endpoint to use; if not set will use the default |
-| `secretRef` _string_ | SecretRef is the name of a Kubernetes Secret which holds credentials for AWS. Expected keys include `access_key_id`, `secret_access_key`, `session_token` |
+| `secretRef` _string_ | SecretRef is the name of a Kubernetes Secret in the consumer's (VDS/VSS/PKI) namespace which holds credentials for AWS. Expected keys include `access_key_id`, `secret_access_key`, `session_token` |
 | `irsaServiceAccount` _string_ | IRSAServiceAccount name to use with IAM Roles for Service Accounts (IRSA), and should be annotated with "eks.amazonaws.com/role-arn". This ServiceAccount will be checked for other EKS annotations: eks.amazonaws.com/audience and eks.amazonaws.com/token-expiration |
 
 
@@ -302,7 +302,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `role` _string_ | Role to use for authenticating to Vault. |
-| `serviceAccount` _string_ | ServiceAccount to use when authenticating to Vault's kubernetes authentication backend. |
+| `serviceAccount` _string_ | ServiceAccount to use when authenticating to Vault's authentication backend. This must reside in the consuming secret's (VDS/VSS/PKI) namespace. |
 | `audiences` _string array_ | TokenAudiences to include in the ServiceAccount token. |
 | `tokenExpirationSeconds` _integer_ | TokenExpirationSeconds to set the ServiceAccount token. |
 
@@ -334,7 +334,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `vaultConnectionRef` _string_ | VaultConnectionRef to the VaultConnection resource, can be prefixed with a namespace, eg: `namespaceA/vaultConnectionRefB`. If no namespace prefix is provided it will default to namespace of the VaultConnection CR. If no value is specified for VaultConnectionRef the Operator will default to	`default` VaultConnection, configured in its own Kubernetes namespace. |
+| `vaultConnectionRef` _string_ | VaultConnectionRef to the VaultConnection resource, can be prefixed with a namespace, eg: `namespaceA/vaultConnectionRefB`. If no namespace prefix is provided it will default to namespace of the VaultConnection CR. If no value is specified for VaultConnectionRef the Operator will default to the `default` VaultConnection, configured in the operators namespace. |
 | `namespace` _string_ | Namespace to auth to in Vault |
 | `allowedNamespaces` _string array_ | AllowedNamespaces Kubernetes Namespaces which are allow-listed for use with this AuthMethod. This field allows administrators to customize which Kubernetes namespaces are authorized to use with this AuthMethod. While Vault will still enforce its own rules, this has the added configurability of restricting which VaultAuthMethods can be used by which namespaces. Accepted values: []{"*"} - wildcard, all namespaces. []{"a", "b"} - list of namespaces. unset - disallow all namespaces except the Operator's the VaultAuthMethod's namespace, this is the default behavior. |
 | `method` _string_ | Method to use when authenticating to Vault. |
@@ -448,7 +448,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in its own Kubernetes namespace. |
+| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operators namespace. |
 | `namespace` _string_ | Namespace where the secrets engine is mounted in Vault. |
 | `mount` _string_ | Mount path of the secret's engine in Vault. |
 | `requestHTTPMethod` _string_ | RequestHTTPMethod to use when syncing Secrets from Vault. Setting a value here is not typically required. If left unset the Operator will make requests using the GET method. In the case where Params are specified the Operator will use the PUT method. Please consult https://developer.hashicorp.com/vault/docs/secrets if you are uncertain about what method to use. Of note, the Vault client treats PUT and POST as being equivalent. The underlying Vault client implementation will always use the PUT method. |
@@ -507,7 +507,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in its own Kubernetes namespace. |
+| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operators namespace. |
 | `namespace` _string_ | Namespace to get the secret from in Vault |
 | `mount` _string_ | Mount for the secret in Vault |
 | `role` _string_ | Role in Vault to use when issuing TLS certificates. |
@@ -609,7 +609,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in its own Kubernetes namespace. |
+| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operators namespace. |
 | `namespace` _string_ | Namespace to get the secret from in Vault |
 | `mount` _string_ | Mount for the secret in Vault |
 | `path` _string_ | Path of the secret in Vault, corresponds to the `path` parameter for, kv-v1: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#read-secret kv-v2: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version |

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -159,7 +159,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `appName` _string_ | AppName of the Vault Secrets Application that is to be synced. |
-| `hcpAuthRef` _string_ | HCPAuthRef to the HCPAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to the namespace of the HCPAuth CR. If no value is specified for HCPAuthRef the Operator will default to the `default` HCPAuth, configured in the operators namespace. HCPAuthRef string `json:"hcpAuthRef,omitempty"` |
+| `hcpAuthRef` _string_ | HCPAuthRef to the HCPAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to the namespace of the HCPAuth CR. If no value is specified for HCPAuthRef the Operator will default to the `default` HCPAuth, configured in the operator's namespace. |
 | `refreshAfter` _string_ | RefreshAfter a period of time, in duration notation e.g. 30s, 1m, 24h |
 | `rolloutRestartTargets` _[RolloutRestartTarget](#rolloutrestarttarget) array_ | RolloutRestartTargets should be configured whenever the application(s) consuming the HCP Vault Secrets App does not support dynamically reloading a rotated secret. In that case one, or more RolloutRestartTarget(s) can be configured here. The Operator will trigger a "rollout-restart" for each target whenever the Vault secret changes between reconciliation events. See RolloutRestartTarget for more details. |
 | `destination` _[Destination](#destination)_ | Destination provides configuration necessary for syncing the HCP Vault Application secrets to Kubernetes. |
@@ -334,7 +334,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `vaultConnectionRef` _string_ | VaultConnectionRef to the VaultConnection resource, can be prefixed with a namespace, eg: `namespaceA/vaultConnectionRefB`. If no namespace prefix is provided it will default to namespace of the VaultConnection CR. If no value is specified for VaultConnectionRef the Operator will default to the `default` VaultConnection, configured in the operators namespace. |
+| `vaultConnectionRef` _string_ | VaultConnectionRef to the VaultConnection resource, can be prefixed with a namespace, eg: `namespaceA/vaultConnectionRefB`. If no namespace prefix is provided it will default to namespace of the VaultConnection CR. If no value is specified for VaultConnectionRef the Operator will default to the `default` VaultConnection, configured in the operator's namespace. |
 | `namespace` _string_ | Namespace to auth to in Vault |
 | `allowedNamespaces` _string array_ | AllowedNamespaces Kubernetes Namespaces which are allow-listed for use with this AuthMethod. This field allows administrators to customize which Kubernetes namespaces are authorized to use with this AuthMethod. While Vault will still enforce its own rules, this has the added configurability of restricting which VaultAuthMethods can be used by which namespaces. Accepted values: []{"*"} - wildcard, all namespaces. []{"a", "b"} - list of namespaces. unset - disallow all namespaces except the Operator's the VaultAuthMethod's namespace, this is the default behavior. |
 | `method` _string_ | Method to use when authenticating to Vault. |
@@ -448,7 +448,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operators namespace. |
+| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operator's namespace. |
 | `namespace` _string_ | Namespace where the secrets engine is mounted in Vault. |
 | `mount` _string_ | Mount path of the secret's engine in Vault. |
 | `requestHTTPMethod` _string_ | RequestHTTPMethod to use when syncing Secrets from Vault. Setting a value here is not typically required. If left unset the Operator will make requests using the GET method. In the case where Params are specified the Operator will use the PUT method. Please consult https://developer.hashicorp.com/vault/docs/secrets if you are uncertain about what method to use. Of note, the Vault client treats PUT and POST as being equivalent. The underlying Vault client implementation will always use the PUT method. |
@@ -507,7 +507,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operators namespace. |
+| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operator's namespace. |
 | `namespace` _string_ | Namespace to get the secret from in Vault |
 | `mount` _string_ | Mount for the secret in Vault |
 | `role` _string_ | Role in Vault to use when issuing TLS certificates. |
@@ -609,7 +609,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operators namespace. |
+| `vaultAuthRef` _string_ | VaultAuthRef to the VaultAuth resource, can be prefixed with a namespace, eg: `namespaceA/vaultAuthRefB`. If no namespace prefix is provided it will default to namespace of the VaultAuth CR. If no value is specified for VaultAuthRef the Operator will default to the `default` VaultAuth, configured in the operator's namespace. |
 | `namespace` _string_ | Namespace to get the secret from in Vault |
 | `mount` _string_ | Mount for the secret in Vault |
 | `path` _string_ | Path of the secret in Vault, corresponds to the `path` parameter for, kv-v1: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#read-secret kv-v2: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version |


### PR DESCRIPTION
Adds namespace requirements for vault auth components to clarify where the serviceaccount/secretRefs need to reside.