### PR TITLE
Helm: rename backOffOnSecretSourceError to backoffOnSecretSourceError

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -177,12 +177,12 @@ globalTransformationOptions configures the manager's --global-transformation-opt
 {{- end -}}
 
 {{/*
-backOffOnSecretSourceError provides the backoff options for the manager when a
+backoffOnSecretSourceError provides the backoff options for the manager when a
 secret source error occurs.
 */}}
-{{- define "vso.backOffOnSecretSourceError" -}}
+{{- define "vso.backoffOnSecretSourceError" -}}
 {{- $opts := list -}}
-{{- with .Values.controller.manager.backOffOnSecretSourceError -}}
+{{- with .Values.controller.manager.backoffOnSecretSourceError -}}
 {{- with .initialInterval -}}
 {{- $opts = mustAppend $opts (printf "--backoff-initial-interval=%s" .) -}}
 {{- end -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
         {{- if $opts }}
         - --global-transformation-options={{ $opts }}
         {{- end }}
-        {{- with include "vso.backOffOnSecretSourceError" . }}
+        {{- with include "vso.backoffOnSecretSourceError" . }}
         {{- . -}}
         {{- end }}
         {{- if .Values.controller.manager.extraArgs }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -162,7 +162,7 @@ controller:
 
     # Backoff settings for the controller manager. These settings control the backoff behavior
     # when the controller encounters an error while fetching secrets from the SecretSource.
-    backOffOnSecretSourceError:
+    backoffOnSecretSourceError:
       # Initial interval between retries.
       # @type: duration
       initialInterval: "5s"

--- a/test/unit/deployment.bats
+++ b/test/unit/deployment.bats
@@ -788,7 +788,7 @@ load _helpers
    [ "${actual}" = "--bar=qux" ]
 }
 
-@test "controller/Deployment: with backOffOnSecretSourceError defaults" {
+@test "controller/Deployment: with backoffOnSecretSourceError defaults" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/deployment.yaml \
@@ -810,15 +810,15 @@ load _helpers
    [ "${actual}" = "--backoff-randomization-factor=0.50" ]
 }
 
-@test "controller/Deployment: with backOffOnSecretSourceError set" {
+@test "controller/Deployment: with backoffOnSecretSourceError set" {
   cd `chart_dir`
   local object=$(helm template \
       -s templates/deployment.yaml \
-      --set 'controller.manager.backOffOnSecretSourceError.initialInterval=30s' \
-      --set 'controller.manager.backOffOnSecretSourceError.maxInterval=300s' \
-      --set 'controller.manager.backOffOnSecretSourceError.maxElapsedTime=24h' \
-      --set 'controller.manager.backOffOnSecretSourceError.multiplier=2.5' \
-      --set 'controller.manager.backOffOnSecretSourceError.randomizationFactor=3.7361' \
+      --set 'controller.manager.backoffOnSecretSourceError.initialInterval=30s' \
+      --set 'controller.manager.backoffOnSecretSourceError.maxInterval=300s' \
+      --set 'controller.manager.backoffOnSecretSourceError.maxElapsedTime=24h' \
+      --set 'controller.manager.backoffOnSecretSourceError.multiplier=2.5' \
+      --set 'controller.manager.backoffOnSecretSourceError.randomizationFactor=3.7361' \
       . | tee /dev/stderr |
       yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
 


### PR DESCRIPTION
See #732 for more details on the originally added feature.