### PR TITLE
Helm: fix invalid value name for telemetry.serviceMonitor.enabled

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -721,7 +721,7 @@ telemetry:
 
     # Enable deployment of the Vault Secrets Operator ServiceMonitor CustomResource.
     # @type: boolean
-    nabled: false
+    enabled: false
 
     # Selector labels to add to the ServiceMonitor.
     # When empty, defaults to:


### PR DESCRIPTION
Corrects an issue introduced in #778

Replaces #784 

Ref: https://github.com/hashicorp/vault-secrets-operator/pull/778/files#diff-a9d07052701ab3b718c82ac0fe74b965a8260b06bb5906362081718b0ee593b4R724