### PR TITLE
CI: Fix tests in GKE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,7 @@ port-forward:
 	    echo "Port 38300 is already in use, please free it up and try again."; \
 	else \
 	    echo "Starting port forwarding..."; \
-	    bash -c 'trap exit SIGINT; while true; do kubectl port-forward -n $(K8S_VAULT_NAMESPACE) service/vault 38300:8200; done'; \
+	    bash -c 'trap exit SIGINT; while true; do kubectl port-forward -n $(K8S_VAULT_NAMESPACE) statefulset/vault 38300:8200; done'; \
 	fi
 
 ##@ Deployment

--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,7 @@ port-forward:
 	    echo "Port 38300 is already in use, please free it up and try again."; \
 	else \
 	    echo "Starting port forwarding..."; \
-	    bash -c 'trap exit SIGINT; while true; do kubectl port-forward -n $(K8S_VAULT_NAMESPACE) statefulset/vault 38300:8200; done'; \
+	    bash -c 'trap exit SIGINT; while true; do kubectl port-forward -n $(K8S_VAULT_NAMESPACE) service/vault 38300:8200; done'; \
 	fi
 
 ##@ Deployment

--- a/gcp.mk
+++ b/gcp.mk
@@ -36,7 +36,7 @@ build-push: import-gcp-vars ci-build ci-docker-build ## Build the operator image
 
 .PHONY: integration-test-gke
 integration-test-gke: export SKIP_GCP_TESTS=false
-integration-test-gke: build-push ## Run integration tests in the GKE cluster
+integration-test-gke: ## Run integration tests in the GKE cluster
 	$(MAKE) port-forward &
 	$(MAKE) integration-test K8S_CLUSTER_CONTEXT=$(K8S_CLUSTER_CONTEXT) IMAGE_TAG_BASE=$(IMAGE_TAG_BASE) \
 	IMG=$(IMG) VAULT_OIDC_DISC_URL=$(GKE_OIDC_URL) VAULT_OIDC_CA=false \

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/client_model v0.6.0
 	github.com/stretchr/testify v1.9.0
-	google.golang.org/api v0.171.0
+	google.golang.org/api v0.172.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.3
 	k8s.io/apimachinery v0.29.3
@@ -158,7 +158,7 @@ require (
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240205150955-31a09d347014 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240314234333-6e1732d8331c // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/grpc v1.62.1 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1086,8 +1086,8 @@ google.golang.org/api v0.96.0/go.mod h1:w7wJQLTM+wvQpNf5JyEcBoxK0RH7EDrh/L4qfsuJ
 google.golang.org/api v0.97.0/go.mod h1:w7wJQLTM+wvQpNf5JyEcBoxK0RH7EDrh/L4qfsuJ13s=
 google.golang.org/api v0.98.0/go.mod h1:w7wJQLTM+wvQpNf5JyEcBoxK0RH7EDrh/L4qfsuJ13s=
 google.golang.org/api v0.100.0/go.mod h1:ZE3Z2+ZOr87Rx7dqFsdRQkRBk36kDtp/h+QpHbB7a70=
-google.golang.org/api v0.171.0 h1:w174hnBPqut76FzW5Qaupt7zY8Kql6fiVjgys4f58sU=
-google.golang.org/api v0.171.0/go.mod h1:Hnq5AHm4OTMt2BUVjael2CWZFD6vksJdWCWiUAmjC9o=
+google.golang.org/api v0.172.0 h1:/1OcMZGPmW1rX2LCu2CmGUD1KXK1+pfzxotxyRUCCdk=
+google.golang.org/api v0.172.0/go.mod h1:+fJZq6QXWfa9pXhnIzsjx4yI22d4aI9ZpLb58gvXjis=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1202,8 +1202,8 @@ google.golang.org/genproto v0.0.0-20240205150955-31a09d347014 h1:g/4bk7P6TPMkAUb
 google.golang.org/genproto v0.0.0-20240205150955-31a09d347014/go.mod h1:xEgQu1e4stdSSsxPDK8Azkrk/ECl5HvdPf6nbZrTS5M=
 google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2 h1:rIo7ocm2roD9DcFIX67Ym8icoGCKSARAiPljFhh5suQ=
 google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2/go.mod h1:O1cOfN1Cy6QEYr7VxtjOyP5AdAuR0aJ/MYZaaof623Y=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240314234333-6e1732d8331c h1:lfpJ/2rWPa/kJgxyyXM8PrNnfCzcmxJ265mADgwmvLI=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240314234333-6e1732d8331c/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 h1:NnYq6UN9ReLM9/Y01KWNOWyI5xQ9kbIms5GGJVwS/Yc=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/test/integration/infra/gke/main.tf
+++ b/test/integration/infra/gke/main.tf
@@ -41,6 +41,8 @@ resource "google_container_cluster" "primary" {
     workload_pool = "${var.project_id}.svc.id.goog"
   }
 
+  deletion_protection = false
+
   depends_on = [google_project_iam_member.default_gar_reader,
   google_project_iam_member.default_gar_writer]
 }

--- a/test/integration/infra/gke/providers.tf
+++ b/test/integration/infra/gke/providers.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.63.1"
+      version = "5.23.0"
     }
   }
 }

--- a/test/integration/infra/variables.tf
+++ b/test/integration/infra/variables.tf
@@ -47,7 +47,7 @@ variable "vault_enterprise" {
 }
 
 variable "vault_chart_version" {
-  default = "0.23.0"
+  default = "0.27.0"
 }
 
 variable "install_kube_prometheus" {

--- a/test/integration/vaultauthmethods/terraform-gcp/main.tf
+++ b/test/integration/vaultauthmethods/terraform-gcp/main.tf
@@ -13,7 +13,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "5.16.0"
+      version = "5.23.0"
     }
   }
 }
@@ -35,7 +35,7 @@ provider "vault" {
 module "gke-workload-identity" {
   count      = var.run_gcp_tests ? 1 : 0
   source     = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
-  version    = "28.0.0"
+  version    = "30.2.0"
   name       = "workload-identity-sa-${var.test_id}"
   namespace  = var.k8s_test_namespace
   project_id = var.gcp_project_id


### PR DESCRIPTION
Update the google terraform provider and module to the latest versions so they match between the infra setup and auth method tests. Set gke `deletion_protection=false` so the cluster can be deleted in CI ([new for v5](https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md#500-oct-2-2023)). Bump google.golang.org/api from 0.171.0 to 0.172.0. Bump vault-helm default to 0.27.0.