### PR TITLE
Use exponential backoffs on secret source errors.

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -183,7 +183,7 @@ secret source error occurs.
 */}}
 {{- define "vso.backOffOnSecretSourceError" -}}
 {{- $opts := list -}}
-{{- with .Values.controller.manager.backoffOnSecretSourceError -}}
+{{- with .Values.controller.manager.backOffOnSecretSourceError -}}
 {{- with .initialInterval -}}
 {{- $opts = mustAppend $opts (printf "--back-off-initial-interval=%s" .) -}}
 {{- end -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -175,3 +175,27 @@ globalTransformationOptions configures the manager's --global-transformation-opt
 {{- $opts | join "," -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+backOffOnSecretSourceError provides the back-off options for the manager when a
+secret source error occurs.
+*/}}
+{{- define "vso.backOffOnSecretSourceError" -}}
+{{- $opts := list -}}
+{{- with .Values.controller.manager.backoffOnSecretSourceError -}}
+{{- with .initialInterval -}}
+{{- $opts = mustAppend $opts (printf "--back-off-initial-interval=%s" .) -}}
+{{- end -}}
+{{- with .maxInterval -}}
+{{- $opts = mustAppend $opts (printf "--back-off-max-interval=%s" .) -}}
+{{- end -}}
+{{- with .multiplier -}}
+{{- $opts = mustAppend $opts (printf "--back-off-multiplier=%.2f"  (. | float64)) -}}
+{{- end -}}
+{{- with .randomizationFactor -}}
+{{- $opts = mustAppend $opts (printf "--back-off-randomization-factor=%.2f" (. | float64)) -}}
+{{- end -}}
+{{- $opts | toYaml | nindent 8 -}}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -78,6 +78,9 @@ spec:
         {{- if $opts }}
         - --global-transformation-options={{ $opts }}
         {{- end }}
+        {{- with include "vso.backOffOnSecretSourceError" . }}
+        {{- . -}}
+        {{- end }}
         {{- if .Values.controller.manager.extraArgs }}
         {{- toYaml .Values.controller.manager.extraArgs | nindent 8 }}
         {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -113,6 +113,22 @@ controller:
       # in the destination K8s Secret.
       excludeRaw: false
 
+    # Backoff settings for the controller manager. These settings control the backoff behavior
+    # when the controller encounters an error while fetching secrets from the SecretSource.
+    backoffOnSecretSourceError:
+      # Initial interval between retries.
+      # @type: duration
+      initialInterval: "5s"
+      # Maximum interval between retries.
+      # @type: duration
+      maxInterval: "60s"
+      # Randomization factor to add jitter to the interval between retries.
+      # @type: float
+      randomizationFactor: 0.5
+      # Sets the multiplier for increasing the interval between retries.
+      # @type: float
+      multiplier: 1.5
+
     # Configures the client cache which is used by the controller to cache (and potentially persist) vault tokens that
     # are the result of using the VaultAuthMethod. This enables re-use of Vault Tokens
     # throughout their TTLs as well as the ability to renew.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -115,7 +115,7 @@ controller:
 
     # Backoff settings for the controller manager. These settings control the backoff behavior
     # when the controller encounters an error while fetching secrets from the SecretSource.
-    backoffOnSecretSourceError:
+    backOffOnSecretSourceError:
       # Initial interval between retries.
       # @type: duration
       initialInterval: "5s"

--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -5,7 +5,9 @@ package controllers
 
 import (
 	"sync"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -226,4 +228,70 @@ func (r *SyncRegistry) ObjectKeys() []client.ObjectKey {
 	}
 
 	return result
+}
+
+// BackOffRegistry is a registry that stores sync backoff for a client.Object.
+type BackOffRegistry struct {
+	m    map[client.ObjectKey]*BackOff
+	mu   sync.RWMutex
+	opts []backoff.ExponentialBackOffOpts
+}
+
+// Delete objKey to the set of registered objects.
+func (r *BackOffRegistry) Delete(objKey client.ObjectKey) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	_, ok := r.m[objKey]
+	delete(r.m, objKey)
+	return ok
+}
+
+// Get is a getter/setter that returns the BackOff for objKey.
+// If objKey is not in the set of registered objects, it will be added. Return
+// true if the sync backoff entry was created.
+func (r *BackOffRegistry) Get(objKey client.ObjectKey) (*BackOff, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	entry, ok := r.m[objKey]
+	if !ok {
+		entry = &BackOff{
+			bo: backoff.NewExponentialBackOff(r.opts...),
+		}
+		r.m[objKey] = entry
+	}
+
+	return entry, !ok
+}
+
+// BackOff is a wrapper around backoff.BackOff that does not implement
+// BackOff.Reset, since elements in BackOffRegistry are meant to be ephemeral.
+type BackOff struct {
+	bo backoff.BackOff
+}
+
+// NextBackOff returns the next backoff duration.
+func (s *BackOff) NextBackOff() time.Duration {
+	return s.bo.NextBackOff()
+}
+
+// DefaultExponentialBackOffOpts returns the default exponential options for the
+func DefaultExponentialBackOffOpts() []backoff.ExponentialBackOffOpts {
+	return []backoff.ExponentialBackOffOpts{
+		backoff.WithInitialInterval(requeueDurationOnError),
+		backoff.WithMaxInterval(time.Second * 60),
+	}
+}
+
+// NewBackOffRegistry returns a BackOffRegistry.
+func NewBackOffRegistry(opts ...backoff.ExponentialBackOffOpts) *BackOffRegistry {
+	if len(opts) == 0 {
+		opts = DefaultExponentialBackOffOpts()
+	}
+
+	return &BackOffRegistry{
+		m:    map[client.ObjectKey]*BackOff{},
+		opts: opts,
+	}
 }

--- a/controllers/registry_test.go
+++ b/controllers/registry_test.go
@@ -564,7 +564,9 @@ func TestBackOffRegistry_Get(t *testing.T) {
 			got, got1 := r.Get(tt.objKey)
 			assert.NotNilf(t, got, "Get(%v)", tt.objKey)
 			assert.Equalf(t, tt.want1, got1, "Get(%v)", tt.objKey)
-			assert.Greaterf(t, got.bo.NextBackOff(), time.Duration(0), "Get(%v)", tt.objKey)
+			last := got.bo.NextBackOff()
+			assert.Greaterf(t, last, time.Duration(0), "Get(%v)", tt.objKey)
+			assert.Greaterf(t, got.bo.NextBackOff(), last, "Get(%v)", tt.objKey)
 		})
 	}
 }

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -162,7 +162,6 @@ func (r *VaultDynamicSecretReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// indicates that the resource has been added to the SyncRegistry
 		// and must be synced.
 		syncReason = "force sync"
-		syncReason = "last sync error"
 	// indicates that the resource has been updated since the last sync.
 	case o.GetGeneration() != o.Status.LastGeneration:
 		syncReason = "resource updated"

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -155,27 +155,27 @@ func (r *VaultDynamicSecretReconciler) Reconcile(ctx context.Context, req ctrl.R
 	switch {
 	// indicates that the resource has not been synced yet.
 	case o.Status.LastGeneration == 0:
-		syncReason = "initial sync"
+		syncReason = consts.ReasonInitialSync
 	// indicates that the resource has been added to the SyncRegistry
 	// and must be synced.
 	case r.SyncRegistry.Has(req.NamespacedName):
 		// indicates that the resource has been added to the SyncRegistry
 		// and must be synced.
-		syncReason = "force sync"
+		syncReason = consts.ReasonForceSync
 	// indicates that the resource has been updated since the last sync.
 	case o.GetGeneration() != o.Status.LastGeneration:
-		syncReason = "resource updated"
+		syncReason = consts.ReasonResourceUpdated
 	// indicates that the destination secret does not exist and the resource is configured to create it.
 	case o.Spec.Destination.Create && !destExists:
-		syncReason = "destination secret does not exist and create=true"
+		syncReason = consts.ReasonInexistentDestination
 	// indicates that the cache key has changed since the last sync. This can happen
 	// when the VaultAuth or VaultConnection objects are updated since the last sync.
 	case lastClientCacheKey != "" && lastClientCacheKey != o.Status.VaultClientMeta.CacheKey:
-		syncReason = "new vault client due to config change"
+		syncReason = consts.ReasonVaultClientConfigChanged
 	// indicates that the Vault client ID has changed since the last sync. This can
 	// happen when the client has re-authenticated to Vault since the last sync.
 	case lastClientID != "" && lastClientID != o.Status.VaultClientMeta.ID:
-		syncReason = "vault token rotated"
+		syncReason = consts.ReasonVaultTokenRotated
 	}
 
 	doSync := syncReason != ""
@@ -253,7 +253,7 @@ func (r *VaultDynamicSecretReconciler) Reconcile(ctx context.Context, req ctrl.R
 				r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonSecretLeaseRenewalError,
 					"Could not renew lease, lease_id=%s, err=%s", leaseID, err)
 			}
-			syncReason = "lease renewal failed"
+			syncReason = consts.ReasonSecretLeaseRenewalError
 		}
 	}
 

