### PR TITLE
API: resync is no longer needed.

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -65,9 +65,6 @@ type Transformation struct {
 	// applied before any inclusion patterns. To exclude all source secret data
 	// fields, you can configure the single pattern ".*".
 	Excludes []string `json:"excludes,omitempty"`
-	// Resync the Secret on updates to any configured TransformationRefs.
-	// +kubebuilder:default=true
-	Resync bool `json:"resync"`
 	// ExcludeRaw data from the destination Secret. Exclusion policy can be set
 	// globally by including 'exclude-raw` in the '--global-transformation-options'
 	// command line flag. If set, the command line flag always takes precedence over

--- a/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -104,11 +104,6 @@ spec:
                         items:
                           type: string
                         type: array
-                      resync:
-                        default: true
-                        description: Resync the Secret on updates to any configured
-                          TransformationRefs.
-                        type: boolean
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.
@@ -183,7 +178,6 @@ spec:
                         type: array
                     required:
                     - excludeRaw
-                    - resync
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -107,11 +107,6 @@ spec:
                         items:
                           type: string
                         type: array
-                      resync:
-                        default: true
-                        description: Resync the Secret on updates to any configured
-                          TransformationRefs.
-                        type: boolean
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.
@@ -186,7 +181,6 @@ spec:
                         type: array
                     required:
                     - excludeRaw
-                    - resync
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -116,11 +116,6 @@ spec:
                         items:
                           type: string
                         type: array
-                      resync:
-                        default: true
-                        description: Resync the Secret on updates to any configured
-                          TransformationRefs.
-                        type: boolean
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.
@@ -195,7 +190,6 @@ spec:
                         type: array
                     required:
                     - excludeRaw
-                    - resync
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -99,11 +99,6 @@ spec:
                         items:
                           type: string
                         type: array
-                      resync:
-                        default: true
-                        description: Resync the Secret on updates to any configured
-                          TransformationRefs.
-                        type: boolean
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.
@@ -178,7 +173,6 @@ spec:
                         type: array
                     required:
                     - excludeRaw
-                    - resync
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -104,11 +104,6 @@ spec:
                         items:
                           type: string
                         type: array
-                      resync:
-                        default: true
-                        description: Resync the Secret on updates to any configured
-                          TransformationRefs.
-                        type: boolean
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.
@@ -183,7 +178,6 @@ spec:
                         type: array
                     required:
                     - excludeRaw
-                    - resync
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -107,11 +107,6 @@ spec:
                         items:
                           type: string
                         type: array
-                      resync:
-                        default: true
-                        description: Resync the Secret on updates to any configured
-                          TransformationRefs.
-                        type: boolean
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.
@@ -186,7 +181,6 @@ spec:
                         type: array
                     required:
                     - excludeRaw
-                    - resync
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -116,11 +116,6 @@ spec:
                         items:
                           type: string
                         type: array
-                      resync:
-                        default: true
-                        description: Resync the Secret on updates to any configured
-                          TransformationRefs.
-                        type: boolean
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.
@@ -195,7 +190,6 @@ spec:
                         type: array
                     required:
                     - excludeRaw
-                    - resync
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -99,11 +99,6 @@ spec:
                         items:
                           type: string
                         type: array
-                      resync:
-                        default: true
-                        description: Resync the Secret on updates to any configured
-                          TransformationRefs.
-                        type: boolean
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.
@@ -178,7 +173,6 @@ spec:
                         type: array
                     required:
                     - excludeRaw
-                    - resync
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -318,7 +318,6 @@ _Appears in:_
 | `transformationRefs` _[TransformationRef](#transformationref) array_ | TransformationRefs contain references to template configuration from SecretTransformation. |
 | `includes` _string array_ | Includes contains regex patterns used to filter top-level source secret data fields for inclusion in the final K8s Secret data. These pattern filters are never applied to templated fields as defined in Templates. They are always applied last. |
 | `excludes` _string array_ | Excludes contains regex patterns used to filter top-level source secret data fields for exclusion from the final K8s Secret data. These pattern filters are never applied to templated fields as defined in Templates. They are always applied before any inclusion patterns. To exclude all source secret data fields, you can configure the single pattern ".*". |
-| `resync` _boolean_ | Resync the Secret on updates to any configured TransformationRefs. |
 | `excludeRaw` _boolean_ | ExcludeRaw data from the destination Secret. Exclusion policy can be set globally by including 'exclude-raw` in the '--global-transformation-options' command line flag. If set, the command line flag always takes precedence over this configuration. |
 
 


### PR DESCRIPTION
Removes obsolete `spec.destination.transformation.resync` field.