### PR TITLE
Helm: adds values for setting VSO's logging options

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -241,3 +241,47 @@ aggregateRoleMatchLabelsEditor generates the matchLabels for the editor cluster 
 {{- $ret | toYaml -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+logging args
+*/}}
+{{- define "vso.controllerLoggingArgs" -}}
+{{- $extraArgs := dict -}}
+{{- with .Values.controller.manager.extraArgs -}}
+{{- range . -}}
+{{ $parts := splitList "=" . -}}
+{{ $arg := (($parts | first) | trimPrefix "-") }}
+{{- $_ := set $extraArgs ( $arg | trimPrefix "-")  . -}}
+{{- end -}}
+{{- end -}}
+{{- $ret := list -}}
+{{- with .Values.controller.manager.logging -}}
+{{- if $level := .level -}}
+{{ $arg := "zap-log-level" -}}
+{{- if not (hasKey $extraArgs $arg) -}}
+{{- if eq $level "debug-extended" -}}
+{{- $level = "5" -}}
+{{- end -}}
+{{- if eq .level "trace" -}}
+{{- $level = "6" -}}
+{{- end -}}
+{{- $ret = append $ret (printf "--%s=%s" $arg $level) -}}
+{{- end -}}
+{{- end -}}
+{{- if .timeEncoding -}}
+{{ $arg := "zap-time-encoding" -}}
+{{- if not (hasKey $extraArgs $arg) -}}
+{{- $ret = append $ret (printf "--%s=%s" $arg .timeEncoding) -}}
+{{- end -}}
+{{- end -}}
+{{- if .stacktraceLevel -}}
+{{ $arg := "zap-stacktrace-level" -}}
+{{- if not (hasKey $extraArgs $arg) -}}
+{{- $ret = append $ret (printf "--%s=%s" $arg .stacktraceLevel) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $ret -}}
+{{- $ret | toYaml | nindent 8 -}}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -82,10 +82,13 @@ spec:
         - --global-transformation-options={{ $opts }}
         {{- end }}
         {{- with include "vso.backOffOnSecretSourceError" . }}
-        {{- . -}}
+        {{- . }}
         {{- end }}
-        {{- if .Values.controller.manager.extraArgs }}
-        {{- toYaml .Values.controller.manager.extraArgs | nindent 8 }}
+        {{- with include "vso.controllerLoggingArgs" . }}
+        {{- . }}
+        {{- end }}
+        {{- with .Values.controller.manager.extraArgs }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         command:
         - /vault-secrets-operator

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -151,6 +151,26 @@ controller:
       repository: hashicorp/vault-secrets-operator
       tag: 0.6.0
 
+    # logging
+    logging:
+      # Sets the log level for the operator.
+      # Builtin levels are: info, error, debug, debug-extended, trace
+      # Default: info
+      # @type: string
+      level: info
+
+      # Sets the time encoding for the operator.
+      # Options are: epoch, millis, nano, iso8601, rfc3339, rfc3339nano
+      # Default: rfc3339
+      # @type: string
+      timeEncoding: rfc3339
+
+      # Sets the stacktrace level for the operator.
+      # Options are: info, error, panic
+      # Default: panic
+      # @type: string
+      stacktraceLevel: panic
+
     # Global secret transformation options. In addition to the boolean options
     # below, these options may be set via the
     # `VSO_GLOBAL_TRANSFORMATION_OPTIONS` environment variable as a
@@ -415,8 +435,7 @@ controller:
 
     # Defines additional commandline arguments to be passed to the
     # vault-secrets-operator manager container.
-    # extraArgs:
-    # - -zap-log-level=5
+    #
     # @type: array
     extraArgs: []
 
@@ -702,7 +721,7 @@ telemetry:
 
     # Enable deployment of the Vault Secrets Operator ServiceMonitor CustomResource.
     # @type: boolean
-    enabled: false
+    nabled: false
 
     # Selector labels to add to the ServiceMonitor.
     # When empty, defaults to:

--- a/test/unit/deployment.bats
+++ b/test/unit/deployment.bats
@@ -670,7 +670,7 @@ load _helpers
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
-   [ "${actual}" = "8" ]
+   [ "${actual}" = "11" ]
 }
 
 #
@@ -684,11 +684,11 @@ load _helpers
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
-   [ "${actual}" = "10" ]
+   [ "${actual}" = "13" ]
 
-   local actual=$(echo "$object" | yq '.[8]' | tee /dev/stderr)
+   local actual=$(echo "$object" | yq '.[11]' | tee /dev/stderr)
    [ "${actual}" = "--foo=baz" ]