--- a/controllers/vaultpkisecret_controller.go
+++ b/controllers/vaultpkisecret_controller.go
@@ -120,7 +120,7 @@ func (r *VaultPKISecretReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	case o.Status.SerialNumber == "":
 		syncReason = consts.ReasonInitialSync
 	case r.SyncRegistry.Has(req.NamespacedName):
-		syncReason = consts.ReasonSyncOnRefUpdate
+		syncReason = consts.ReasonForceSync
 	case schemaEpoch > 0 && o.GetGeneration() != o.Status.LastGeneration:
 		syncReason = consts.ReasonResourceUpdated
 	case o.Spec.Destination.Create && !destinationExists:

--- a/internal/consts/reasons.go
+++ b/internal/consts/reasons.go
@@ -32,5 +32,7 @@ const (
 	ReasonCertificateRevocationError = "CertificateRevocationError"
 	ReasonTransformationError        = "TransformationError"
 	ReasonSecretDataBuilderError     = "SecretDataBuilderError"
-	ReasonSyncOnRefUpdate            = "SyncOnRefUpdate"
+	ReasonForceSync                  = "ForceSync"
+	ReasonVaultTokenRotated          = "VaultTokenRotated"
+	ReasonVaultClientConfigChanged   = "VaultClientConfigChanged"
 )

--- a/internal/options/env.go
+++ b/internal/options/env.go
@@ -4,6 +4,8 @@
 package options
 
 import (
+	"time"
+
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -26,6 +28,18 @@ type VSOEnvOptions struct {
 
 	// GlobalTransformationOptions is VSO_GLOBAL_TRANSFORMATION_OPTIONS environment variable option
 	GlobalTransformationOptions string `split_words:"true"`
+
+	// BackOffInitialInterval is VSO_BACK_OFF_INITIAL_INTERVAL environment variable option
+	BackOffInitialInterval time.Duration `split_words:"true"`
+
+	// BackOffMaxInterval is VSO_BACK_OFF_MAX_INTERVAL environment variable option
+	BackOffMaxInterval time.Duration `split_words:"true"`
+
+	// BackOffRandomizationFactor is VSO_BACK_OFF_RANDOMIZATION_FACTOR environment variable option
+	BackOffRandomizationFactor float64 `split_words:"true"`
+
+	// BackOffMultiplier is VSO_BACK_OFF_MULTIPLIER environment variable option
+	BackOffMultiplier float64 `split_words:"true"`
 }
 
 // Parse environment variable options, prefixed with "VSO_"

--- a/internal/options/env_test.go
+++ b/internal/options/env_test.go
@@ -4,8 +4,8 @@
 package options
 
 import (
-	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,24 +26,27 @@ func TestParse(t *testing.T) {
 				"VSO_CLIENT_CACHE_SIZE":              "100",
 				"VSO_CLIENT_CACHE_PERSISTENCE_MODEL": "memory",
 				"VSO_MAX_CONCURRENT_RECONCILES":      "10",
+				"VSO_BACK_OFF_INITIAL_INTERVAL":      "1s",
+				"VSO_BACK_OFF_MAX_INTERVAL":          "60s",
+				"VSO_BACK_OFF_RANDOMIZATION_FACTOR":  "0.5",
+				"VSO_BACK_OFF_MULTIPLIER":            "2.5",
 			},
 			wantOptions: VSOEnvOptions{
 				OutputFormat:                "json",
 				ClientCacheSize:             makeInt(t, 100),
 				ClientCachePersistenceModel: "memory",
 				MaxConcurrentReconciles:     makeInt(t, 10),
+				BackOffInitialInterval:      time.Second * 1,
+				BackOffMaxInterval:          time.Second * 60,
+				BackOffRandomizationFactor:  0.5,
+				BackOffMultiplier:           2.5,
 			},
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			defer func() {
-				for env := range tt.envs {
-					require.NoError(t, os.Unsetenv(env))
-				}
-			}()
 			for env, val := range tt.envs {
-				require.NoError(t, os.Setenv(env, val))
+				t.Setenv(env, val)
 			}
 
 			gotOptions := VSOEnvOptions{}

--- a/test/unit/deployment.bats
+++ b/test/unit/deployment.bats
@@ -812,10 +812,10 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -s templates/deployment.yaml \
-      --set 'controller.manager.backoffOnSecretSourceError.initialInterval=30s' \
-      --set 'controller.manager.backoffOnSecretSourceError.maxInterval=300s' \
-      --set 'controller.manager.backoffOnSecretSourceError.multiplier=2.5' \
-      --set 'controller.manager.backoffOnSecretSourceError.randomizationFactor=3.7361' \
+      --set 'controller.manager.backOffOnSecretSourceError.initialInterval=30s' \
+      --set 'controller.manager.backOffOnSecretSourceError.maxInterval=300s' \
+      --set 'controller.manager.backOffOnSecretSourceError.multiplier=2.5' \
+      --set 'controller.manager.backOffOnSecretSourceError.randomizationFactor=3.7361' \
       . | tee /dev/stderr |
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 

--- a/test/unit/deployment.bats
+++ b/test/unit/deployment.bats
@@ -670,7 +670,7 @@ load _helpers
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
-   [ "${actual}" = "3" ]
+   [ "${actual}" = "7" ]
 }
 
 #
@@ -684,11 +684,11 @@ load _helpers
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
-   [ "${actual}" = "5" ]
+   [ "${actual}" = "9" ]
 
-   local actual=$(echo "$object" | yq '.[3]' | tee /dev/stderr)
+   local actual=$(echo "$object" | yq '.[7]' | tee /dev/stderr)
    [ "${actual}" = "--foo=baz" ]
-   local actual=$(echo "$object" | yq '.[4]' | tee /dev/stderr)
+   local actual=$(echo "$object" | yq '.[8]' | tee /dev/stderr)
    [ "${actual}" = "--bar=qux" ]
 }
 
@@ -750,7 +750,7 @@ load _helpers
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
-   [ "${actual}" = "3" ]
+   [ "${actual}" = "7" ]
 }
 
 @test "controller/Deployment: with globalTransformationOptions.excludeRaw" {
@@ -762,7 +762,7 @@ load _helpers
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
-   [ "${actual}" = "4" ]
+   [ "${actual}" = "8" ]
 
    local actual=$(echo "$object" | yq '.[3]' | tee /dev/stderr)
    [ "${actual}" = "--global-transformation-options=exclude-raw" ]
@@ -778,14 +778,58 @@ load _helpers
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
-   [ "${actual}" = "6" ]
+   [ "${actual}" = "10" ]
 
    local actual=$(echo "$object" | yq '.[3]' | tee /dev/stderr)
    [ "${actual}" = "--global-transformation-options=exclude-raw" ]
-   local actual=$(echo "$object" | yq '.[4]' | tee /dev/stderr)
+   local actual=$(echo "$object" | yq '.[8]' | tee /dev/stderr)
    [ "${actual}" = "--foo=baz" ]
-   local actual=$(echo "$object" | yq '.[5]' | tee /dev/stderr)
+   local actual=$(echo "$object" | yq '.[9]' | tee /dev/stderr)
    [ "${actual}" = "--bar=qux" ]
+}
+
+@test "controller/Deployment: with backOffOnSecretSourceError defaults" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/deployment.yaml \
+      . | tee /dev/stderr |
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+   local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
+   [ "${actual}" = "7" ]
+
+   local actual=$(echo "$object" | yq '.[3]' | tee /dev/stderr)
+   [ "${actual}" = "--back-off-initial-interval=5s" ]
+   local actual=$(echo "$object" | yq '.[4]' | tee /dev/stderr)
+   [ "${actual}" = "--back-off-max-interval=60s" ]
+   local actual=$(echo "$object" | yq '.[5]' | tee /dev/stderr)
+   [ "${actual}" = "--back-off-multiplier=1.50" ]
+   local actual=$(echo "$object" | yq '.[6]' | tee /dev/stderr)
+   [ "${actual}" = "--back-off-randomization-factor=0.50" ]
+}
+
+@test "controller/Deployment: with backOffOnSecretSourceError set" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/deployment.yaml \
+      --set 'controller.manager.backoffOnSecretSourceError.initialInterval=30s' \
+      --set 'controller.manager.backoffOnSecretSourceError.maxInterval=300s' \
+      --set 'controller.manager.backoffOnSecretSourceError.multiplier=2.5' \
+      --set 'controller.manager.backoffOnSecretSourceError.randomizationFactor=3.7361' \
+      . | tee /dev/stderr |
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+   local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
+   [ "${actual}" = "7" ]
+
+   local actual=$(echo "$object" | yq '.[3]' | tee /dev/stderr)
+   [ "${actual}" = "--back-off-initial-interval=30s" ]
+   local actual=$(echo "$object" | yq '.[4]' | tee /dev/stderr)
+   [ "${actual}" = "--back-off-max-interval=300s" ]
+   local actual=$(echo "$object" | yq '.[5]' | tee /dev/stderr)
+   [ "${actual}" = "--back-off-multiplier=2.50" ]
+   local actual=$(echo "$object" | yq '.[6]' | tee /dev/stderr)
+   [ "${actual}" = "--back-off-randomization-factor=3.74" ]
 }
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
Previously, the back off duration was based on a fixed duration + some jitter. This PR introduces exponential back offs for all secret syncing controllers. The back off will be calculated and honored whenever an error is encountered while fetching from a secret source e.g: Vault, HCPVS. The back off configuration is controlled via some new command line arguments:

