### PR TITLE
update tlsConfig & namespaceSelector for metrics serviceMonitor

### DIFF
--- a/chart/templates/prometheus-servicemonitor.yaml
+++ b/chart/templates/prometheus-servicemonitor.yaml
@@ -23,6 +23,11 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+  {{- if .Values.telemetry.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+    matchNames:
+  {{- toYaml .Values.telemetry.serviceMonitor.namespaceSelector | nindent 6 }}
+  {{- end }}       
   endpoints:
     - port: {{ .Values.telemetry.serviceMonitor.port }}
       scheme: {{ .Values.telemetry.serviceMonitor.scheme }}
@@ -34,5 +39,10 @@ spec:
         format:
           - prometheus
       tlsConfig:
-        insecureSkipVerify: true
+        insecureSkipVerify: {{ .Values.telemetry.serviceMonitor.insecureSkipVerify }}   
+        {{- if .Values.telemetry.serviceMonitor.tlsconfiguration.enabled }}           
+        caFile: {{ .Values.telemetry.serviceMonitor.tlsconfiguration.caFile }}
+        certFile: {{ .Values.telemetry.serviceMonitor.tlsconfiguration.certFile }}
+        keyFile: {{ .Values.telemetry.serviceMonitor.tlsconfiguration.keyFile }}  
+        {{- end }}
 {{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -640,9 +640,13 @@ telemetry:
 
     # Selector labels to add to the ServiceMonitor.
     # When empty, defaults to:
-    #  release: prometheus
+    #  control-plane: controller-manager
     # @type: string
     selectors: {}
+
+    # NamespaceSelector labels to add Vault Secrets Operator metric's service namespace
+    # When empty , defaults to your Vault Secrets Operator's release namespace  
+    namespaceSelector: {}
 
     # Scheme of the service Prometheus scrapes metrics from. This must match the scheme of the metrics service of VSO
     # @type: string
@@ -659,6 +663,21 @@ telemetry:
     # File Prometheus reads bearer token from for scraping metrics
     # @type: string
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+    # tlsConfig for serviceMonitor.
+    # true means skip the verification of SSL/TLS certificates when establishing a secure connection to the target endpoints
+    insecureSkipVerify: true 
+
+    # Enable tlsconfiguration to provide CA certificates, client certificates, and client keys for SSL/TLS certificates validation
+    # @type: boolean
+    tlsconfiguration: 
+      enabled: false  
+      
+      # Uncomment following to add configuration
+      # @type: string
+      # caFile: /path/to/ca.crt
+      # certFile: /path/to/client.crt
+      # keyFile: /path/to/client.key
 
     # Interval at which Prometheus scrapes metrics
     # @type: string


### PR DESCRIPTION
Update the comment to fix the [default selector label](https://github.com/hashicorp/vault-secrets-operator/blob/main/chart/templates/prometheus-servicemonitor.yaml#L25) in serviceMonitor
Added namespaceSelector field - this is required incase ServiceMonitor is deployed in any other namespace instead of VSO namespace
Added tlsConfig[] to add CA certificates, client certificates and client keys for SSL/TLS certificates validation on metrics' serviceMonitor. Without these we don't even have option to add these configuration in serviceMonitor