### PR TITLE
Make excludeRaw optional

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -69,8 +69,7 @@ type Transformation struct {
 	// globally by including 'exclude-raw` in the '--global-transformation-options'
 	// command line flag. If set, the command line flag always takes precedence over
 	// this configuration.
-	// +kubebuilder:default=false
-	ExcludeRaw bool `json:"excludeRaw"`
+	ExcludeRaw bool `json:"excludeRaw,omitempty"`
 }
 
 // TransformationRef contains the configuration for accessing templates from an

--- a/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -77,7 +77,6 @@ spec:
                       the secret data before it is stored in the Destination.
                     properties:
                       excludeRaw:
-                        default: false
                         description: ExcludeRaw data from the destination Secret.
                           Exclusion policy can be set globally by including 'exclude-raw`
                           in the '--global-transformation-options' command line flag.
@@ -176,8 +175,6 @@ spec:
                           - name
                           type: object
                         type: array
-                    required:
-                    - excludeRaw
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -80,7 +80,6 @@ spec:
                       the secret data before it is stored in the Destination.
                     properties:
                       excludeRaw:
-                        default: false
                         description: ExcludeRaw data from the destination Secret.
                           Exclusion policy can be set globally by including 'exclude-raw`
                           in the '--global-transformation-options' command line flag.
@@ -179,8 +178,6 @@ spec:
                           - name
                           type: object
                         type: array
-                    required:
-                    - excludeRaw
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -89,7 +89,6 @@ spec:
                       the secret data before it is stored in the Destination.
                     properties:
                       excludeRaw:
-                        default: false
                         description: ExcludeRaw data from the destination Secret.
                           Exclusion policy can be set globally by including 'exclude-raw`
                           in the '--global-transformation-options' command line flag.
@@ -188,8 +187,6 @@ spec:
                           - name
                           type: object
                         type: array
-                    required:
-                    - excludeRaw
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -72,7 +72,6 @@ spec:
                       the secret data before it is stored in the Destination.
                     properties:
                       excludeRaw:
-                        default: false
                         description: ExcludeRaw data from the destination Secret.
                           Exclusion policy can be set globally by including 'exclude-raw`
                           in the '--global-transformation-options' command line flag.
@@ -171,8 +170,6 @@ spec:
                           - name
                           type: object
                         type: array
-                    required:
-                    - excludeRaw
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -77,7 +77,6 @@ spec:
                       the secret data before it is stored in the Destination.
                     properties:
                       excludeRaw:
-                        default: false
                         description: ExcludeRaw data from the destination Secret.
                           Exclusion policy can be set globally by including 'exclude-raw`
                           in the '--global-transformation-options' command line flag.
@@ -176,8 +175,6 @@ spec:
                           - name
                           type: object
                         type: array
-                    required:
-                    - excludeRaw
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -80,7 +80,6 @@ spec:
                       the secret data before it is stored in the Destination.
                     properties:
                       excludeRaw:
-                        default: false
                         description: ExcludeRaw data from the destination Secret.
                           Exclusion policy can be set globally by including 'exclude-raw`
                           in the '--global-transformation-options' command line flag.
@@ -179,8 +178,6 @@ spec:
                           - name
                           type: object
                         type: array
-                    required:
-                    - excludeRaw
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -89,7 +89,6 @@ spec:
                       the secret data before it is stored in the Destination.
                     properties:
                       excludeRaw:
-                        default: false
                         description: ExcludeRaw data from the destination Secret.
                           Exclusion policy can be set globally by including 'exclude-raw`
                           in the '--global-transformation-options' command line flag.
@@ -188,8 +187,6 @@ spec:
                           - name
                           type: object
                         type: array
-                    required:
-                    - excludeRaw
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be

--- a/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -72,7 +72,6 @@ spec:
                       the secret data before it is stored in the Destination.
                     properties:
                       excludeRaw:
-                        default: false
                         description: ExcludeRaw data from the destination Secret.
                           Exclusion policy can be set globally by including 'exclude-raw`
                           in the '--global-transformation-options' command line flag.
@@ -171,8 +170,6 @@ spec:
                           - name
                           type: object
                         type: array
-                    required:
-                    - excludeRaw
                     type: object
                   type:
                     description: Type of Kubernetes Secret. Requires Create to be


### PR DESCRIPTION
Previously, excludeRaw was required, and had a default value. That adds a bit more work for the developer when configuring the CR using an IDE with CRD schema support.