-   local actual=$(echo "$object" | yq '.[9]' | tee /dev/stderr)
+   local actual=$(echo "$object" | yq '.[12]' | tee /dev/stderr)
    [ "${actual}" = "--bar=qux" ]
 }
 
@@ -750,7 +750,7 @@ load _helpers
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
-   [ "${actual}" = "8" ]
+   [ "${actual}" = "11" ]
 }
 
 @test "controller/Deployment: with globalTransformationOptions.excludeRaw" {
@@ -762,7 +762,7 @@ load _helpers
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
-   [ "${actual}" = "9" ]
+   [ "${actual}" = "12" ]
 
    local actual=$(echo "$object" | yq '.[3]' | tee /dev/stderr)
    [ "${actual}" = "--global-transformation-options=exclude-raw" ]
@@ -778,13 +778,13 @@ load _helpers
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
-   [ "${actual}" = "11" ]
+   [ "${actual}" = "14" ]
 
    local actual=$(echo "$object" | yq '.[3]' | tee /dev/stderr)
    [ "${actual}" = "--global-transformation-options=exclude-raw" ]
-   local actual=$(echo "$object" | yq '.[9]' | tee /dev/stderr)
+   local actual=$(echo "$object" | yq '.[12]' | tee /dev/stderr)
    [ "${actual}" = "--foo=baz" ]
-   local actual=$(echo "$object" | yq '.[10]' | tee /dev/stderr)
+   local actual=$(echo "$object" | yq '.[13]' | tee /dev/stderr)
    [ "${actual}" = "--bar=qux" ]
 }
 
@@ -796,7 +796,7 @@ load _helpers
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
-   [ "${actual}" = "8" ]
+   [ "${actual}" = "11" ]
 
    local actual=$(echo "$object" | yq '.[3]' | tee /dev/stderr)
    [ "${actual}" = "--backoff-initial-interval=5s" ]
@@ -808,6 +808,7 @@ load _helpers
    [ "${actual}" = "--backoff-multiplier=1.50" ]
    local actual=$(echo "$object" | yq '.[7]' | tee /dev/stderr)
    [ "${actual}" = "--backoff-randomization-factor=0.50" ]
