### PR TITLE
ci: bump max tries for HCPVSA tests

### DIFF
--- a/test/integration/hcpvaultsecretsapp_integration_test.go
+++ b/test/integration/hcpvaultsecretsapp_integration_test.go
@@ -335,11 +335,11 @@ func TestHCPVaultSecretsApp(t *testing.T) {
 				}
 			}
 
-			d, err := time.ParseDuration(obj.Spec.RefreshAfter)
-			if assert.NoError(t, err, "time.ParseDuration(%v)", obj.Spec.RefreshAfter) {
-				assertRemediationOnDestinationDeletion(t, ctx, crdClient, obj,
-					time.Millisecond*500, uint64(d.Seconds()*3))
-			}
+			// we set a fairly large value for maxTries to help mitigate the effects of the
+			// HVS' request rate limiter. Typically, the rate limiter is only ever triggered
+			// when we have four or more GH workflows running concurrently.
+			assertRemediationOnDestinationDeletion(t, ctx, crdClient, obj,
+				time.Millisecond*500, uint64(160))
 		})
 	}
 }


### PR DESCRIPTION
Pass a fairly large value for maxTries to
assertRemediationOnDestinationDeletion() to help mitigate the effects of the HVS' request rate limiter. Typically, the rate limiter is only ever triggered when there are four or more GH workflows running concurrently.