### PR TITLE
Build: retry GH fetch on transient errors

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,8 @@ on:
 
 env:
   PKG_NAME: "vault-secrets-operator"
+  # used by scripts that fetch build tools from GH
+  GH_GET_RETRIES: 5
 
 jobs:
   get-product-version:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,10 @@ name: Tests
 
 on: [push, workflow_dispatch]
 
+env:
+  # used by scripts that fetch build tools from GH
+  GH_GET_RETRIES: 5
+
 jobs:
   fmtcheck:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@
 VERSION ?= 0.0.0-dev
 KUBE_RBAC_PROXY_VERSION = v0.15.0
 
+GH_GET_RETRIES ?= 5
+
 GO_VERSION = $(shell cat .go-version)
 
 CONFIG_SRC_DIR ?= config

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@
 VERSION ?= 0.0.0-dev
 KUBE_RBAC_PROXY_VERSION = v0.15.0
 
-GH_GET_RETRIES ?= 5
-
 GO_VERSION = $(shell cat .go-version)
 
 CONFIG_SRC_DIR ?= config

--- a/hack/.functions
+++ b/hack/.functions
@@ -1,6 +1,13 @@
+#
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+#
+
 function getGH() {
   local url="$1"
   local dest="$2"
+  local num_retries="${3:-${GH_GET_NUM_RETRIES}}"
+
   headers=(
       '--header' "Accept: application/vnd.github+json"
       '--header' "X-GitHub-Api-Version: 2022-11-28"
@@ -16,7 +23,10 @@ function getGH() {
   if [ -z "${dest}" ]; then
     opts+=('-O')
   else
-    opts+=('-o' "$dest")
+    opts+=('-o' "${dest}")
   fi
-  ${cmd} "${opts[@]}" "${headers[@]}" ${url}
+  if [ -n "${num_retries}" ]; then
+    opts+=('--retry' "${num_retries}")
+  fi
+  ${cmd} "${opts[@]}" "${headers[@]}" "${url}"
 }

--- a/hack/.functions
+++ b/hack/.functions
@@ -6,7 +6,7 @@
 function getGH() {
   local url="$1"
   local dest="$2"
-  local num_retries="${3:-${GH_GET_NUM_RETRIES}}"
+  local num_retries="${3:-${GH_GET_RETRIES}}"
 
   headers=(
       '--header' "Accept: application/vnd.github+json"


### PR DESCRIPTION
Makes fetching build tools from GH a bit more robust by retrying on transient errors. 

Add support for setting curl's `--retry` option which will retry on any of the following HTTP response codes: 408, 429, 500, 502, 503, 504

Example of a related build failure:
https://github.com/hashicorp/vault-secrets-operator/actions/runs/7922121731/job/21629102539#step:6:19