### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.5.1 (February 20th, 2024)
+Fix:
+* Sync: mitigate potential schema validation failures by only adding finalizers after a status update: [GH-609](https://github.com/hashicorp/vault-secrets-operator/pull/609)
+
+Dependency Updates:
+* Bump github.com/prometheus/client_model from 0.5.0 to 0.6.0: [GH-613](https://github.com/hashicorp/vault-secrets-operator/pull/613)
+* Bump google.golang.org/api from 0.163.0 to 0.165.0: [GH-614](https://github.com/hashicorp/vault-secrets-operator/pull/614)
+* Bump k8s.io/api from 0.29.1 to 0.29.2: [GH-612](https://github.com/hashicorp/vault-secrets-operator/pull/612)
+* Bump k8s.io/apimachinery from 0.29.1 to 0.29.2: [GH-615](https://github.com/hashicorp/vault-secrets-operator/pull/615)
+* Bump k8s.io/client-go from 0.29.1 to 0.29.2: [GH-611](https://github.com/hashicorp/vault-secrets-operator/pull/611)
+
 ## 0.5.0 (February 15th, 2024)
 
 Features:

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault-secrets-operator
-version: 0.5.0
-appVersion: "0.5.0"
+version: 0.5.1
+appVersion: "0.5.1"
 kubeVersion: ">=1.22.0-0"
 description: Official Vault Secrets Operator Chart
 type: application

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -102,7 +102,7 @@ controller:
     image:
       pullPolicy: IfNotPresent
       repository: hashicorp/vault-secrets-operator
-      tag: 0.5.0
+      tag: 0.5.1
 
     # Global secret transformation options.
     # @type: array<string>

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,4 +16,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: hashicorp/vault-secrets-operator
-  newTag: 0.5.0
+  newTag: 0.5.1


### PR DESCRIPTION
Bug fix release for [v0.5.1](https://github.com/hashicorp/vault-secrets-operator/milestone/20). Addresses some issues encountered when upgrading from older versions of VSO.