### PR TITLE
Always add finalizers after status updates

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -250,6 +250,7 @@ func maybeAddFinalizer(ctx context.Context, c client.Client, o client.Object, fi
 		controllerutil.AddFinalizer(o, finalizer)
 		if err := c.Update(ctx, o); err != nil {
 			logger.Error(err, "Failed to add finalizer")
+			controllerutil.RemoveFinalizer(o, finalizer)
 			return false, err
 		}
 

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -12,9 +12,11 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 	"github.com/hashicorp/vault-secrets-operator/internal/common"
+	"github.com/hashicorp/vault-secrets-operator/internal/consts"
 )
 
 var (
@@ -232,4 +234,27 @@ func parseDurationString(duration, path string, min time.Duration) (time.Duratio
 
 func isInWindow(t1, t2 time.Time) bool {
 	return t1.After(t2) || t1.Equal(t2)
+}
+
+// maybeAddFinalizer updates client.Object with finalizer if it is not already
+// set. Return true if the object was updated, in which case the object's
+// ResourceVersion will have changed. This update should be handled by in the
+// caller.
+func maybeAddFinalizer(ctx context.Context, c client.Client, o client.Object, finalizer string) (bool, error) {
+	if o.GetDeletionTimestamp() == nil && !controllerutil.ContainsFinalizer(o, finalizer) {
+		// always call maybeAddFinalizer() after client.Client.Status.Update() to avoid
+		// API validation errors due to changes to the status schema.
+		logger := log.FromContext(ctx).WithValues("finalizer", finalizer)
+		logger.V(consts.LogLevelTrace).Info("Adding finalizer",
+			"finalizer", finalizer)
+		controllerutil.AddFinalizer(o, finalizer)
+		if err := c.Update(ctx, o); err != nil {
+			logger.Error(err, "Failed to add finalizer")
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -4,12 +4,22 @@
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 )
 
 func Test_dynamicHorizon(t *testing.T) {
@@ -201,4 +211,130 @@ func Test_isInWindow(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_maybeAddFinalizer(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clientBuilder := newClientBuilder()
+	type args struct{}
+	tests := []struct {
+		name      string
+		o         client.Object
+		create    bool
+		finalizer string
+		want      bool
+		wantErr   assert.ErrorAssertionFunc
+	}{
+		{
+			name: "updated",
+			o: &secretsv1beta1.VaultAuth{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "updated",
+				},
+				Spec: secretsv1beta1.VaultAuthSpec{
+					Method: "kubernetes",
+				},
+			},
+			create:    true,
+			finalizer: vaultAuthFinalizer,
+			want:      true,
+			wantErr:   assert.NoError,
+		},
+		{
+			name: "not-updated",
+			o: &secretsv1beta1.VaultAuth{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "updated",
+					Finalizers: []string{
+						vaultAuthFinalizer,
+					},
+				},
+				Spec: secretsv1beta1.VaultAuthSpec{
+					Method: "kubernetes",
+				},
+			},
+			create:    true,
+			finalizer: vaultAuthFinalizer,
+			want:      false,
+			wantErr:   assert.NoError,
+		},
+		{
+			name: "not-updated-inexistent-object",
+			o: &secretsv1beta1.VaultAuth{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "updated",
+					Finalizers: []string{
+						vaultAuthFinalizer,
+					},
+				},
+				Spec: secretsv1beta1.VaultAuthSpec{
+					Method: "kubernetes",
+				},
+			},
+			create:    false,
+			finalizer: vaultAuthFinalizer,
+			want:      false,
+			wantErr:   assert.NoError,
+		},
+		{
+			name: "invalid-not-found",
+			o: &secretsv1beta1.VaultAuth{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "updated",
+				},
+				Spec: secretsv1beta1.VaultAuthSpec{
+					Method: "kubernetes",
+				},
+			},
+			finalizer: vaultAuthFinalizer,
+			want:      false,
+			wantErr: func(t assert.TestingT, err error, _ ...interface{}) bool {
+				return assert.True(t, apierrors.IsNotFound(err))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := clientBuilder.Build()
+			var origResourceVersion string
+			if tt.create {
+				require.NoError(t, c.Create(ctx, tt.o))
+				origResourceVersion = tt.o.GetResourceVersion()
+			}
+
+			got, err := maybeAddFinalizer(ctx, c, tt.o, tt.finalizer)
+			if !tt.wantErr(t, err, fmt.Sprintf("maybeAddFinalizer(%v, %v, %v, %v)", ctx, c, tt.o, tt.finalizer)) {
+				return
+			}
+
+			assert.Equalf(t, tt.want, got, "maybeAddFinalizer(%v, %v, %v, %v)", ctx, c, tt.o, tt.finalizer)
+			assert.Equalf(t, []string{tt.finalizer}, tt.o.GetFinalizers(), "maybeAddFinalizer(%v, %v, %v, %v)", ctx, c, tt.o, tt.finalizer)
+
+			if tt.create {
+				var updated secretsv1beta1.VaultAuth
+				if assert.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(tt.o), &updated)) {
+					if tt.want {
+						assert.NotEqual(t, origResourceVersion, tt.o.GetResourceVersion())
+					} else {
+						// ensure that the object was not updated.
+						assert.Equal(t, origResourceVersion, tt.o.GetResourceVersion())
+					}
+				}
+			}
+		})
+	}
+}
+
+// newClientBuilder copied from helpers.
+func newClientBuilder() *fake.ClientBuilder {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(secretsv1beta1.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme)
 }

