### PR TITLE
VDS: support configuring an explicit sync delay

### DIFF
--- a/api/v1beta1/vaultdynamicsecret_types.go
+++ b/api/v1beta1/vaultdynamicsecret_types.go
@@ -60,6 +60,15 @@ type VaultDynamicSecretSpec struct {
 	RolloutRestartTargets []RolloutRestartTarget `json:"rolloutRestartTargets,omitempty"`
 	// Destination provides configuration necessary for syncing the Vault secret to Kubernetes.
 	Destination Destination `json:"destination"`
+	// RefreshAfter a period of time for VSO to sync the source secret data, in
+	// duration notation e.g. 30s, 1m, 24h. This value only needs to be set when
+	// syncing from a secret's engine that does not provide a lease TTL in its
+	// response. The value should be within the secret engine's configured ttl or
+	// max_ttl. The source secret's lease duration takes precedence over this
+	// configuration when it is greater than 0.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(s|m|h))$"
+	RefreshAfter string `json:"refreshAfter,omitempty"`
 }
 
 // VaultDynamicSecretStatus defines the observed state of VaultDynamicSecret

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -207,6 +207,16 @@ spec:
                   to Mount. Please consult https://developer.hashicorp.com/vault/docs/secrets
                   if you are uncertain about what 'path' should be set to.
                 type: string
+              refreshAfter:
+                description: RefreshAfter a period of time for VSO to sync the source
+                  secret data, in duration notation e.g. 30s, 1m, 24h. This value
+                  only needs to be set when syncing from a secret's engine that does
+                  not provide a lease TTL in its response. The value should be within
+                  the secret engine's configured ttl or max_ttl. The source secret's
+                  lease duration takes precedence over this configuration when it
+                  is greater than 0.
+                pattern: ^([0-9]+(\.[0-9]+)?(s|m|h))$
+                type: string
               renewalPercent:
                 default: 67
                 description: RenewalPercent is the percent out of 100 of the lease

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -207,6 +207,16 @@ spec:
                   to Mount. Please consult https://developer.hashicorp.com/vault/docs/secrets
                   if you are uncertain about what 'path' should be set to.
                 type: string
+              refreshAfter:
+                description: RefreshAfter a period of time for VSO to sync the source
+                  secret data, in duration notation e.g. 30s, 1m, 24h. This value
+                  only needs to be set when syncing from a secret's engine that does
+                  not provide a lease TTL in its response. The value should be within
+                  the secret engine's configured ttl or max_ttl. The source secret's
+                  lease duration takes precedence over this configuration when it
+                  is greater than 0.
+                pattern: ^([0-9]+(\.[0-9]+)?(s|m|h))$
+                type: string
               renewalPercent:
                 default: 67
                 description: RenewalPercent is the percent out of 100 of the lease

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -597,6 +597,7 @@ _Appears in:_
 | `allowStaticCreds` _boolean_ | AllowStaticCreds should be set when syncing credentials that are periodically rotated by the Vault server, rather than created upon request. These secrets are sometimes referred to as "static roles", or "static credentials", with a request path that contains "static-creds". |
 | `rolloutRestartTargets` _[RolloutRestartTarget](#rolloutrestarttarget) array_ | RolloutRestartTargets should be configured whenever the application(s) consuming the Vault secret does not support dynamically reloading a rotated secret. In that case one, or more RolloutRestartTarget(s) can be configured here. The Operator will trigger a "rollout-restart" for each target whenever the Vault secret changes between reconciliation events. See RolloutRestartTarget for more details. |
 | `destination` _[Destination](#destination)_ | Destination provides configuration necessary for syncing the Vault secret to Kubernetes. |
+| `refreshAfter` _string_ | RefreshAfter a period of time for VSO to sync the source secret data, in duration notation e.g. 30s, 1m, 24h. This value only needs to be set when syncing from a secret's engine that does not provide a lease TTL in its response. The value should be within the secret engine's configured ttl or max_ttl. The source secret's lease duration takes precedence over this configuration when it is greater than 0. |
 
 
 


### PR DESCRIPTION
There are some secrets engines that do not provide a lease TTL that the VDS reconciler can use to compute a VDS instances enqueue horizon. This change adds the ability to set a sync duration explicity via the new configuration option: spec.refreshAfter. In the case where the lease TTL is known, spec.refreshAfter will be ignored if set.