### PR TITLE
Add vault-eco team label

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -14,4 +14,4 @@ jobs:
       JIRA_SYNC_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
       JIRA_SYNC_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
     with:
-      teams-array: '["ecosystem", "foundations-eco"]'
+      teams-array: '["ecosystem", "foundations-eco", "vault-eco"]'


### PR DESCRIPTION
The foundations-eco team label may be dropped later.