### PR TITLE
Fix: prune referrers

### DIFF
--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -118,7 +118,7 @@ func (r *VaultDynamicSecretReconciler) Reconcile(ctx context.Context, req ctrl.R
 				req.NamespacedName)
 		}
 	} else {
-		r.ReferenceCache.Remove(SecretTransformation, req.NamespacedName)
+		r.ReferenceCache.Prune(SecretTransformation, req.NamespacedName)
 	}
 
 	destExists, _ := helpers.CheckSecretExists(ctx, r.Client, o)

--- a/controllers/vaultpkisecret_controller.go
+++ b/controllers/vaultpkisecret_controller.go
@@ -148,7 +148,7 @@ func (r *VaultPKISecretReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				req.NamespacedName)
 		}
 	} else {
-		r.ReferenceCache.Remove(SecretTransformation, req.NamespacedName)
+		r.ReferenceCache.Prune(SecretTransformation, req.NamespacedName)
 	}
 
 	transOption, err := helpers.NewSecretTransformationOption(ctx, r.Client, o, r.GlobalTransformationOption)


### PR DESCRIPTION
Update the VDS and VPS controllers to call `Prune()` instead of `Remove()` on its reference cache.