### PR TITLE
olm: remove the `skips` from the last release

### DIFF
--- a/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
@@ -168,7 +168,4 @@ spec:
   provider:
     name: HashiCorp
     url: https://www.hashicorp.com/
-  skips:
-  - vault-secrets-operator.v0.5.0
-  - vault-secrets-operator.v0.5.1
   version: 0.0.0-dev


### PR DESCRIPTION
Since they were only needed for v0.5.2