### PR TITLE
Skip storing kind cluster logs on main (temporary workaround)

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -115,13 +115,15 @@ runs:
         fi
         make $make_target INTEGRATION_TESTS_PARALLEL=true SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
     - name: Store kind cluster logs
-      if: success()
+      # skip main as a temporary workaround for CRT build prepare issue ref: https://github.com/hashicorp/bob/pull/189.
+      if: success() && !contains(github.ref, 'refs/heads/main')
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: ${{ steps.create_kind_export_log_root.outputs.log_artifact_name }}
         path: ${{ steps.create_kind_export_log_root.outputs.log_root }}
     - name: Store kind cluster logs failure
-      if: failure()
+      # skip main as a temporary workaround for CRT build prepare issue ref: https://github.com/hashicorp/bob/pull/189.
+      if: failure() && !contains(github.ref, 'refs/heads/main')
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: ${{ steps.create_kind_export_log_root.outputs.log_artifact_name }}-failed


### PR DESCRIPTION
Skip storing kind cluster logs on main
    
Temporary workaround for CRT build prepare issue ref:  https://github.com/hashicorp/bob/pull/189.

