### PR TITLE
[0.7.0] fix typo in values.yaml for enabling servicemonitor for telemetry

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -721,7 +721,7 @@ telemetry:
 
     # Enable deployment of the Vault Secrets Operator ServiceMonitor CustomResource.
     # @type: boolean
-    nabled: false
+    enabled: false
 
     # Selector labels to add to the ServiceMonitor.
     # When empty, defaults to:


### PR DESCRIPTION
In 0.6.0 this was correct:

https://github.com/hashicorp/vault-secrets-operator/blob/v0.6.0/chart/values.yaml#L639

>    enabled: false

In 0.7.0 this changed:

https://github.com/hashicorp/vault-secrets-operator/blob/v0.7.0/chart/values.yaml#L724
>    nabled: false

In the current state it's not possible to enable the servicemonitor:

```
➜  vault-secrets-operator git:(main) ✗ grep -A 3 "Enable deployment of the Vault Secrets Operator ServiceMonitor CustomResource." values.yaml; helm template vso . | grep -i servicemonitor
    # Enable deployment of the Vault Secrets Operator ServiceMonitor CustomResource.
    # @type: boolean
    nabled: true

➜  vault-secrets-operator git:(main) ✗ grep -A 3 "Enable deployment of the Vault Secrets Operator ServiceMonitor CustomResource." values.yaml; helm template vso . | grep -i servicemonitor
    # Enable deployment of the Vault Secrets Operator ServiceMonitor CustomResource.
    # @type: boolean
    enabled: true

# Source: vault-secrets-operator/templates/prometheus-servicemonitor.yaml
kind: ServiceMonitor
```