+   local actual=$(echo "$object" | yq '.[8]' | tee /dev/stderr)
 }
 
 @test "controller/Deployment: with backOffOnSecretSourceError set" {
@@ -823,7 +824,7 @@ load _helpers
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 
    local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
-   [ "${actual}" = "8" ]
+   [ "${actual}" = "11" ]
    local actual=$(echo "$object" | yq '.[3]' | tee /dev/stderr)
    [ "${actual}" = "--backoff-initial-interval=30s" ]
    local actual=$(echo "$object" | yq '.[4]' | tee /dev/stderr)
@@ -834,6 +835,171 @@ load _helpers
    [ "${actual}" = "--backoff-multiplier=2.50" ]
    local actual=$(echo "$object" | yq '.[7]' | tee /dev/stderr)
    [ "${actual}" = "--backoff-randomization-factor=3.74" ]
+}
+
+
+#--------------------------------------------------------------------
+# manager logging args
+@test "controller/Deployment: manager logging defaults" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/deployment.yaml \
+      . | tee /dev/stderr |
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+   local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
+   [ "${actual}" = "11" ]
+
+   local actual=$(echo "$object" | yq '.[8]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-log-level=info" ]
+   local actual=$(echo "$object" | yq '.[9]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-time-encoding=rfc3339" ]
+   local actual=$(echo "$object" | yq '.[10]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-stacktrace-level=panic" ]
+}
+
+@test "controller/Deployment: manager logging set all" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/deployment.yaml \
+      --set 'controller.manager.logging.level=debug' \
+      --set 'controller.manager.logging.timeEncoding=nanos' \
+      --set 'controller.manager.logging.stacktraceLevel=error' \
+      . | tee /dev/stderr |
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+   local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
+   [ "${actual}" = "11" ]
+
+   local actual=$(echo "$object" | yq '.[8]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-log-level=debug" ]
+   local actual=$(echo "$object" | yq '.[9]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-time-encoding=nanos" ]
+   local actual=$(echo "$object" | yq '.[10]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-stacktrace-level=error" ]
+}
+
+@test "controller/Deployment: manager logging set custom log level debug-extended" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/deployment.yaml \
+      --set 'controller.manager.logging.level=debug-extended' \
+      . | tee /dev/stderr |
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+   local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
+   [ "${actual}" = "11" ]
+
+   local actual=$(echo "$object" | yq '.[8]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-log-level=5" ]
+   local actual=$(echo "$object" | yq '.[9]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-time-encoding=rfc3339" ]
+   local actual=$(echo "$object" | yq '.[10]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-stacktrace-level=panic" ]
+}
+
+@test "controller/Deployment: manager logging set custom log level trace" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/deployment.yaml \
+      --set 'controller.manager.logging.level=trace' \
+      . | tee /dev/stderr |
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+   local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
+   [ "${actual}" = "11" ]
+
+   local actual=$(echo "$object" | yq '.[8]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-log-level=6" ]
+   local actual=$(echo "$object" | yq '.[9]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-time-encoding=rfc3339" ]
+   local actual=$(echo "$object" | yq '.[10]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-stacktrace-level=panic" ]
+}
+
+@test "controller/Deployment: manager logging with intersecting log level extraArgs" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/deployment.yaml \
+      --set 'controller.manager.extraArgs={--zap-log-level=extra,--bar=qux}' \
+      . | tee /dev/stderr |
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+   local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
+   [ "${actual}" = "12" ]
+
+   local actual=$(echo "$object" | yq '.[8]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-time-encoding=rfc3339" ]
+   local actual=$(echo "$object" | yq '.[9]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-stacktrace-level=panic" ]
+   local actual=$(echo "$object" | yq '.[10]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-log-level=extra" ]
+   local actual=$(echo "$object" | yq '.[11]' | tee /dev/stderr)
+   [ "${actual}" = "--bar=qux" ]
+}
+
+@test "controller/Deployment: manager logging with intersecting time encoding extraArgs" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/deployment.yaml \
+      --set 'controller.manager.extraArgs={--zap-time-encoding=extra,--bar=qux}' \
+      . | tee /dev/stderr |
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+   local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
+   [ "${actual}" = "12" ]
+
+   local actual=$(echo "$object" | yq '.[8]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-log-level=info" ]
+   local actual=$(echo "$object" | yq '.[9]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-stacktrace-level=panic" ]
+   local actual=$(echo "$object" | yq '.[10]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-time-encoding=extra" ]
+   local actual=$(echo "$object" | yq '.[11]' | tee /dev/stderr)
+   [ "${actual}" = "--bar=qux" ]
+}
+
+@test "controller/Deployment: manager logging with intersecting stacktrace level extraArgs" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -s templates/deployment.yaml \
+      --set 'controller.manager.extraArgs={--zap-stacktrace-level=extra,--bar=qux}' \
+      . | tee /dev/stderr |
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+   local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
+   [ "${actual}" = "12" ]
+
+   local actual=$(echo "$object" | yq '.[8]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-log-level=info" ]
+   local actual=$(echo "$object" | yq '.[9]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-time-encoding=rfc3339" ]
+   local actual=$(echo "$object" | yq '.[10]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-stacktrace-level=extra" ]
+   local actual=$(echo "$object" | yq '.[11]' | tee /dev/stderr)
+   [ "${actual}" = "--bar=qux" ]
+}
+
+@test "controller/Deployment: manager logging with all intersecting extraArgs" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --debug \
+      -s templates/deployment.yaml \
+      --set 'controller.manager.extraArgs={--zap-log-level=extra,-zap-time-encoding=extra,-zap-stacktrace-level=extra,--bar=qux}' \
+      . | tee /dev/stderr |
+      yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+   local actual=$(echo "$object" | yq '. | length' | tee /dev/stderr)
+   [ "${actual}" = "12" ]
+
+   local actual=$(echo "$object" | yq '.[8]' | tee /dev/stderr)
+   [ "${actual}" = "--zap-log-level=extra" ]
+   local actual=$(echo "$object" | yq '.[9]' | tee /dev/stderr)
+   [ "${actual}" = "-zap-time-encoding=extra" ]
+   local actual=$(echo "$object" | yq '.[10]' | tee /dev/stderr)
+   [ "${actual}" = "-zap-stacktrace-level=extra" ]
+   local actual=$(echo "$object" | yq '.[11]' | tee /dev/stderr)
+   [ "${actual}" = "--bar=qux" ]
 }
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
Adds the ability to specify various logging parameters that can be set at VSO controller-manager runtime:

Examples:
```yaml
controller:
  manager:
    # logging
    logging:
      # Sets the log level for the operator.
      # Builtin levels are: info, error, debug, debug-extended, trace
      # @type: string
      level: info

      # Sets the time encoding for the operator.
      # Options are: epoch, millis, nano, iso8601, rfc3339, rfc3339nano
      # Default: rfc3339
      # @type: string
      timeEncoding: rfc3339

      # Sets the stacktrace level for the operator.
      # Options are: info, error, panic
      # Default: panic
      # @type: string
      stacktraceLevel: panic
```