--- a/controllers/hcpvaultsecretsapp_controller.go
+++ b/controllers/hcpvaultsecretsapp_controller.go
@@ -185,14 +185,23 @@ func (r *HCPVaultSecretsAppReconciler) Reconcile(ctx context.Context, req ctrl.R
 		r.Recorder.Event(o, corev1.EventTypeNormal, consts.ReasonSecretSync, "Secret sync not required")
 	}
 
-	o.Status.LastGeneration = o.GetGeneration()
-	if err := r.Status().Update(ctx, o); err != nil {
+	if err := r.updateStatus(ctx, o); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{
 		RequeueAfter: requeueAfter,
 	}, nil
+}
+
+func (r *HCPVaultSecretsAppReconciler) updateStatus(ctx context.Context, o *secretsv1beta1.HCPVaultSecretsApp) error {
+	o.Status.LastGeneration = o.GetGeneration()
+	if err := r.Status().Update(ctx, o); err != nil {
+		r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonStatusUpdateError,
+			"Failed to update the resource's status, err=%s", err)
+	}
+
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -102,11 +102,7 @@ func (r *VaultDynamicSecretReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
-	if o.GetDeletionTimestamp() == nil {
-		if err := r.addFinalizer(ctx, o); err != nil {
-			return ctrl.Result{}, err
-		}
-	} else {
+	if o.GetDeletionTimestamp() != nil {
 		logger.Info("Got deletion timestamp", "obj", o)
 		return ctrl.Result{}, r.handleDeletion(ctx, o)
 	}
@@ -408,7 +404,8 @@ func (r *VaultDynamicSecretReconciler) updateStatus(ctx context.Context, o *secr
 			"Failed to update the resource's status, err=%s", err)
 	}
 
-	return nil
+	_, err := maybeAddFinalizer(ctx, r.Client, o, vaultDynamicSecretFinalizer)
+	return err
 }
 
 func (r *VaultDynamicSecretReconciler) getVaultSecretLease(resp *api.Secret) *secretsv1beta1.VaultSecretLease {
@@ -441,16 +438,6 @@ func (r *VaultDynamicSecretReconciler) renewLease(
 	}
 
 	return r.getVaultSecretLease(resp.Secret()), nil
-}
-
-func (r *VaultDynamicSecretReconciler) addFinalizer(ctx context.Context, o *secretsv1beta1.VaultDynamicSecret) error {
-	if !controllerutil.ContainsFinalizer(o, vaultDynamicSecretFinalizer) {
-		controllerutil.AddFinalizer(o, vaultDynamicSecretFinalizer)
-		if err := r.Client.Update(ctx, o); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -242,7 +242,6 @@ func (r *VaultDynamicSecretReconciler) Reconcile(ctx context.Context, req ctrl.R
 	doRolloutRestart := (doSync && o.Status.LastGeneration > 1) || staticCredsUpdated
 	o.Status.SecretLease = *secretLease
 	o.Status.LastRenewalTime = nowFunc().Unix()
-	o.Status.LastGeneration = o.GetGeneration()
 	if err := r.updateStatus(ctx, o); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -402,6 +401,8 @@ func (r *VaultDynamicSecretReconciler) updateStatus(ctx context.Context, o *secr
 	if r.runtimePodUID != "" {
 		o.Status.LastRuntimePodUID = r.runtimePodUID
 	}
+
+	o.Status.LastGeneration = o.GetGeneration()
 	if err := r.Status().Update(ctx, o); err != nil {
 		r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonStatusUpdateError,
 			"Failed to update the resource's status, err=%s", err)

--- a/controllers/vaultpkisecret_controller.go
+++ b/controllers/vaultpkisecret_controller.go
@@ -77,11 +77,7 @@ func (r *VaultPKISecretReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
-	if o.GetDeletionTimestamp() == nil {
-		if err := r.addFinalizer(ctx, o); err != nil {
-			return ctrl.Result{}, err
-		}
-	} else {
+	if o.GetDeletionTimestamp() != nil {
 		logger.Info("Got deletion timestamp", "obj", o)
 		return ctrl.Result{}, r.handleDeletion(ctx, o)
 	}
@@ -342,22 +338,6 @@ func (r *VaultPKISecretReconciler) handleDeletion(ctx context.Context, o *secret
 	return nil
 }
 
-func (r *VaultPKISecretReconciler) addFinalizer(ctx context.Context, s *secretsv1beta1.VaultPKISecret) error {
-	logger := log.FromContext(ctx).WithValues("finalizer", vaultPKIFinalizer)
-	if !controllerutil.ContainsFinalizer(s, vaultPKIFinalizer) {
-		controllerutil.AddFinalizer(s, vaultPKIFinalizer)
-		logger.V(consts.LogLevelDebug).Info("Adding finalizer")
-		if err := r.Client.Update(ctx, s); err != nil {
-			logger.Error(err, "Adding finalizer")
-			return err
-		}
-		return nil
-	} else {
-		logger.V(consts.LogLevelDebug).Info("Finalizer already added")
-		return nil
-	}
-}
-
 func (r *VaultPKISecretReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	r.referenceCache = newResourceReferenceCache()
 	return ctrl.NewControllerManagedBy(mgr).
@@ -451,7 +431,8 @@ func (r *VaultPKISecretReconciler) updateStatus(ctx context.Context, o *secretsv
 		return err
 	}
 
-	return nil
+	_, err := maybeAddFinalizer(ctx, r.Client, o, vaultPKIFinalizer)
+	return err
 }
 
 func computeExpirationTimePKI(o *secretsv1beta1.VaultPKISecret, offset int64) time.Time {

--- a/controllers/vaultpkisecret_controller.go
+++ b/controllers/vaultpkisecret_controller.go
@@ -299,7 +299,6 @@ func (r *VaultPKISecretReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	o.Status.SerialNumber = certResp.SerialNumber
 	o.Status.Expiration = certResp.Expiration
 	o.Status.LastRotation = time.Now().Unix()
-	o.Status.LastGeneration = o.GetGeneration()
 	if err := r.updateStatus(ctx, o); err != nil {
 		logger.Error(err, "Failed to update the status")
 		return ctrl.Result{}, err
@@ -441,7 +440,10 @@ func (r *VaultPKISecretReconciler) recordEvent(p *secretsv1beta1.VaultPKISecret,
 func (r *VaultPKISecretReconciler) updateStatus(ctx context.Context, o *secretsv1beta1.VaultPKISecret) error {
 	logger := log.FromContext(ctx)
 	logger.V(consts.LogLevelTrace).Info("Update status called")
+
 	metrics.SetResourceStatus("vaultpkisecret", o, o.Status.Valid)
+
+	o.Status.LastGeneration = o.GetGeneration()
 	if err := r.Status().Update(ctx, o); err != nil {
 		msg := "Failed to update the resource's status"
 		r.recordEvent(o, consts.ReasonStatusUpdateError, "%s: %s", msg, err)

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -65,11 +65,7 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	if o.GetDeletionTimestamp() == nil {
-		if err := r.addFinalizer(ctx, o); err != nil {
-			return ctrl.Result{}, err
-		}
-	} else {
+	if o.GetDeletionTimestamp() != nil {
 		logger.Info("Got deletion timestamp", "obj", o)
 		return ctrl.Result{}, r.handleDeletion(ctx, o)
 	}
@@ -183,23 +179,16 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 }
 
 func (r *VaultStaticSecretReconciler) updateStatus(ctx context.Context, o *secretsv1beta1.VaultStaticSecret) error {
+	logger := log.FromContext(ctx)
+	logger.V(consts.LogLevelDebug).Info("Updating status")
 	o.Status.LastGeneration = o.GetGeneration()
 	if err := r.Status().Update(ctx, o); err != nil {
 		r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonStatusUpdateError,
 			"Failed to update the resource's status, err=%s", err)
 	}
 
-	return nil
-}
-
-func (r *VaultStaticSecretReconciler) addFinalizer(ctx context.Context, o client.Object) error {
-	if !controllerutil.ContainsFinalizer(o, vaultStaticSecretFinalizer) {
-		controllerutil.AddFinalizer(o, vaultStaticSecretFinalizer)
-		if err := r.Client.Update(ctx, o); err != nil {
-			return err
-		}
-	}
-	return nil
+	_, err := maybeAddFinalizer(ctx, r.Client, o, vaultStaticSecretFinalizer)
+	return err
 }
 
 func (r *VaultStaticSecretReconciler) handleDeletion(ctx context.Context, o client.Object) error {


### PR DESCRIPTION
Make updating a resource's status more consistent for all secret controllers, by factoring out the Status.Update() calls to controller methods, and always setting the lastGeneraton from the reconciled object.

The root cause of #608 seems to be API schema differences when going directly from v0.2.0 to v0.5.0. In v0.5.0 we added finalizers the VPS, VSS, and HCPVSA controllers. Finalizers were being added before the object's status was updated, unfortunately that would result in a error that would prevent the secret from ever being  synced, and the object's status from ever being updated. The workaround is documented here: https://github.com/hashicorp/vault-secrets-operator/issues/608#issuecomment-1953010710

The solution is to add the finalizer after the status update. All controllers that have finalizers have been updated accordingly.