### PR TITLE
HCPVSA: sync on lastGeneration change

### DIFF
--- a/api/v1beta1/hcpvaultsecretsapp_types.go
+++ b/api/v1beta1/hcpvaultsecretsapp_types.go
@@ -36,6 +36,8 @@ type HCPVaultSecretsAppSpec struct {
 
 // HCPVaultSecretsAppStatus defines the observed state of HCPVaultSecretsApp
 type HCPVaultSecretsAppStatus struct {
+	// LastGeneration is the Generation of the last reconciled resource.
+	LastGeneration int64 `json:"lastGeneration"`
 	// SecretMAC used when deciding whether new Vault secret data should be synced.
 	//
 	// The controller will compare the "new" HCP Vault Secrets App data to this value

--- a/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -239,6 +239,11 @@ spec:
           status:
             description: HCPVaultSecretsAppStatus defines the observed state of HCPVaultSecretsApp
             properties:
+              lastGeneration:
+                description: LastGeneration is the Generation of the last reconciled
+                  resource.
+                format: int64
+                type: integer
               secretMAC:
                 description: "SecretMAC used when deciding whether new Vault secret
                   data should be synced. \n The controller will compare the \"new\"
@@ -247,6 +252,8 @@ spec:
                   SecretMac is also used to detect drift in the Destination Secret's
                   Data. If drift is detected the data will be synced to the Destination."
                 type: string
+            required:
+            - lastGeneration
             type: object
         type: object
     served: true

--- a/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -239,6 +239,11 @@ spec:
           status:
             description: HCPVaultSecretsAppStatus defines the observed state of HCPVaultSecretsApp
             properties:
+              lastGeneration:
+                description: LastGeneration is the Generation of the last reconciled
+                  resource.
+                format: int64
+                type: integer
               secretMAC:
                 description: "SecretMAC used when deciding whether new Vault secret
                   data should be synced. \n The controller will compare the \"new\"
@@ -247,6 +252,8 @@ spec:
                   SecretMac is also used to detect drift in the Destination Secret's
                   Data. If drift is detected the data will be synced to the Destination."
                 type: string
+            required:
+            - lastGeneration
             type: object
         type: object
     served: true

--- a/controllers/hcpvaultsecretsapp_controller.go
+++ b/controllers/hcpvaultsecretsapp_controller.go
@@ -154,6 +154,7 @@ func (r *HCPVaultSecretsAppReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}, nil
 	}
 
+	doSync := true
 	// doRolloutRestart only if this is not the first time this secret has been synced
 	doRolloutRestart := o.Status.SecretMAC != ""
 	macsEqual, messageMAC, err := helpers.HandleSecretHMAC(ctx, r.Client, r.HMACValidator, o, data)
@@ -163,8 +164,14 @@ func (r *HCPVaultSecretsAppReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}, nil
 	}
 
+	// skip the next sync if the data has not changed since the last sync, and the
+	// resource has not been updated.
+	if o.Status.LastGeneration == o.GetGeneration() {
+		doSync = !macsEqual
+	}
+
 	o.Status.SecretMAC = base64.StdEncoding.EncodeToString(messageMAC)
-	if !macsEqual {
+	if doSync {
 		if err := helpers.SyncSecret(ctx, r.Client, o, data); err != nil {
 			r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonSecretSyncError,
 				"Failed to update k8s secret: %s", err)
@@ -182,6 +189,7 @@ func (r *HCPVaultSecretsAppReconciler) Reconcile(ctx context.Context, req ctrl.R
 		r.Recorder.Event(o, corev1.EventTypeNormal, consts.ReasonSecretSync, "Secret sync not required")
 	}
 
+	o.Status.LastGeneration = o.GetGeneration()
 	if err := r.Status().Update(ctx, o); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/hcpvaultsecretsapp_controller.go
+++ b/controllers/hcpvaultsecretsapp_controller.go
@@ -166,7 +166,9 @@ func (r *HCPVaultSecretsAppReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// skip the next sync if the data has not changed since the last sync, and the
 	// resource has not been updated.
-	if o.Status.LastGeneration == o.GetGeneration() {
+	// Note: spec.status.lastGeneration was added later, so we don't want to force a
+	// sync until we've updated it.
+	if o.Status.LastGeneration == 0 || o.Status.LastGeneration == o.GetGeneration() {
 		doSync = !macsEqual
 	}
 

--- a/internal/helpers/secrets.go
+++ b/internal/helpers/secrets.go
@@ -257,6 +257,7 @@ func SyncSecret(ctx context.Context, client ctrlclient.Client, obj ctrlclient.Ob
 	dest.SetAnnotations(meta.Destination.Annotations)
 	dest.SetLabels(labels)
 	dest.SetOwnerReferences(references)
+	logger.V(consts.LogLevelTrace).Info("ObjectMeta", "objectMeta", dest.ObjectMeta)
 
 	if exists {
 		logger.V(consts.LogLevelDebug).Info("Updating secret")


### PR DESCRIPTION
Previously, the HCPVSA controller would skip the secret sync if the last sync data HMAC matched. This PR makes the controller behave like all of the secret type controllers, and sync on a generational update.