### PR TITLE
Test infra: install metrics-server

### DIFF
--- a/test/integration/infra/metrics-server.tf
+++ b/test/integration/infra/metrics-server.tf
@@ -1,0 +1,14 @@
+# helm upgrade --install --set args={--kubelet-insecure-tls} metrics-server metrics-server/metrics-server --namespace kube-system
+
+resource "helm_release" "metrics_server" {
+  count      = var.metrics_server_enabled ? 1 : 0
+  name       = "metrics-server"
+  repository = "https://kubernetes-sigs.github.io/metrics-server"
+  chart      = "metrics-server"
+  namespace  = "kube-system"
+
+  set {
+    name  = "args"
+    value = "{--kubelet-insecure-tls}"
+  }
+}

--- a/test/integration/infra/variables.tf
+++ b/test/integration/infra/variables.tf
@@ -54,3 +54,8 @@ variable "install_kube_prometheus" {
   type    = bool
   default = false
 }
+
+variable "metrics_server_enabled" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
It is nice to have k8s cluster metrics during integration testing.