### PR TITLE
Reconcile on secret deletion

### DIFF
--- a/controllers/eventhandlers.go
+++ b/controllers/eventhandlers.go
@@ -124,8 +124,7 @@ func (e *enqueueRefRequestsHandler) enqueue(ctx context.Context,
 
 // enqueueOnDeletionRequestHandler enqueues objects whenever the
 // watched/dependent object is deleted. All OwnerReferences matching gvk will be
-// enqueued after some randomly computed duration up to maxRequeueAfter has
-// elapsed.
+// enqueued after some randomly computed duration up until maxRequeueAfter.
 type enqueueOnDeletionRequestHandler struct {
 	gvk             schema.GroupVersionKind
 	maxRequeueAfter time.Duration

--- a/controllers/eventhandlers.go
+++ b/controllers/eventhandlers.go
@@ -88,7 +88,7 @@ func (e *enqueueRefRequestsHandler) enqueue(ctx context.Context,
 	logger := log.FromContext(ctx).WithName("enqueueRefRequestsHandler")
 	reqs := map[reconcile.Request]empty{}
 	d := e.maxRequeueAfter
-	if d == 0 {
+	if d <= 0 {
 		d = maxRequeueAfter
 	}
 	if refs, ok := e.refCache.Get(e.kind, client.ObjectKeyFromObject(o)); ok {
@@ -150,7 +150,7 @@ func (e *enqueueOnDeletionRequestHandler) Delete(ctx context.Context,
 		WithValues("ownerGVK", e.gvk)
 	reqs := map[reconcile.Request]empty{}
 	d := e.maxRequeueAfter
-	if d == 0 {
+	if d <= 0 {
 		d = maxRequeueAfter
 	}
 	for _, ref := range evt.Object.GetOwnerReferences() {

--- a/controllers/eventhandlers.go
+++ b/controllers/eventhandlers.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -47,11 +49,15 @@ type enqueueRefRequestsHandler struct {
 	maxRequeueAfter time.Duration
 }
 
-func (e *enqueueRefRequestsHandler) Create(ctx context.Context, evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+func (e *enqueueRefRequestsHandler) Create(ctx context.Context,
+	evt event.CreateEvent, q workqueue.RateLimitingInterface,
+) {
 	e.enqueue(ctx, q, evt.Object)
 }
 
-func (e *enqueueRefRequestsHandler) Update(ctx context.Context, evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+func (e *enqueueRefRequestsHandler) Update(ctx context.Context,
+	evt event.UpdateEvent, q workqueue.RateLimitingInterface,
+) {
 	if evt.ObjectOld == nil {
 		return
 	}
@@ -64,15 +70,21 @@ func (e *enqueueRefRequestsHandler) Update(ctx context.Context, evt event.Update
 	}
 }
 
-func (e *enqueueRefRequestsHandler) Delete(ctx context.Context, evt event.DeleteEvent, _ workqueue.RateLimitingInterface) {
+func (e *enqueueRefRequestsHandler) Delete(ctx context.Context,
+	evt event.DeleteEvent, _ workqueue.RateLimitingInterface,
+) {
 	e.refCache.Remove(e.kind, client.ObjectKeyFromObject(evt.Object))
 }
 
-func (e *enqueueRefRequestsHandler) Generic(ctx context.Context, evt event.GenericEvent, _ workqueue.RateLimitingInterface) {
+func (e *enqueueRefRequestsHandler) Generic(ctx context.Context,
+	_ event.GenericEvent, _ workqueue.RateLimitingInterface,
+) {
 	return
 }
 
-func (e *enqueueRefRequestsHandler) enqueue(ctx context.Context, q workqueue.RateLimitingInterface, o client.Object) {
+func (e *enqueueRefRequestsHandler) enqueue(ctx context.Context,
+	q workqueue.RateLimitingInterface, o client.Object,
+) {
 	logger := log.FromContext(ctx).WithName("enqueueRefRequestsHandler")
 	reqs := map[reconcile.Request]empty{}
 	d := e.maxRequeueAfter
@@ -108,4 +120,62 @@ func (e *enqueueRefRequestsHandler) enqueue(ctx context.Context, q workqueue.Rat
 			}
 		}
 	}
+}
+
+// enqueueOnDeletionRequestHandler enqueues objects whenever the
+// watched/dependent object is deleted. All OwnerReferences matching gvk will be
+// enqueued after some randomly computed duration up to maxRequeueAfter has
+// elapsed.
+type enqueueOnDeletionRequestHandler struct {
+	gvk             schema.GroupVersionKind
+	maxRequeueAfter time.Duration
+}
+
+func (e *enqueueOnDeletionRequestHandler) Create(_ context.Context,
+	_ event.CreateEvent, _ workqueue.RateLimitingInterface,
+) {
+	return
+}
+
+func (e *enqueueOnDeletionRequestHandler) Update(_ context.Context,
+	_ event.UpdateEvent, _ workqueue.RateLimitingInterface,
+) {
+	return
+}
+
+func (e *enqueueOnDeletionRequestHandler) Delete(ctx context.Context,
+	evt event.DeleteEvent, q workqueue.RateLimitingInterface,
+) {
+	logger := log.FromContext(ctx).WithName("enqueueOnDeletionRequestHandler").
+		WithValues("ownerGVK", e.gvk)
+	reqs := map[reconcile.Request]empty{}
+	d := e.maxRequeueAfter
+	if d == 0 {
+		d = maxRequeueAfter
+	}
+	for _, ref := range evt.Object.GetOwnerReferences() {
+		if ref.APIVersion == e.gvk.GroupVersion().String() && ref.Kind == e.gvk.Kind {
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: evt.Object.GetNamespace(),
+					Name:      ref.Name,
+				},
+			}
+			if _, ok := reqs[req]; !ok {
+				_, horizon := computeMaxJitterDuration(d)
+				logger.V(consts.LogLevelTrace).Info(
+					"Enqueuing", "obj", ref, "refKind", ref.Kind, "horizon", horizon)
+				q.AddAfter(req, horizon)
+				reqs[req] = empty{}
+			}
+		} else {
+			logger.V(consts.LogLevelTrace).Info("No match", "ref", ref)
+		}
+	}
+}
+
+func (e *enqueueOnDeletionRequestHandler) Generic(ctx context.Context,
+	_ event.GenericEvent, _ workqueue.RateLimitingInterface,
+) {
+	return
 }

--- a/controllers/eventhandlers.go
+++ b/controllers/eventhandlers.go
@@ -41,6 +41,8 @@ func NewEnqueueRefRequestsHandler(kind ResourceKind, refCache ResourceReferenceC
 	}
 }
 
+var _ handler.EventHandler = (*enqueueRefRequestsHandler)(nil)
+
 type enqueueRefRequestsHandler struct {
 	kind            ResourceKind
 	refCache        ResourceReferenceCache
@@ -79,7 +81,6 @@ func (e *enqueueRefRequestsHandler) Delete(ctx context.Context,
 func (e *enqueueRefRequestsHandler) Generic(ctx context.Context,
 	_ event.GenericEvent, _ workqueue.RateLimitingInterface,
 ) {
-	return
 }
 
 func (e *enqueueRefRequestsHandler) enqueue(ctx context.Context,
@@ -122,6 +123,8 @@ func (e *enqueueRefRequestsHandler) enqueue(ctx context.Context,
 	}
 }
 
+var _ handler.EventHandler = (*enqueueOnDeletionRequestHandler)(nil)
+
 // enqueueOnDeletionRequestHandler enqueues objects whenever the
 // watched/dependent object is deleted. All OwnerReferences matching gvk will be
 // enqueued after some randomly computed duration up until maxRequeueAfter.
@@ -133,13 +136,11 @@ type enqueueOnDeletionRequestHandler struct {
 func (e *enqueueOnDeletionRequestHandler) Create(_ context.Context,
 	_ event.CreateEvent, _ workqueue.RateLimitingInterface,
 ) {
-	return
 }
 
 func (e *enqueueOnDeletionRequestHandler) Update(_ context.Context,
 	_ event.UpdateEvent, _ workqueue.RateLimitingInterface,
 ) {
-	return
 }
 
 func (e *enqueueOnDeletionRequestHandler) Delete(ctx context.Context,
@@ -176,5 +177,4 @@ func (e *enqueueOnDeletionRequestHandler) Delete(ctx context.Context,
 func (e *enqueueOnDeletionRequestHandler) Generic(ctx context.Context,
 	_ event.GenericEvent, _ workqueue.RateLimitingInterface,
 ) {
-	return
 }

--- a/controllers/eventhandlers_test.go
+++ b/controllers/eventhandlers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -474,4 +475,325 @@ func (q *DelegatingQueue) Forget(item interface{}) {}
 
 func (q *DelegatingQueue) NumRequeues(item interface{}) int {
 	return 0
+}
+
+func Test_enqueueOnDeletionRequestHandler_Delete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	kind := VaultStaticSecret
+	ownerRefsSupported := []metav1.OwnerReference{
+		{
+			APIVersion: secretsv1beta1.GroupVersion.String(),
+			Kind:       kind.String(),
+			Name:       "baz",
+		},
+	}
+
+	ownerRefsUnsupported := []metav1.OwnerReference{
+		{
+			APIVersion: secretsv1beta1.GroupVersion.String(),
+			Kind:       "Unknown",
+			Name:       "foo",
+		},
+	}
+	deleteEventSupported := event.DeleteEvent{
+		Object: &secretsv1beta1.SecretTransformation{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       "default",
+				Name:            "vso-secret",
+				OwnerReferences: ownerRefsSupported,
+			},
+		},
+	}
+
+	deleteEventUnsupported := event.DeleteEvent{
+		Object: &secretsv1beta1.SecretTransformation{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       "default",
+				Name:            "vso-secret",
+				OwnerReferences: ownerRefsUnsupported,
+			},
+		},
+	}
+
+	wantAddedAfterValid := []any{
+		reconcile.Request{
+			NamespacedName: client.ObjectKey{
+				Namespace: "default",
+				Name:      "baz",
+			},
+		},
+	}
+
+	gvk := secretsv1beta1.GroupVersion.WithKind(kind.String())
+	tests := []testCaseEnqueueOnDeletionRequestHandler{
+		{
+			name: "enqueued",
+			kind: kind,
+			deleteEvents: []event.DeleteEvent{
+				deleteEventSupported,
+			},
+			q: &DelegatingQueue{
+				Interface: workqueue.New(),
+			},
+			gvk:             gvk,
+			wantAddedAfter:  wantAddedAfterValid,
+			maxRequeueAfter: time.Second * 10,
+		},
+		{
+			name: "enqueued-mixed",
+			kind: kind,
+			deleteEvents: []event.DeleteEvent{
+				deleteEventUnsupported,
+				deleteEventSupported,
+			},
+			q: &DelegatingQueue{
+				Interface: workqueue.New(),
+			},
+			gvk:             gvk,
+			wantAddedAfter:  wantAddedAfterValid,
+			maxRequeueAfter: time.Second * 10,
+		},
+		{
+			name: "not-enqueued",
+			kind: kind,
+			deleteEvents: []event.DeleteEvent{
+				deleteEventUnsupported,
+			},
+			q: &DelegatingQueue{
+				Interface: workqueue.New(),
+			},
+			gvk: gvk,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+
+			assertEnqueueOnDeletionRequestHandler(t, ctx, tt)
+		})
+	}
+}
+
+func Test_enqueueOnDeletionRequestHandler_Create(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	kind := VaultStaticSecret
+	ownerRefsSupported := []metav1.OwnerReference{
+		{
+			APIVersion: secretsv1beta1.GroupVersion.String(),
+			Kind:       kind.String(),
+			Name:       "baz",
+		},
+	}
+
+	ownerRefsUnsupported := []metav1.OwnerReference{
+		{
+			APIVersion: secretsv1beta1.GroupVersion.String(),
+			Kind:       "Unknown",
+			Name:       "foo",
+		},
+	}
+	createEvent := event.CreateEvent{
+		Object: &secretsv1beta1.SecretTransformation{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       "default",
+				Name:            "vso-secret",
+				OwnerReferences: ownerRefsSupported,
+			},
+		},
+	}
+
+	createEventUnsupported := event.CreateEvent{
+		Object: &secretsv1beta1.SecretTransformation{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       "default",
+				Name:            "vso-secret",
+				OwnerReferences: ownerRefsUnsupported,
+			},
+		},
+	}
+
+	gvk := secretsv1beta1.GroupVersion.WithKind(kind.String())
+	tests := []testCaseEnqueueOnDeletionRequestHandler{
+		{
+			name: "supported-not-enqueued",
+			kind: kind,
+			createEvents: []event.CreateEvent{
+				createEvent,
+			},
+			q: &DelegatingQueue{
+				Interface: workqueue.New(),
+			},
+			gvk:            gvk,
+			wantAddedAfter: nil,
+		},
+		{
+			name: "unsupported-not-enqueued",
+			kind: kind,
+			createEvents: []event.CreateEvent{
+				createEventUnsupported,
+			},
+			q: &DelegatingQueue{
+				Interface: workqueue.New(),
+			},
+			gvk:            gvk,
+			wantAddedAfter: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+
+			assertEnqueueOnDeletionRequestHandler(t, ctx, tt)
+		})
+	}
+}
+
+func Test_enqueueOnDeletionRequestHandler_Update(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	kind := VaultStaticSecret
+	ownerRefsSupported := []metav1.OwnerReference{
+		{
+			APIVersion: secretsv1beta1.GroupVersion.String(),
+			Kind:       kind.String(),
+			Name:       "baz",
+		},
+	}
+
+	ownerRefsUnsupported := []metav1.OwnerReference{
+		{
+			APIVersion: secretsv1beta1.GroupVersion.String(),
+			Kind:       "Unknown",
+			Name:       "foo",
+		},
+	}
+
+	updateEvent := event.UpdateEvent{
+		ObjectOld: &secretsv1beta1.SecretTransformation{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation:      1,
+				Namespace:       "default",
+				Name:            "vso-secret",
+				OwnerReferences: ownerRefsSupported,
+			},
+		},
+		ObjectNew: &secretsv1beta1.SecretTransformation{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation:      2,
+				Namespace:       "default",
+				Name:            "vso-secret",
+				OwnerReferences: ownerRefsSupported,
+			},
+		},
+	}
+
+	updateEventUnsupported := event.UpdateEvent{
+		ObjectOld: &secretsv1beta1.SecretTransformation{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation:      1,
+				Namespace:       "default",
+				Name:            "vso-secret",
+				OwnerReferences: ownerRefsUnsupported,
+			},
+		},
+		ObjectNew: &secretsv1beta1.SecretTransformation{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation:      2,
+				Namespace:       "default",
+				Name:            "vso-secret",
+				OwnerReferences: ownerRefsUnsupported,
+			},
+		},
+	}
+
+	gvk := secretsv1beta1.GroupVersion.WithKind(kind.String())
+	tests := []testCaseEnqueueOnDeletionRequestHandler{
+		{
+			name: "supported-not-enqueued",
+			kind: kind,
+			updateEvents: []event.UpdateEvent{
+				updateEvent,
+			},
+			q: &DelegatingQueue{
+				Interface: workqueue.New(),
+			},
+			gvk:            gvk,
+			wantAddedAfter: nil,
+		},
+		{
+			name: "unsupported-not-enqueued",
+			kind: kind,
+			updateEvents: []event.UpdateEvent{
+				updateEventUnsupported,
+			},
+			q: &DelegatingQueue{
+				Interface: workqueue.New(),
+			},
+			gvk:            gvk,
+			wantAddedAfter: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+
+			assertEnqueueOnDeletionRequestHandler(t, ctx, tt)
+		})
+	}
+}
+
+type testCaseEnqueueOnDeletionRequestHandler struct {
+	name            string
+	kind            ResourceKind
+	q               *DelegatingQueue
+	deleteEvents    []event.DeleteEvent
+	createEvents    []event.CreateEvent
+	updateEvents    []event.UpdateEvent
+	wantAddedAfter  []any
+	maxRequeueAfter time.Duration
+	gvk             schema.GroupVersionKind
+}
+
+func assertEnqueueOnDeletionRequestHandler(t *testing.T, ctx context.Context,
+	tt testCaseEnqueueOnDeletionRequestHandler,
+) {
+	t.Helper()
+
+	e := &enqueueOnDeletionRequestHandler{
+		gvk: tt.gvk,
+	}
+
+	m := tt.maxRequeueAfter
+	if tt.maxRequeueAfter == 0 {
+		m = maxRequeueAfter
+	}
+
+	for _, evt := range tt.createEvents {
+		e.Create(ctx, evt, tt.q)
+	}
+
+	for _, evt := range tt.updateEvents {
+		e.Update(ctx, evt, tt.q)
+	}
+
+	for _, evt := range tt.deleteEvents {
+		e.Delete(ctx, evt, tt.q)
+	}
+
+	if assert.Equal(t, tt.wantAddedAfter, tt.q.AddedAfter) {
+		if assert.Equal(t, len(tt.q.AddedAfter), len(tt.q.AddedAfterDuration)) {
+			for _, d := range tt.q.AddedAfterDuration {
+				assert.Greater(t, d.Seconds(), float64(0))
+				assert.LessOrEqual(t, d.Seconds(), float64(m))
+			}
+		}
+	}
 }

--- a/controllers/hcpvaultsecretsapp_controller.go
+++ b/controllers/hcpvaultsecretsapp_controller.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -200,6 +201,13 @@ func (r *HCPVaultSecretsAppReconciler) SetupWithManager(mgr ctrl.Manager, opts c
 		Watches(
 			&secretsv1beta1.SecretTransformation{},
 			NewEnqueueRefRequestsHandlerST(r.ReferenceCache, nil),
+		).
+		Watches(
+			&corev1.Secret{},
+			&enqueueOnDeletionRequestHandler{
+				gvk: secretsv1beta1.GroupVersion.WithKind(HCPVaultSecretsApp.String()),
+			},
+			builder.WithPredicates(&secretsPredicate{}),
 		).
 		Complete(r)
 }

--- a/controllers/predicates.go
+++ b/controllers/predicates.go
@@ -9,6 +9,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/hashicorp/vault-secrets-operator/internal/helpers"
 )
 
 func syncableSecretPredicate(syncReg *SyncRegistry) predicate.Predicate {
@@ -68,5 +70,23 @@ func (p *labelChangedPredicate) Update(e event.UpdateEvent) bool {
 		return true
 	}
 
+	return false
+}
+
+type secretsPredicate struct{}
+
+func (s *secretsPredicate) Create(_ event.CreateEvent) bool {
+	return false
+}
+
+func (s *secretsPredicate) Delete(evt event.DeleteEvent) bool {
+	return helpers.HasOwnerLabels(evt.Object)
+}
+
+func (s *secretsPredicate) Update(_ event.UpdateEvent) bool {
+	return false
+}
+
+func (s *secretsPredicate) Generic(_ event.GenericEvent) bool {
 	return false
 }

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -12,12 +12,26 @@ import (
 type ResourceKind int
 
 // SecretTransformation maps to SecretTransformation custom resource.
-const SecretTransformation ResourceKind = iota
+const (
+	SecretTransformation ResourceKind = iota
+	VaultDynamicSecret
+	VaultStaticSecret
+	VaultPKISecret
+	HCPVaultSecretsApp
+)
 
 func (k ResourceKind) String() string {
 	switch k {
 	case SecretTransformation:
 		return "SecretTransformation"
+	case VaultDynamicSecret:
+		return "VaultDynamicSecret"
+	case VaultStaticSecret:
+		return "VaultStaticSecret"
+	case VaultPKISecret:
+		return "VaultPKISecret"
+	case HCPVaultSecretsApp:
+		return "HCPVaultSecretsApp"
 	default:
 		return "unknown"
 	}

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -11,7 +11,6 @@ import (
 
 type ResourceKind int
 
-// SecretTransformation maps to SecretTransformation custom resource.
 const (
 	SecretTransformation ResourceKind = iota
 	VaultDynamicSecret

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -467,6 +468,13 @@ func (r *VaultDynamicSecretReconciler) SetupWithManager(mgr ctrl.Manager, opts c
 		Watches(
 			&secretsv1beta1.SecretTransformation{},
 			NewEnqueueRefRequestsHandlerST(r.ReferenceCache, r.SyncRegistry),
+		).
+		Watches(
+			&corev1.Secret{},
+			&enqueueOnDeletionRequestHandler{
+				gvk: secretsv1beta1.GroupVersion.WithKind(VaultDynamicSecret.String()),
+			},
+			builder.WithPredicates(&secretsPredicate{}),
 		).
 		Complete(r)
 }

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -223,6 +224,13 @@ func (r *VaultStaticSecretReconciler) SetupWithManager(mgr ctrl.Manager, opts co
 		Watches(
 			&secretsv1beta1.SecretTransformation{},
 			NewEnqueueRefRequestsHandlerST(r.ReferenceCache, nil),
+		).
+		Watches(
+			&corev1.Secret{},
+			&enqueueOnDeletionRequestHandler{
+				gvk: secretsv1beta1.GroupVersion.WithKind(VaultStaticSecret.String()),
+			},
+			builder.WithPredicates(&secretsPredicate{}),
 		).
 		Complete(r)
 }

--- a/internal/helpers/secrets_test.go
+++ b/internal/helpers/secrets_test.go
@@ -1562,6 +1562,9 @@ func TestHasOwnerLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+
 			assert.Equalf(t, tt.want, HasOwnerLabels(tt.o), "HasOwnerLabels(%v)", tt.o)
 		})
 	}

--- a/internal/helpers/secrets_test.go
+++ b/internal/helpers/secrets_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -1519,6 +1520,49 @@ func TestSecretDataBuilder_WithHVSAppSecrets(t *testing.T) {
 				return
 			}
 			assert.Equalf(t, tt.want, got, "WithHVSAppSecrets(%v, %v)", tt.resp, tt.opt)
+		})
+	}
+}
+
+func TestHasOwnerLabels(t *testing.T) {
+	t.Parallel()
+
+	// label setup copied to controllers.Test_secretsPredicate_Delete()
+	require.Greater(t, len(OwnerLabels), 1, "OwnerLabels global is invalid,")
+
+	hasNotLabels := maps.Clone(OwnerLabels)
+	for k := range hasNotLabels {
+		delete(hasNotLabels, k)
+		break
+	}
+
+	tests := []struct {
+		name string
+		o    ctrlclient.Object
+		want bool
+	}{
+		{
+			name: "has",
+			o: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: OwnerLabels,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "has-not",
+			o: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: hasNotLabels,
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, HasOwnerLabels(tt.o), "HasOwnerLabels(%v)", tt.o)
 		})
 	}
 }


### PR DESCRIPTION
Previously each secret controller could only detect the deletion of a destination K8s Secret that it owned on the next call to `Reconcile()`. This PR adds support for watching K8s secrets that it owns. Upon deletion, the owner resource will be enqueued for reconciliation with a random delay.