### PR TITLE
Add new required ClusterServiceVersion annotations

### DIFF
--- a/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
@@ -60,6 +60,16 @@ metadata:
     containerImage: registry.connect.redhat.com/hashicorp/vault-secrets-operator
     description: The Vault Secrets Operator (VSO) allows Pods to consume Vault secrets
       natively from Kubernetes Secrets.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     repository: https://github.com/hashicorp/vault-secrets-operator
     support: HashiCorp
   name: vault-secrets-operator.v0.0.0-dev


### PR DESCRIPTION
Adds the newly required 'features.operators.openshift.io' annotations to the ClusterServiceVersion we submit to OperatorHub.

- [annotation definitions](https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-annotations-infra_osdk-generating-csvs)
- [knowledge base article](https://access.redhat.com/articles/7056408)