### PR TITLE
Client: skip LifetimeWatcher validation for non-renewable auth tokens

### DIFF
--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -198,7 +198,11 @@ func (c *defaultClient) Validate() error {
 		return fmt.Errorf("auth secret not set, never logged in")
 	}
 
-	if !c.skipRenewal {
+	if c.authSecret.Auth == nil {
+		return fmt.Errorf("invalid auth secret, Auth field is nil")
+	}
+
+	if !c.skipRenewal && c.authSecret.Auth.Renewable {
 		if c.lastWatcherErr != nil {
 			return c.lastWatcherErr
 		}

--- a/internal/vault/client_test.go
+++ b/internal/vault/client_test.go
@@ -427,6 +427,21 @@ func Test_defaultClient_Validate(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid-with-auth-secret-nil",
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err,
+					"auth secret not set, never logged in", i...)
+			},
+		},
+		{
+			name:       "invalid-with-secret-auth-nil",
+			authSecret: &api.Secret{},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err,
+					"invalid auth secret, Auth field is nil", i...)
+			},
+		},
+		{
 			name: "valid-with-watcher",
 			authSecret: &api.Secret{
 				Auth: &api.SecretAuth{
@@ -480,12 +495,27 @@ func Test_defaultClient_Validate(t *testing.T) {
 			wantErr:        assert.NoError,
 		},
 		{
+			name: "valid-with-watcher-nil-non-renewable",
+			authSecret: &api.Secret{
+				LeaseDuration: 30,
+				Renewable:     false,
+				Auth: &api.SecretAuth{
+					LeaseDuration: 30,
+					Renewable:     false,
+				},
+			},
+			skipRenewal: false,
+			lastRenewal: time.Now().Unix() - 5,
+			wantErr:     assert.NoError,
+		},
+		{
 			name: "invalid-with-watcher-nil",
 			authSecret: &api.Secret{
 				LeaseDuration: 30,
 				Renewable:     false,
 				Auth: &api.SecretAuth{
 					LeaseDuration: 30,
+					Renewable:     true,
 				},
 			},
 			skipRenewal:    false,
@@ -502,6 +532,7 @@ func Test_defaultClient_Validate(t *testing.T) {
 				Renewable:     false,
 				Auth: &api.SecretAuth{
 					LeaseDuration: 30,
+					Renewable:     true,
 				},
 			},
 			skipRenewal:    false,


### PR DESCRIPTION
Previously calling Validate() on a defaultClient that was authenticated using a non-renewable Vault token, would result in an error when the Client was being fetched from the CachingClientFactory. The defaultClient does not start a LifetimeWatcher in this case, so any related validation checks are invalid. This PR corrects that.