### PR TITLE
chart values: mention global transformation option env variable

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -104,8 +104,10 @@ controller:
       repository: hashicorp/vault-secrets-operator
       tag: 0.5.1
 
-    # Global secret transformation options.
-    # @type: array<string>
+    # Global secret transformation options. In addition to the boolean options
+    # below, these options may be set via the
+    # `VSO_GLOBAL_TRANSFORMATION_OPTIONS` environment variable as a
+    # comma-separated list. Valid values are: `exclude-raw`
     globalTransformationOptions:
       # excludeRaw directs the operator to prevent _raw secret data being stored
       # in the destination K8s Secret.


### PR DESCRIPTION
Also remove the docstring type for
`controller.manager.globalTransformationOptions` since it's not actually used in the chart as an array.