### PR TITLE
VDS: make rotationSchedule status field optional

### DIFF
--- a/api/v1beta1/vaultdynamicsecret_types.go
+++ b/api/v1beta1/vaultdynamicsecret_types.go
@@ -108,7 +108,7 @@ type VaultStaticCredsMetaData struct {
 	// schedule for each rotation.
 	// e.g. "1 0 * * *" would rotate at one minute past midnight (00:01) every
 	// day.
-	RotationSchedule string `json:"rotationSchedule"`
+	RotationSchedule string `json:"rotationSchedule,omitempty"`
 	// TTL is the seconds remaining before the next rotation.
 	TTL int64 `json:"ttl"`
 }

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -351,7 +351,6 @@ spec:
                 required:
                 - lastVaultRotation
                 - rotationPeriod
-                - rotationSchedule
                 - ttl
                 type: object
             required:

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -351,7 +351,6 @@ spec:
                 required:
                 - lastVaultRotation
                 - rotationPeriod
-                - rotationSchedule
                 - ttl
                 type: object
             required:


### PR DESCRIPTION
The `rotationSchedule` should be an optional status field, since it is not guaranteed to be provided from the corresponding Vault request.