```
  -back-off-initial-interval duration
        Initial interval between retries on secret source errors. All errors are tried using an exponential backoff strategy. Also set from environment variable VSO_BACK_OFF_INITIAL_INTERVAL. (default 5s)
  -back-off-max-interval duration
        Maximum interval between retries on secret source errors. All errors are tried using an exponential backoff strategy. Also set from environment variable VSO_BACK_OFF_MAX_INTERVAL. (default 1m0s)
  -back-off-multiplier float
        Sets the multiplier for increasing the interval between retries on secret source errors. All errors are tried using an exponential backoff strategy. Also set from environment variable VSO_BACK_OFF_MULTIPLIER. (default 1.5)
  -back-off-randomization-factor float
        Sets the randomization factor to add jitter to the interval between retries on secret source errors. All errors are tried using an exponential backoff strategy. Also set from environment variable VSO_BACK_OFF_RANDOMIZATION_FACTOR. (default 0.5)
```

Or through the Helm chart values:
```yaml
    # Backoff settings for the controller manager. These settings control the backoff behavior
    # when the controller encounters an error while fetching secrets from the SecretSource.
    backOffOnSecretSourceError:
      # Initial interval between retries.
      # @type: duration
      initialInterval: "5s"
      # Maximum interval between retries.
      # @type: duration
      maxInterval: "60s"
      # Randomization factor to add jitter to the interval between retries.
      # @type: float
      randomizationFactor: 0.5
      # Sets the multiplier for increasing the interval between retries.
      # @type: float
      multiplier: 1.5
```