### PR TITLE
Fix: include global templates only on empty templateRefs

### DIFF
--- a/internal/helpers/template.go
+++ b/internal/helpers/template.go
@@ -275,14 +275,16 @@ func gatherTemplates(ctx context.Context, client ctrlclient.Client, meta *common
 			)
 		}
 
-		for key, tmpl := range obj.Spec.Templates {
-			// only add key/templates that have not already been seen, first in takes precedence
-			if _, ok := seenTemplates[key]; !ok {
-				if tmpl.Name == "" {
-					tmpl.Name = fmt.Sprintf("%s/%s", objKey, key)
-				}
+		if len(ref.TemplateRefs) == 0 {
+			for key, tmpl := range obj.Spec.Templates {
+				// only add key/templates that have not already been seen, first in takes precedence
+				if _, ok := seenTemplates[key]; !ok {
+					if tmpl.Name == "" {
+						tmpl.Name = fmt.Sprintf("%s/%s", objKey, key)
+					}
 
-				addTemplate(tmpl, key)
+					addTemplate(tmpl, key)
+				}
 			}
 		}
 	}

--- a/internal/helpers/template_test.go
+++ b/internal/helpers/template_test.go
@@ -699,6 +699,10 @@ func TestNewSecretTransformationOption(t *testing.T) {
 								Name: "default",
 								Text: "{{- baz -}}",
 							},
+							"baz": {
+								Name: "baz",
+								Text: "{{- baz -}}",
+							},
 						},
 					},
 					nil,


### PR DESCRIPTION
Ensure that a transformationRef's template overrides are honored. 