### PR TITLE
Disable development logger mode by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,8 +116,9 @@ func main() {
 		fmt.Sprintf("Set global secret transformation options as a comma delimited string. "+
 			"Also set from environment variable VSO_GLOBAL_TRANSFORMATION_OPTIONS."+
 			"Valid values are: %v", []string{"exclude-raw"}))
+
 	opts := zap.Options{
-		Development: true,
+		Development: os.Getenv("VSO_LOGGER_DEVELOPMENT_MODE") != "",
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Disables the "development" zap log options by default. Now all log lines will be structured e.g:

```
{"level":"info","ts":"2024-05-14T20:53:26Z","logger":"controller-runtime.metrics","msg":"Shutting down metrics server with timeout of 1 minute"}
{"level":"info","ts":"2024-05-14T20:53:26Z","msg":"shutting down server","name":"health probe","addr":"[::]:8081"}
{"level":"info","ts":"2024-05-14T20:53:26Z","msg":"Wait completed, proceeding to shutdown the manager"}
```

To enable the old logging behavior VSO should be started with the environment variable `VSO_LOGGER_DEVELOPMENT_MODE` set to a non-empty value.