### PR TITLE
Core: lock on get backoff

### DIFF
--- a/controllers/registry.go
+++ b/controllers/registry.go
@@ -251,8 +251,8 @@ func (r *BackOffRegistry) Delete(objKey client.ObjectKey) bool {
 // If objKey is not in the set of registered objects, it will be added. Return
 // true if the sync backoff entry was created.
 func (r *BackOffRegistry) Get(objKey client.ObjectKey) (*BackOff, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	entry, ok := r.m[objKey]
 	if !ok {


### PR DESCRIPTION
`BackOffRegistry.Get()` is a getter/setter  so it should always lock for rw.