### PR TITLE
demo: add cross Vault namespace example

### DIFF
--- a/demo.mk
+++ b/demo.mk
@@ -36,6 +36,7 @@ demo-destroy: demo-delete-kind ## delete the kind cluster
 .PHONY: demo-infra-vault
 demo-infra-vault: ## Deploy Vault for the demo
 	$(MAKE) setup-vault \
+		VAULT_ENTERPRISE=$(VAULT_ENTERPRISE) \
 		TF_VAULT_STATE_DIR=$(TF_VAULT_STATE_DIR) \
 		TF_INFRA_STATE_DIR=$(TF_VAULT_STATE_DIR) \
 		K8S_CLUSTER_CONTEXT=$(K8S_CLUSTER_CONTEXT)
@@ -47,6 +48,19 @@ demo-infra-app: demo-setup-kind ## Deploy Postgres for the demo
 	cp $(DEMO_ROOT)/infra/app/*.tf $(TF_APP_STATE_DIR)/.
 	$(TERRAFORM) -chdir=$(TF_APP_STATE_DIR) init -upgrade
 	$(TERRAFORM) -chdir=$(TF_APP_STATE_DIR) apply -auto-approve \
+		-var vault_enterprise=$(VAULT_ENTERPRISE) \
+		-var vault_address=http://127.0.0.1:38302 \
+		-var vault_token=root \
+		-var k8s_config_context=$(K8S_CLUSTER_CONTEXT) \
+		$(EXTRA_VARS) || exit 1 \
+
+.PHONY: demo-infra-app-plan
+demo-infra-app-plan: demo-setup-kind ## Deploy Postgres for the demo
+	@mkdir -p $(TF_APP_STATE_DIR)
+	rm -f $(TF_APP_STATE_DIR)/*.tf
+	cp $(DEMO_ROOT)/infra/app/*.tf $(TF_APP_STATE_DIR)/.
+	$(TERRAFORM) -chdir=$(TF_APP_STATE_DIR) init -upgrade
+	$(TERRAFORM) -chdir=$(TF_APP_STATE_DIR) plan \
 		-var vault_enterprise=$(VAULT_ENTERPRISE) \
 		-var vault_address=http://127.0.0.1:38302 \
 		-var vault_token=root \

--- a/demo/infra/app/app.tf
+++ b/demo/infra/app/app.tf
@@ -39,7 +39,7 @@ resource "kubernetes_manifest" "vault-auth-default" {
       namespace = vault_auth_backend.default.namespace
       mount     = vault_auth_backend.default.path
       kubernetes = {
-        role           = vault_kubernetes_auth_backend_role.dev.role_name
+        role           = vault_kubernetes_auth_backend_role.default.role_name
         serviceAccount = "default"
         audiences = [
           "vault",
@@ -117,7 +117,7 @@ resource "kubernetes_secret" "db" {
 resource "kubernetes_deployment" "example" {
   metadata {
     name      = "vso-db-demo"
-    namespace = kubernetes_namespace.dev.metadata[0].name
+    namespace = local.k8s_namespace
     labels = {
       test = "vso-db-demo"
     }

--- a/demo/infra/app/cross-vault-ns.tf
+++ b/demo/infra/app/cross-vault-ns.tf
@@ -1,0 +1,263 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# demonstrates how to setup cross Vault namespace for VSO and K8s auth when var.vault_enterprise = true
+
+# sets the group policy application to work with with cross Vault namespace auth
+resource "vault_generic_endpoint" "sys-group-policy-application" {
+  count = var.vault_enterprise ? 1 : 0
+  data_json = jsonencode(
+    {
+      group_policy_application_mode = "any"
+    }
+  )
+  path = "sys/config/group-policy-application"
+}
+
+# default service account from the tenant namespace
+resource "kubernetes_service_account" "tenant" {
+  metadata {
+    namespace = local.k8s_namespace_name
+    name      = "tenant"
+    labels = {
+      "x-ns" : var.vault_enterprise
+    }
+  }
+}
+
+# identity entity that maps to the service account name
+# provides cross Vault namespace when the k8s auth role's alias_name_source = "serviceaccount_name"
+resource "vault_identity_entity" "tenant-sa-name" {
+  namespace = local.namespace
+  name      = "${kubernetes_service_account.tenant.metadata[0].namespace}/${kubernetes_service_account.tenant.metadata[0].name}"
+}
+
+# identity entity that maps to the service account UID
+# provides cross Vault namespace when the k8s auth role's alias_name_source = "serviceaccount_uid"
+resource "vault_identity_entity" "tenant-sa-uid" {
+  namespace = local.namespace
+  name      = kubernetes_service_account.tenant.metadata[0].uid
+}
+
+# identity entity alias that maps to the service account UID
+# provides cross Vault namespace when the k8s auth role's alias_name_source = "serviceaccount_uid"
+resource "vault_identity_entity_alias" "tenant-sa-uid" {
+  namespace      = local.namespace
+  name           = kubernetes_service_account.tenant.metadata[0].uid
+  mount_accessor = vault_auth_backend.default.accessor
+  canonical_id   = vault_identity_entity.tenant-sa-uid.id
+}
+
+# identity entity alias that maps to the service account name
+# provides cross Vault namespace when the k8s auth role's alias_name_source = "serviceaccount_name"
+resource "vault_identity_entity_alias" "tenant-sa-name" {
+  namespace      = local.namespace
+  name           = vault_identity_entity.tenant-sa-name.name
+  mount_accessor = vault_auth_backend.default.accessor
+  canonical_id   = vault_identity_entity.tenant-sa-name.id
+}
+
+# parent identity group that holds all vso tenant entities
+resource "vault_identity_group" "vso-tenants-parent" {
+  namespace = local.tenant_namespace
+  name      = "vso-tenants-parent"
+  type      = "internal"
+  member_entity_ids = [
+    vault_identity_entity_alias.tenant-sa-name.canonical_id,
+    vault_identity_entity_alias.tenant-sa-uid.canonical_id,
+  ]
+}
+
+# identity group that provides cross namespace support when var.vault_enterprise is true
+resource "vault_identity_group" "vso-tenants" {
+  namespace        = local.tenant_namespace
+  member_group_ids = [vault_identity_group.vso-tenants-parent.id]
+  name             = "vso-tenants"
+  policies = [
+    vault_policy.tenant-kv.name,
+  ]
+  type = "internal"
+}
+
+resource "vault_policy" "tenant-kv" {
+  name      = "tenant-kv"
+  namespace = local.tenant_namespace
+  policy    = <<EOF
+path "${vault_mount.tenant-kv.path}/data/${vault_kv_secret_v2.tenant-kv.name}" {
+   capabilities = ["read"]
+}
+EOF
+}
+
+resource "vault_mount" "tenant-kv" {
+  namespace = local.tenant_namespace
+  path      = "tenant-kv"
+  type      = "kv-v2"
+}
+
+resource "vault_kv_secret_v2" "tenant-kv" {
+  namespace           = local.tenant_namespace
+  mount               = vault_mount.tenant-kv.path
+  name                = "x-ns"
+  delete_all_versions = true
+  data_json = jsonencode(
+    {
+      x_ns   = "true"
+      secret = "foo"
+    }
+  )
+}
+
+# tenant role used to test cross vault namespace with identity alias using the serviceaccount name
+resource "vault_kubernetes_auth_backend_role" "tenant-sa-name" {
+  namespace                        = vault_auth_backend.default.namespace
+  backend                          = vault_kubernetes_auth_backend_config.default.backend
+  role_name                        = "${local.auth_role}-alias"
+  alias_name_source                = "serviceaccount_name"
+  bound_service_account_names      = [kubernetes_service_account.tenant.metadata[0].name]
+  bound_service_account_namespaces = [kubernetes_service_account.tenant.metadata[0].namespace]
+  token_period                     = 120
+  token_policies = [
+    vault_policy.db.name,
+  ]
+  audience = "vault"
+}
+
+# tenant role used to test cross vault namespace with identity alias using the serviceaccount UID
+resource "vault_kubernetes_auth_backend_role" "tenant-sa-uid" {
+  namespace                        = vault_auth_backend.default.namespace
+  backend                          = vault_kubernetes_auth_backend_config.default.backend
+  role_name                        = "${local.auth_role}-uid"
+  alias_name_source                = "serviceaccount_uid"
+  bound_service_account_names      = [kubernetes_service_account.tenant.metadata[0].name]
+  bound_service_account_namespaces = [kubernetes_service_account.tenant.metadata[0].namespace]
+  token_period                     = 120
+  token_policies = [
+    vault_policy.db.name,
+  ]
+  audience = "vault"
+}
+
+# VaultAuth for service account UID K8s auth role
+resource "kubernetes_manifest" "tenant-vault-auth-sa-uid" {
+  manifest = {
+    apiVersion = "secrets.hashicorp.com/v1beta1"
+    kind       = "VaultAuth"
+    metadata = {
+      name      = "vso-auth-sa-uid"
+      namespace = local.k8s_namespace
+      labels = {
+        "x-ns" : var.vault_enterprise
+      }
+    }
+    spec = {
+      namespace = vault_auth_backend.default.namespace
+      mount     = vault_auth_backend.default.path
+      method    = "kubernetes"
+      kubernetes = {
+        role           = vault_kubernetes_auth_backend_role.tenant-sa-uid.role_name
+        serviceAccount = kubernetes_service_account.tenant.metadata[0].name
+        audiences = [
+          "vault"
+        ]
+      }
+    }
+  }
+  field_manager {
+    # force field manager conflicts to be overridden
+    force_conflicts = true
+  }
+}
+
+# VaultAuth for service account name K8s auth role
+resource "kubernetes_manifest" "tenant-vault-auth-sa-name" {
+  manifest = {
+    apiVersion = "secrets.hashicorp.com/v1beta1"
+    kind       = "VaultAuth"
+    metadata = {
+      name      = "vso-auth-sa-name"
+      namespace = local.k8s_namespace
+      labels = {
+        "x-ns" : var.vault_enterprise
+      }
+    }
+    spec = {
+      namespace = vault_auth_backend.default.namespace
+      mount     = vault_auth_backend.default.path
+      method    = "kubernetes"
+      kubernetes = {
+        role           = vault_kubernetes_auth_backend_role.tenant-sa-name.role_name
+        serviceAccount = kubernetes_service_account.tenant.metadata[0].name
+        audiences = [
+          "vault"
+        ]
+      }
+    }
+  }
+  field_manager {
+    # force field manager conflicts to be overridden
+    force_conflicts = true
+  }
+}
+
+resource "kubernetes_manifest" "tenant-vss-uid" {
+  manifest = {
+    apiVersion = "secrets.hashicorp.com/v1beta1"
+    kind       = "VaultStaticSecret"
+    metadata = {
+      name      = "vso-${local.name_prefix}-vss-uid"
+      namespace = local.k8s_namespace
+      labels = {
+        "x-ns" : var.vault_enterprise
+      }
+    }
+    spec = {
+      namespace      = local.tenant_namespace
+      mount          = vault_mount.tenant-kv.path
+      type           = "kv-v2"
+      path           = vault_kv_secret_v2.tenant-kv.name
+      vaultAuthRef   = kubernetes_manifest.tenant-vault-auth-sa-uid.manifest.metadata.name
+      hmacSecretData = true
+      destination = {
+        create = true
+        name   = "vso-${local.name_prefix}-vss-uid"
+      }
+    }
+  }
+
+  field_manager {
+    # force field manager conflicts to be overridden
+    force_conflicts = true
+  }
+}
+
+resource "kubernetes_manifest" "tenant-vss-name" {
+  manifest = {
+    apiVersion = "secrets.hashicorp.com/v1beta1"
+    kind       = "VaultStaticSecret"
+    metadata = {
+      name      = "vso-${local.name_prefix}-vss-name"
+      namespace = local.k8s_namespace
+      labels = {
+        "x-ns" : var.vault_enterprise
+      }
+    }
+    spec = {
+      namespace      = local.tenant_namespace
+      mount          = vault_mount.tenant-kv.path
+      type           = "kv-v2"
+      path           = vault_kv_secret_v2.tenant-kv.name
+      vaultAuthRef   = kubernetes_manifest.tenant-vault-auth-sa-name.manifest.metadata.name
+      hmacSecretData = true
+      destination = {
+        create = true
+        name   = "vso-${local.name_prefix}-vss-name"
+      }
+    }
+  }
+
+  field_manager {
+    # force field manager conflicts to be overridden
+    force_conflicts = true
+  }
+}

--- a/demo/infra/app/hcpvs.tf
+++ b/demo/infra/app/hcpvs.tf
@@ -30,7 +30,7 @@ resource "kubernetes_secret" "hcp-vsa-sp" {
   count = var.with_hcp_vault_secrets ? 1 : 0
   metadata {
     name      = "vso-db-demo-hcp-vsa-sp"
-    namespace = kubernetes_namespace.dev.metadata[0].name
+    namespace = local.k8s_namespace
   }
   data = {
     "clientID"     = var.hcp_client_id
@@ -45,7 +45,7 @@ resource "kubernetes_manifest" "hcp-vsa-secret" {
     kind       = "HCPVaultSecretsApp"
     metadata = {
       name      = "vso-db-demo-hcp-vsa"
-      namespace = kubernetes_namespace.dev.metadata[0].name
+      namespace = local.k8s_namespace
     }
     spec = {
       appName      = var.hcp_hvs_app_name

--- a/demo/infra/app/locals.tf
+++ b/demo/infra/app/locals.tf
@@ -3,11 +3,14 @@
 
 locals {
   # common locals
-  name_prefix = "demo"
-  namespace   = var.vault_enterprise ? vault_namespace.test[0].path_fq : null
+  name_prefix      = "demo"
+  namespace        = var.vault_enterprise ? vault_namespace.test[0].path_fq : null
+  tenant_namespace = var.vault_enterprise ? vault_namespace.tenant[0].path_fq : null
 
   # k8s locals
-  k8s_namespace = "${local.name_prefix}-ns"
+  k8s_namespace_name = "${local.name_prefix}-ns"
+  # used to avoid duplicate declarations in in referring resources
+  k8s_namespace = kubernetes_namespace.dev.metadata[0].name
 
   # auth locals
   auth_mount         = "${local.name_prefix}-auth-mount"

--- a/demo/infra/app/main.tf
+++ b/demo/infra/app/main.tf
@@ -5,15 +5,15 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "2.11.0"
+      version = "2.12.1"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.17.0"
+      version = "2.25.2"
     }
     vault = {
       source  = "hashicorp/vault"
-      version = "3.12.0"
+      version = "3.24.0"
     }
   }
 }
@@ -38,11 +38,16 @@ provider "kubernetes" {
 
 resource "kubernetes_namespace" "dev" {
   metadata {
-    name = local.k8s_namespace
+    name = local.k8s_namespace_name
   }
 }
 
 resource "vault_namespace" "test" {
   count = var.vault_enterprise ? 1 : 0
   path  = "${local.name_prefix}-ns"
+}
+
+resource "vault_namespace" "tenant" {
+  count = var.vault_enterprise ? 1 : 0
+  path  = "${local.name_prefix}-tenant-ns"
 }

--- a/demo/infra/app/outputs.tf
+++ b/demo/infra/app/outputs.tf
@@ -5,7 +5,7 @@ output "name_prefix" {
   value = local.name_prefix
 }
 output "k8s_namespace" {
-  value = local.k8s_namespace
+  value = local.k8s_namespace_name
 }
 output "auth_mount" {
   value = local.auth_mount


### PR DESCRIPTION
Updates the demo to include an example of deploying VSO resources with cross Vault namespace authentication support. Secrets are synced from a secrets engine mounted in a separate Vault namespace.

Setup the demo with the following command:

```
make -f demo.mk VAULT_ENTERPRISE=true docker-build demo
```