### PR TITLE
Chart: support setting imagePullPolicy

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -52,6 +52,7 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ .Values.controller.kubernetesClusterDomain }}
         image: {{ .Values.controller.kubeRbacProxy.image.repository }}:{{ .Values.controller.kubeRbacProxy.image.tag }}
+        imagePullPolicy: {{ .Values.controller.kubeRbacProxy.image.pullPolicy }}
         ports:
         - containerPort: 8443
           name: https
@@ -98,7 +99,7 @@ spec:
           value: {{ .value }}
         {{- end }}
         image: {{ .Values.controller.manager.image.repository }}:{{ .Values.controller.manager.image.tag }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.controller.manager.image.pullPolicy }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -60,6 +60,7 @@ controller:
   kubeRbacProxy:
     # Image sets the repo and tag of the kube-rbac-proxy image to use for the controller.
     image:
+      pullPolicy: IfNotPresent
       repository: gcr.io/kubebuilder/kube-rbac-proxy
       tag: v0.15.0
 
@@ -99,6 +100,7 @@ controller:
 
     # Image sets the repo and tag of the vault-secrets-operator image to use for the controller.
     image:
+      pullPolicy: IfNotPresent
       repository: hashicorp/vault-secrets-operator
       tag: 0.4.3
 

--- a/test/unit/deployment.bats
+++ b/test/unit/deployment.bats
@@ -768,3 +768,38 @@ load _helpers
    local actual=$(echo "$object" | yq '.[5]' | tee /dev/stderr)
    [ "${actual}" = "--bar=qux" ]
 }
+
+#--------------------------------------------------------------------
+# image.pullPolicy
+@test "controller/Deployment: imagePullPolicy default" {
+  cd `chart_dir`
+  local deployment=$(helm template \
+      -s templates/deployment.yaml  \
+      . | tee /dev/stderr |
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager")' | tee /dev/stderr)
+
+  local actual=$(echo "${deployment}" | yq '.spec.template.spec.containers[] | select(.name == "manager") | .imagePullPolicy' | tee /dev/stderr)
+  [ "${actual}" = "IfNotPresent" ]
+
+  actual=$(echo "${deployment}" | yq '.spec.template.spec.containers[] | select(.name == "kube-rbac-proxy") | .imagePullPolicy' | tee /dev/stderr)
+  [ "${actual}" = "IfNotPresent" ]
+}
+
+@test "controller/Deployment: imagePullPolicy updated" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/deployment.yaml  \
+      --set 'controller.manager.image.pullPolicy=Always' \
+      . | tee /dev/stderr |
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .imagePullPolicy' | tee /dev/stderr)
+
+   [ "${actual}" = "Always" ]
+
+  actual=$(helm template \
+      -s templates/deployment.yaml  \
+      --set 'controller.kubeRbacProxy.image.pullPolicy=Never' \
+      . | tee /dev/stderr |
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "kube-rbac-proxy") | .imagePullPolicy' | tee /dev/stderr)
+
+   [ "${actual}" = "Never" ]
+}


### PR DESCRIPTION
Add support for setting the imagePullPolicy for the `manager` and `kube-rbac-proxy` containers. The default for both is `IfNotPresent`