### PR TITLE
Rework the reference cache

### DIFF
--- a/controllers/eventhandlers.go
+++ b/controllers/eventhandlers.go
@@ -93,14 +93,19 @@ func (e *enqueueRefRequestsHandler) enqueue(ctx context.Context,
 		d = maxRequeueAfter
 	}
 
-	for _, ref := range e.refCache.Get(e.kind, client.ObjectKeyFromObject(o)) {
-		if e.validator != nil {
-			if err := e.validator(ctx, o); err != nil {
-				logger.Error(err, "Validation failed, skipping enqueue")
-				return
-			}
-		}
+	referrers := e.refCache.Get(e.kind, client.ObjectKeyFromObject(o))
+	if len(referrers) == 0 {
+		return
+	}
 
+	if e.validator != nil {
+		if err := e.validator(ctx, o); err != nil {
+			logger.Error(err, "Validation failed, skipping enqueue")
+			return
+		}
+	}
+
+	for _, ref := range referrers {
 		if e.syncReg != nil {
 			e.syncReg.Add(ref)
 		}

--- a/controllers/eventhandlers_test.go
+++ b/controllers/eventhandlers_test.go
@@ -71,26 +71,23 @@ func Test_enqueueRefRequestsHandler_Create(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	cache := &resourceReferenceCache{
-		m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{
-			SecretTransformation: {
-				client.ObjectKey{
-					Namespace: "default",
-					Name:      "templates",
-				}: map[client.ObjectKey]empty{
-					{
-						Namespace: "foo",
-						Name:      "baz",
-					}: {},
-				},
-			},
-		},
-	}
 	createEvent := event.CreateEvent{
 		Object: &secretsv1beta1.SecretTransformation{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "default",
 				Name:      "templates",
+			},
+		},
+	}
+	cache := &resourceReferenceCache{
+		m: refCacheMap{
+			SecretTransformation: {
+				{
+					Namespace: "foo",
+					Name:      "baz",
+				}: map[client.ObjectKey]empty{
+					client.ObjectKeyFromObject(createEvent.Object): {},
+				},
 			},
 		},
 	}
@@ -153,7 +150,7 @@ func Test_enqueueRefRequestsHandler_Create(t *testing.T) {
 			name: "empty-ref-cache",
 			kind: SecretTransformation,
 			refCache: &resourceReferenceCache{
-				m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{},
+				m: refCacheMap{},
 			},
 			createEvents: createEvents,
 			q: &DelegatingQueue{
@@ -175,21 +172,6 @@ func Test_enqueueRefRequestsHandler_Update(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	cache := &resourceReferenceCache{
-		m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{
-			SecretTransformation: {
-				client.ObjectKey{
-					Namespace: "default",
-					Name:      "templates",
-				}: map[client.ObjectKey]empty{
-					{
-						Namespace: "foo",
-						Name:      "baz",
-					}: {},
-				},
-			},
-		},
-	}
 	objectOld := &secretsv1beta1.SecretTransformation{
 		ObjectMeta: metav1.ObjectMeta{
 			Generation: 1,
@@ -205,6 +187,18 @@ func Test_enqueueRefRequestsHandler_Update(t *testing.T) {
 		},
 	}
 
+	cache := &resourceReferenceCache{
+		m: refCacheMap{
+			SecretTransformation: {
+				{
+					Namespace: "foo",
+					Name:      "baz",
+				}: map[client.ObjectKey]empty{
+					client.ObjectKeyFromObject(objectNew): {},
+				},
+			},
+		},
+	}
 	updateEventsEnqueue := []event.UpdateEvent{
 		{
 			ObjectOld: objectOld,
@@ -272,7 +266,7 @@ func Test_enqueueRefRequestsHandler_Update(t *testing.T) {
 			name: "no-enqueue-empty-ref-cache",
 			kind: SecretTransformation,
 			refCache: &resourceReferenceCache{
-				m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{},
+				m: refCacheMap{},
 			},
 			updateEvents: updateEventsEnqueue,
 			q: &DelegatingQueue{
@@ -317,13 +311,13 @@ func Test_enqueueRefRequestsHandler_Delete(t *testing.T) {
 	}
 
 	cache := &resourceReferenceCache{
-		m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{
+		m: refCacheMap{
 			SecretTransformation: {
-				client.ObjectKeyFromObject(objectOne): map[client.ObjectKey]empty{
-					{
-						Namespace: "foo",
-						Name:      "baz",
-					}: {},
+				{
+					Namespace: "foo",
+					Name:      "baz",
+				}: map[client.ObjectKey]empty{
+					client.ObjectKeyFromObject(objectOne): {},
 				},
 			},
 		},
@@ -343,7 +337,7 @@ func Test_enqueueRefRequestsHandler_Delete(t *testing.T) {
 				},
 			},
 			wantRefCache: &resourceReferenceCache{
-				m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{},
+				m: refCacheMap{},
 			},
 		},
 		{

--- a/controllers/hcpvaultsecretsapp_controller.go
+++ b/controllers/hcpvaultsecretsapp_controller.go
@@ -131,7 +131,6 @@ func (r *HCPVaultSecretsAppReconciler) Reconcile(ctx context.Context, req ctrl.R
 	r.referenceCache.Set(SecretTransformation, req.NamespacedName,
 		helpers.GetTransformationRefObjKeys(
 			o.Spec.Destination.Transformation, o.Namespace)...)
-	logger.Info("ReferenceCache", "cache", r.referenceCache)
 
 	if err != nil {
 		r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonTransformationError,

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -58,7 +58,15 @@ func newResourceReferenceCache() ResourceReferenceCache {
 type refCacheMap map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty
 
 // resourceReferenceCache provides access to a refCacheMap. It can be used to
-// cache object references for a specific ResourceKind.
+// cache object references for a specific ResourceKind. It should be used
+// whenever you want to cache object references for specific resource kinds.
+// Typically, a CRD specifies a set of object references, with the controller
+// E.g: a VaultStaticSecret refers to a set of SecretTransformation instances.
+// SecretTransformation -> VaultStaticSecret -> [SecretTransformation, ...]
+// populating the cache with all references to a specific resource kind. Then a
+// Watch is set for that kind on the secret controller with a
+// ResourceReferenceCache aware handler.EventHandler. That handler enqueues all
+// objects that refer to the object for the handled event e.g: event.UpdateEvent.
 type resourceReferenceCache struct {
 	m  refCacheMap
 	mu sync.RWMutex

--- a/controllers/registry_test.go
+++ b/controllers/registry_test.go
@@ -8,115 +8,296 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var refObjKey = client.ObjectKey{
-	Namespace: "foo",
-	Name:      "ref",
-}
-
-var referrer1 = client.ObjectKey{
-	Namespace: "quz",
-	Name:      "buz",
-}
-
-var referrer2 = client.ObjectKey{
-	Namespace: "buz",
-	Name:      "qux",
+type resourceRefTest struct {
+	referrer       client.ObjectKey
+	reference      client.ObjectKey
+	references     []client.ObjectKey
+	action         int
+	wantReferrers  []client.ObjectKey
+	wantPruneCount int
+	wantOk         bool
 }
 
 type resourceRefTestCase struct {
-	m              map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty
-	name           string
-	kind           ResourceKind
-	ref            client.ObjectKey
-	referrers      []client.ObjectKey
-	calls          int
-	want           map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty
-	wantOk         bool
-	wantReferrers  []client.ObjectKey
-	wantPruneCount int
+	m     refCacheMap
+	name  string
+	kind  ResourceKind
+	tests []resourceRefTest
+	want  refCacheMap
 }
 
-func Test_resourceReferenceCache_Add(t *testing.T) {
+func Test_resourceReferenceCache(t *testing.T) {
 	t.Parallel()
+	referrer1 := client.ObjectKey{
+		Namespace: "quz",
+		Name:      "buz",
+	}
+	referrer2 := client.ObjectKey{
+		Namespace: "qux",
+		Name:      "buz",
+	}
+	reference1 := client.ObjectKey{
+		Namespace: "baz",
+		Name:      "buz",
+	}
+	reference2 := client.ObjectKey{
+		Namespace: "baz",
+		Name:      "qux",
+	}
 
 	tests := []resourceRefTestCase{
 		{
-			name: "single",
+			name: "set",
 			kind: SecretTransformation,
-			ref:  refObjKey,
-			referrers: []client.ObjectKey{
-				referrer1,
+			tests: []resourceRefTest{
+				{
+					action:     0,
+					referrer:   referrer1,
+					references: []client.ObjectKey{reference1},
+				},
 			},
-			m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{},
-			want: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{
+			m: refCacheMap{
 				SecretTransformation: {
-					refObjKey: map[client.ObjectKey]empty{
-						referrer1: {},
+					referrer1: map[client.ObjectKey]empty{
+						reference2: {},
+					},
+				},
+			},
+			want: refCacheMap{
+				SecretTransformation: {
+					referrer1: map[client.ObjectKey]empty{
+						reference1: {},
 					},
 				},
 			},
 		},
 		{
-			name: "multi",
+			name: "set-empty",
 			kind: SecretTransformation,
-			ref:  refObjKey,
-			referrers: []client.ObjectKey{
-				referrer2,
-				referrer1,
+			tests: []resourceRefTest{
+				{
+					action:   0,
+					referrer: referrer1,
+				},
 			},
-			m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{},
-			want: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{
+			m: refCacheMap{
 				SecretTransformation: {
-					refObjKey: map[client.ObjectKey]empty{
-						referrer1: {},
-						referrer2: {},
+					referrer1: map[client.ObjectKey]empty{
+						reference1: {},
+					},
+				},
+			},
+			want: refCacheMap{},
+		},
+		{
+			name: "get",
+			kind: SecretTransformation,
+			tests: []resourceRefTest{
+				{
+					action:    1,
+					reference: reference1,
+					wantReferrers: []client.ObjectKey{
+						referrer1,
+						referrer2,
+					},
+				},
+			},
+			m: refCacheMap{
+				SecretTransformation: {
+					referrer1: map[client.ObjectKey]empty{
+						reference1: {},
+						reference2: {},
+					},
+					referrer2: map[client.ObjectKey]empty{
+						reference1: {},
+						reference2: {},
+					},
+				},
+			},
+			want: refCacheMap{
+				SecretTransformation: {
+					referrer1: map[client.ObjectKey]empty{
+						reference1: {},
+						reference2: {},
+					},
+					referrer2: map[client.ObjectKey]empty{
+						reference1: {},
+						reference2: {},
 					},
 				},
 			},
 		},
 		{
-			name: "multi-dupes",
+			name: "get-none",
 			kind: SecretTransformation,
-			ref:  refObjKey,
-			referrers: []client.ObjectKey{
-				referrer2,
-				referrer1,
-				referrer2,
-				referrer1,
+			tests: []resourceRefTest{
+				{
+					action:    1,
+					reference: reference1,
+				},
 			},
-			m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{},
-			want: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{
+			m: refCacheMap{
 				SecretTransformation: {
-					refObjKey: map[client.ObjectKey]empty{
-						referrer1: {},
-						referrer2: {},
+					referrer1: map[client.ObjectKey]empty{
+						reference2: {},
+					},
+				},
+			},
+			want: refCacheMap{
+				SecretTransformation: {
+					referrer1: map[client.ObjectKey]empty{
+						reference2: {},
 					},
 				},
 			},
 		},
 		{
-			name:  "multi-dupes-concurrent",
-			kind:  SecretTransformation,
-			ref:   refObjKey,
-			calls: 10,
-			referrers: []client.ObjectKey{
-				referrer2,
-				referrer1,
-				referrer2,
-				referrer1,
+			name: "prune",
+			kind: SecretTransformation,
+			tests: []resourceRefTest{
+				{
+					// prune
+					action:         2,
+					reference:      reference1,
+					wantPruneCount: 1,
+				},
 			},
-			m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{},
-			want: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{
+			m: refCacheMap{
 				SecretTransformation: {
-					refObjKey: map[client.ObjectKey]empty{
-						referrer1: {},
-						referrer2: {},
+					referrer1: map[client.ObjectKey]empty{
+						reference1: {},
+						reference2: {},
 					},
 				},
 			},
+			want: refCacheMap{
+				SecretTransformation: {
+					referrer1: map[client.ObjectKey]empty{
+						reference2: {},
+					},
+				},
+			},
+		},
+		{
+			name: "prune-absent",
+			kind: SecretTransformation,
+			tests: []resourceRefTest{
+				{
+					// prune
+					action:         2,
+					reference:      reference1,
+					wantPruneCount: 0,
+				},
+			},
+			m: refCacheMap{
+				SecretTransformation: {
+					referrer1: map[client.ObjectKey]empty{
+						reference2: {},
+					},
+				},
+			},
+			want: refCacheMap{
+				SecretTransformation: {
+					referrer1: map[client.ObjectKey]empty{
+						reference2: {},
+					},
+				},
+			},
+		},
+		{
+			name: "prune-empty",
+			kind: SecretTransformation,
+			tests: []resourceRefTest{
+				{
+					// prune
+					action:         2,
+					reference:      reference2,
+					wantPruneCount: 2,
+				},
+				{
+					// prune
+					action:         2,
+					reference:      reference1,
+					wantPruneCount: 2,
+				},
+			},
+			m: refCacheMap{
+				SecretTransformation: {
+					referrer1: map[client.ObjectKey]empty{
+						reference1: {},
+						reference2: {},
+					},
+					referrer2: map[client.ObjectKey]empty{
+						reference1: {},
+						reference2: {},
+					},
+				},
+			},
+			want: refCacheMap{},
+		},
+		{
+			name: "remove",
+			kind: SecretTransformation,
+			tests: []resourceRefTest{
+				{
+					action:   3,
+					wantOk:   true,
+					referrer: referrer1,
+				},
+			},
+			m: refCacheMap{
+				SecretTransformation: {
+					referrer1: map[client.ObjectKey]empty{
+						reference1: {},
+						reference2: {},
+					},
+					referrer2: map[client.ObjectKey]empty{
+						reference1: {},
+						reference2: {},
+					},
+				},
+			},
+			want: refCacheMap{
+				SecretTransformation: {
+					referrer2: map[client.ObjectKey]empty{
+						reference1: {},
+						reference2: {},
+					},
+				},
+			},
+		},
+		{
+			name: "remove-empty",
+			kind: SecretTransformation,
+			tests: []resourceRefTest{
+				{
+					action:   3,
+					wantOk:   true,
+					referrer: referrer1,
+				},
+				{
+					action:   3,
+					wantOk:   true,
+					referrer: referrer2,
+				},
+			},
+			m: refCacheMap{
+				SecretTransformation: {
+					referrer1: map[client.ObjectKey]empty{
+						reference1: {},
+						reference2: {},
+					},
+					referrer2: map[client.ObjectKey]empty{
+						reference1: {},
+						reference2: {},
+					},
+				},
+			},
+			want: refCacheMap{},
 		},
 	}
 	for _, tt := range tests {
@@ -125,153 +306,42 @@ func Test_resourceReferenceCache_Add(t *testing.T) {
 				m: tt.m,
 			}
 
-			// test cache locking
-			if tt.calls > 0 {
-				var wg sync.WaitGroup
-				wg.Add(tt.calls)
-				for i := 0; i < tt.calls; i++ {
-					go func() {
-						c := c
-						tt := tt
-						defer wg.Done()
-						c.Add(tt.kind, tt.ref, tt.referrers...)
-					}()
-				}
-				wg.Wait()
-			} else {
-				c.Add(tt.kind, tt.ref, tt.referrers...)
-			}
-			assert.Equalf(t, tt.want, c.m, "Add(%v, %v)", tt.ref, tt.referrers)
-		})
-	}
-}
+			numTests := len(tt.tests)
+			require.Greater(t, numTests, 0, "no test referrers provided")
 
-func Test_resourceReferenceCache_PruneReferrer(t *testing.T) {
-	t.Parallel()
+			var wg sync.WaitGroup
+			wg.Add(numTests)
+			for _, test := range tt.tests {
+				go func(test resourceRefTest) {
+					c := c
+					tt := tt
+					defer wg.Done()
 
-	tests := []resourceRefTestCase{
-		{
-			name:           "last",
-			kind:           SecretTransformation,
-			ref:            referrer1,
-			wantPruneCount: 1,
-			m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{
-				SecretTransformation: {
-					refObjKey: map[client.ObjectKey]empty{
-						referrer1: {},
-					},
-				},
-			},
-			want: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{},
-		},
-		{
-			name:           "ok",
-			kind:           SecretTransformation,
-			ref:            referrer1,
-			wantPruneCount: 1,
-			m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{
-				SecretTransformation: {
-					refObjKey: map[client.ObjectKey]empty{
-						referrer1: {},
-						referrer2: {},
-					},
-				},
-			},
-			want: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{
-				SecretTransformation: {
-					refObjKey: map[client.ObjectKey]empty{
-						referrer2: {},
-					},
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &resourceReferenceCache{
-				m: tt.m,
+					switch test.action {
+					case 0:
+						// set
+						c.Set(tt.kind, test.referrer, test.references...)
+					case 1:
+						// get
+						actual := c.Get(tt.kind, test.reference)
+						assert.ElementsMatchf(t, test.wantReferrers, actual,
+							"Get(%v, %v)", tt.kind, test.reference)
+					case 2:
+						// prune
+						assert.Equalf(t, test.wantPruneCount, c.Prune(tt.kind, test.reference),
+							"Prune(%v, %v)", tt.kind, test.reference)
+					case 3:
+						// remove
+						assert.Equalf(t, test.wantOk, c.Remove(tt.kind, test.referrer),
+							"Remove(%v, %v)", tt.kind, test.referrer)
+					default:
+						require.Fail(t, "unsupported test action %v", test.action)
+					}
+				}(test)
 			}
 
-			assert.Equalf(t, tt.wantPruneCount, c.Prune(tt.kind, tt.ref), "Prune(%v, %v)", tt.kind, tt.ref)
-			assert.Equalf(t, tt.want, c.m, "Prune(%v, %v)", tt.kind, tt.ref)
-		})
-	}
-}
-
-func Test_resourceReferenceCache_Get(t *testing.T) {
-	t.Parallel()
-
-	tests := []resourceRefTestCase{
-		{
-			name: "empty",
-			kind: SecretTransformation,
-			ref:  referrer1,
-			m:    map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{},
-			want: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{},
-		},
-		{
-			name:   "one",
-			kind:   SecretTransformation,
-			ref:    refObjKey,
-			wantOk: true,
-			wantReferrers: []client.ObjectKey{
-				referrer1,
-			},
-			m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{
-				SecretTransformation: {
-					refObjKey: map[client.ObjectKey]empty{
-						referrer1: {},
-					},
-				},
-			},
-		},
-		{
-			name:   "two",
-			kind:   SecretTransformation,
-			ref:    refObjKey,
-			wantOk: true,
-			wantReferrers: []client.ObjectKey{
-				referrer2,
-				referrer1,
-			},
-			m: map[ResourceKind]map[client.ObjectKey]map[client.ObjectKey]empty{
-				SecretTransformation: {
-					refObjKey: map[client.ObjectKey]empty{
-						referrer2: {},
-						referrer1: {},
-					},
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &resourceReferenceCache{
-				m: tt.m,
-			}
-
-			t.Logf("%v", c.m)
-
-			if tt.calls > 0 {
-				var wg sync.WaitGroup
-				wg.Add(tt.calls)
-				for i := 0; i < tt.calls; i++ {
-					go func() {
-						c := c
-						tt := tt
-						defer wg.Done()
-						got1, got := c.Get(tt.kind, tt.ref)
-						assert.Equalf(t, tt.wantOk, got, "Get(%v, %v)", tt.kind, tt.ref)
-						assert.ElementsMatchf(t, tt.wantReferrers, got1, "Get(%v, %v)", tt.kind, tt.ref)
-					}()
-				}
-				wg.Wait()
-			} else {
-				c.Add(tt.kind, tt.ref, tt.referrers...)
-				got1, got := c.Get(tt.kind, tt.ref)
-				assert.Equalf(t, tt.wantOk, got, "Get(%v, %v)", tt.kind, tt.ref)
-				assert.ElementsMatchf(t, tt.wantReferrers, got1, "Get(%v, %v)", tt.kind, tt.ref)
-			}
+			wg.Wait()
+			assert.Equalf(t, tt.want, c.m, "tests=%#v", tt.tests)
 		})
 	}
 }
@@ -299,7 +369,7 @@ func TestSyncRegistry(t *testing.T) {
 		want        *SyncRegistry
 	}{
 		{
-			name: "add",
+			name: "update",
 			m:    map[client.ObjectKey]empty{},
 			objKeyTests: []objKeyTest{
 				{

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -35,7 +35,7 @@ type VaultStaticSecretReconciler struct {
 	ClientFactory              vault.ClientFactory
 	SecretDataBuilder          *helpers.SecretDataBuilder
 	HMACValidator              helpers.HMACValidator
-	ReferenceCache             ResourceReferenceCache
+	referenceCache             ResourceReferenceCache
 	GlobalTransformationOption *helpers.GlobalTransformationOption
 }
 
@@ -92,16 +92,9 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		requeueAfter = computeHorizonWithJitter(d)
 	}
 
-	transRefObjKeys := helpers.GetTransformationRefObjKeys(
-		o.Spec.Destination.Transformation, o.Namespace)
-	if len(transRefObjKeys) > 0 {
-		for _, ref := range transRefObjKeys {
-			r.ReferenceCache.Add(SecretTransformation, ref,
-				req.NamespacedName)
-		}
-	} else {
-		r.ReferenceCache.Prune(SecretTransformation, req.NamespacedName)
-	}
+	r.referenceCache.Set(SecretTransformation, req.NamespacedName,
+		helpers.GetTransformationRefObjKeys(
+			o.Spec.Destination.Transformation, o.Namespace)...)
 
 	transOption, err := helpers.NewSecretTransformationOption(ctx, r.Client, o, r.GlobalTransformationOption)
 	if err != nil {
@@ -201,7 +194,7 @@ func (r *VaultStaticSecretReconciler) addFinalizer(ctx context.Context, o client
 
 func (r *VaultStaticSecretReconciler) handleDeletion(ctx context.Context, o client.Object) error {
 	logger := log.FromContext(ctx)
-	r.ReferenceCache.Prune(SecretTransformation, client.ObjectKeyFromObject(o))
+	r.referenceCache.Remove(SecretTransformation, client.ObjectKeyFromObject(o))
 	if controllerutil.ContainsFinalizer(o, vaultStaticSecretFinalizer) {
 		logger.Info("Removing finalizer")
 		if controllerutil.RemoveFinalizer(o, vaultStaticSecretFinalizer) {
@@ -216,13 +209,14 @@ func (r *VaultStaticSecretReconciler) handleDeletion(ctx context.Context, o clie
 }
 
 func (r *VaultStaticSecretReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
+	r.referenceCache = newResourceReferenceCache()
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&secretsv1beta1.VaultStaticSecret{}).
 		WithEventFilter(syncableSecretPredicate(nil)).
 		WithOptions(opts).
 		Watches(
 			&secretsv1beta1.SecretTransformation{},
-			NewEnqueueRefRequestsHandlerST(r.ReferenceCache, nil),
+			NewEnqueueRefRequestsHandlerST(r.referenceCache, nil),
 		).
 		Complete(r)
 }

--- a/main.go
+++ b/main.go
@@ -286,7 +286,6 @@ func main() {
 		SecretDataBuilder:          secretDataBuilder,
 		HMACValidator:              hmacValidator,
 		ClientFactory:              clientFactory,
-		ReferenceCache:             controllers.NewResourceReferenceCache(),
 		GlobalTransformationOption: globalTransOpt,
 	}).SetupWithManager(mgr, controllerOptions); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "VaultStaticSecret")
@@ -298,7 +297,6 @@ func main() {
 		ClientFactory:              clientFactory,
 		HMACValidator:              hmacValidator,
 		SyncRegistry:               controllers.NewSyncRegistry(),
-		ReferenceCache:             controllers.NewResourceReferenceCache(),
 		Recorder:                   mgr.GetEventRecorderFor("VaultPKISecret"),
 		GlobalTransformationOption: globalTransOpt,
 	}).SetupWithManager(mgr, controllerOptions); err != nil {
@@ -341,7 +339,6 @@ func main() {
 		ClientFactory:              clientFactory,
 		HMACValidator:              hmacValidator,
 		SyncRegistry:               controllers.NewSyncRegistry(),
-		ReferenceCache:             controllers.NewResourceReferenceCache(),
 		GlobalTransformationOption: globalTransOpt,
 	}).SetupWithManager(mgr, vdsOverrideOpts); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "VaultDynamicSecret")
@@ -360,7 +357,6 @@ func main() {
 		Recorder:                   mgr.GetEventRecorderFor("HCPVaultSecretsApp"),
 		SecretDataBuilder:          secretDataBuilder,
 		HMACValidator:              hmacValidator,
-		ReferenceCache:             controllers.NewResourceReferenceCache(),
 		MinRefreshAfter:            minRefreshAfterHVSA,
 		GlobalTransformationOption: globalTransOpt,
 	}).SetupWithManager(mgr, controllerOptions); err != nil {


### PR DESCRIPTION
Previously, the cache was keyed by referent object. This made things simpler for referent management, but it came at the cost of extra memory usage and some added code complexity.

In order to mitigate the potential for encountering an out of memory situation, the cache will map a referring object to its set of references.

Other fixes:
- The previous implementation only supported adding or pruning referrers, which would lead to orphaned references persisting in the cache. So, Add() is replaced by Set(), which sets the set of references for each referring object.
- Make ReferenceCache a private member on all secret controllers.