### PR TITLE
Helm: add support for auto upgrading CRDs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,8 +108,7 @@ jobs:
         run: |
           mkdir dist out
           make ci-build
-          cd dist/${{ env.GOOS }}/${{ env.GOARCH }}/.
-          zip -r --symlinks ../../../out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip .
+          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip dist/${{ env.GOOS }}/${{ env.GOARCH }}/${{ env.PKG_NAME }}
       - name: Upload binaries
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
@@ -126,9 +125,12 @@ jobs:
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.get-product-version.outputs.product-version}}
-
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Setup scripts directory
+        shell: bash
+        run: |
+          make ci-build-scripts-dir GOARCH="${{ matrix.arch }}"
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v2
         env:
@@ -164,9 +166,12 @@ jobs:
       repo: ${{github.event.repository.name}}
       version: ${{needs.get-product-version.outputs.product-version}}
       image_tag: ${{needs.get-product-version.outputs.product-version}}-ubi
-
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Setup scripts directory
+        shell: bash
+        run: |
+          make ci-build-scripts-dir GOARCH="${{ matrix.arch }}"
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v2
         env:
@@ -204,9 +209,12 @@ jobs:
       repo: ${{github.event.repository.name}}
       version: ${{needs.get-product-version.outputs.product-version}}
       image_tag: ${{needs.get-product-version.outputs.product-version}}-ubi
-
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Setup scripts directory
+        shell: bash
+        run: |
+          make ci-build-scripts-dir GOARCH="${{ matrix.arch }}"
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v2
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,6 +41,8 @@ jobs:
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: .go-version
+          cache-dependency-path: |
+            go.sum
       - name: go fmt
         run: |
           make check-fmt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -239,6 +239,47 @@ jobs:
             exit 1
           fi
 
+  chart-upgrade-tests:
+    runs-on: ubuntu-latest
+    needs:
+      - get-product-version
+      - build-pre-checks
+      - build-docker
+    strategy:
+      fail-fast: false
+      matrix:
+        start-chart-version: ["0.2.0"]
+    steps:
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: ${{ github.event.repository.name }}_release-default_linux_amd64_${{ needs.get-product-version.outputs.product-version }}_${{ github.sha }}.docker.tar
+      - name: Load docker image
+        shell: bash
+        run: |
+            docker load --input ${{ github.event.repository.name }}_release-default_linux_amd64_${{ needs.get-product-version.outputs.product-version }}_${{ github.sha }}.docker.tar
+      - name: Install kind
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        with:
+          version: "v0.22.0"
+          install_only: true
+      - uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        id: setup-helm
+        with:
+          version: "v3.15.1"
+      - name: Add repo
+        shell: bash
+        run: |
+          helm repo add hashicorp https://helm.releases.hashicorp.com
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Setup go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version-file: .go-version
+      - name: Run tests
+        shell: bash
+        run: |
+          export TEST_START_CHART_VERSION="${{ matrix.start-chart-version }}"
+          make integration-test-chart VERSION="${{ needs.get-product-version.outputs.product-version }}"
   versions:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,7 +108,8 @@ jobs:
         run: |
           mkdir dist out
           make ci-build
-          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip dist/${{ env.GOOS }}/${{ env.GOARCH }}/
+          cd dist/${{ env.GOOS }}/${{ env.GOARCH }}/.
+          zip -r --symlinks ../../../out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip .
       - name: Upload binaries
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -248,14 +248,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Test upgrading from the previous version to the current build.
+        # This list should be updated with each new release.
+        # We probably only want to maintain the last 5-6 versions.
         start-chart-version:
-        - "0.1.0"
         - "0.2.0"
-        - "0.3.0"
+        - "0.3.1"
         - "0.4.0"
         - "0.5.0"
         - "0.6.0"
-        - "0.7.0"
+        - "0.7.1"
     steps:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,8 +41,6 @@ jobs:
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: .go-version
-          cache-dependency-path: |
-            go.sum
       - name: go fmt
         run: |
           make check-fmt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -248,7 +248,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        start-chart-version: ["0.2.0"]
+        start-chart-version:
+        - "0.1.0"
+        - "0.2.0"
+        - "0.3.0"
+        - "0.4.0"
+        - "0.5.0"
+        - "0.6.0"
+        - "0.7.0"
     steps:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:

--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,8 @@ integration-test-both: ## Run integration tests against Vault Enterprise and Vau
 
 .PHONY: integration-test-chart
 integration-test-chart:
-	IMG=$(IMG) \
+	IMAGE_TAG_BASE=$(IMAGE_TAG_BASE) \
+	VERSION=$(VERSION) \
 	INTEGRATION_TESTS=true \
 	go test github.com/hashicorp/vault-secrets-operator/test/chart/... $(TESTARGS) -timeout=10m
 

--- a/Makefile
+++ b/Makefile
@@ -272,12 +272,15 @@ docker-push: ## Push docker image with the manager.
 
 ##@ CI
 
-.PHONY: ci-build
-ci-build: ## Build operator binary (without generating assets).
+.PHONY: ci-build-scripts-dir
+ci-build-scripts-dir: ## Build operator binary (without generating assets).
 	rm -rf $(BUILD_DIR)/$(GOOS)/$(GOARCH)/scripts
 	mkdir -p $(BUILD_DIR)/$(GOOS)/$(GOARCH)/scripts
 	cp -a chart/crds $(BUILD_DIR)/$(GOOS)/$(GOARCH)/scripts/.
 	ln -s ../$(BIN_NAME) $(BUILD_DIR)/$(GOOS)/$(GOARCH)/scripts/upgrade-crds
+
+.PHONY: ci-build
+ci-build: ci-build-scripts-dir ## Build operator binary (without generating assets).
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
 		-ldflags "${LD_FLAGS} $(shell GOOS=$(GOOS) GOARCH=$(GOARCH) ./scripts/ldflags-version.sh)" \
 		-a \

--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,9 @@ integration-test-both: ## Run integration tests against Vault Enterprise and Vau
 
 .PHONY: integration-test-chart
 integration-test-chart:
-	INTEGRATION_TESTS=true go test github.com/hashicorp/vault-secrets-operator/test/chart/... $(TESTARGS) -timeout=10m
+	IMG=$(IMG) \
+	INTEGRATION_TESTS=true \
+	go test github.com/hashicorp/vault-secrets-operator/test/chart/... $(TESTARGS) -timeout=10m
 
 .PHONY: setup-kind
 setup-kind: ## create a kind cluster for running the acceptance tests locally

--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,10 @@ docker-push: ## Push docker image with the manager.
 
 .PHONY: ci-build
 ci-build: ## Build operator binary (without generating assets).
-	mkdir -p $(BUILD_DIR)/$(GOOS)/$(GOARCH)
+	rm -rf $(BUILD_DIR)/$(GOOS)/$(GOARCH)/scripts
+	mkdir -p $(BUILD_DIR)/$(GOOS)/$(GOARCH)/scripts
+	cp -a chart/crds $(BUILD_DIR)/$(GOOS)/$(GOARCH)/scripts/.
+	ln -s ../$(BIN_NAME) $(BUILD_DIR)/$(GOOS)/$(GOARCH)/scripts/upgrade-crds
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
 		-ldflags "${LD_FLAGS} $(shell GOOS=$(GOOS) GOARCH=$(GOARCH) ./scripts/ldflags-version.sh)" \
 		-a \

--- a/Makefile
+++ b/Makefile
@@ -338,6 +338,10 @@ integration-test-both: ## Run integration tests against Vault Enterprise and Vau
 	$(MAKE) integration-test VAULT_ENTERPRISE=true ENT_TESTS=$(VAULT_ENTERPRISE)
 	$(MAKE) integration-test
 
+.PHONY: integration-test-chart
+integration-test-chart:
+	INTEGRATION_TESTS=true go test github.com/hashicorp/vault-secrets-operator/test/chart/... $(TESTARGS) -timeout=10m
+
 .PHONY: setup-kind
 setup-kind: ## create a kind cluster for running the acceptance tests locally
 	kind get clusters | grep --silent "^$(KIND_CLUSTER_NAME)$$" || \

--- a/chart/templates/cluster-role-binding.yaml
+++ b/chart/templates/cluster-role-binding.yaml
@@ -1,3 +1,8 @@
+{{- /*
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+*/ -}}
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/chart/templates/clusterrole-aggregated-editor.yaml
+++ b/chart/templates/clusterrole-aggregated-editor.yaml
@@ -1,3 +1,8 @@
+{{- /*
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+*/ -}}
+
 {{- if .Values.controller.rbac.clusterRoleAggregation.editorRoles -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/chart/templates/clusterrole-aggregated-viewer.yaml
+++ b/chart/templates/clusterrole-aggregated-viewer.yaml
@@ -1,3 +1,8 @@
+{{- /*
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+*/ -}}
+
 {{- if .Values.controller.rbac.clusterRoleAggregation.viewerRoles -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   name: {{ include "vso.chart.fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/component: controller-manager
   {{- include "vso.chart.labels" . | nindent 4 }}
 {{ include "vso.imagePullSecrets" .}}
 ---
@@ -167,6 +168,7 @@ metadata:
   name: {{ printf "%s-%s" "pdcc" (include "vso.chart.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/component: controller-manager
   {{- include "vso.chart.labels" . | nindent 4 }}
   annotations:
     # This is what defines this resource as a hook. Without this line, the
@@ -177,6 +179,7 @@ metadata:
       {{- toYaml .Values.controller.annotations | nindent 4 }}
     {{- end }}
 spec:
+  backoffLimit: 5
   template:
     metadata:
       # This name is truncated because kubernetes applies labels to the job which contain the job and pod
@@ -195,15 +198,20 @@ spec:
         - --pre-delete-hook-timeout-seconds={{ .Values.controller.preDeleteHookTimeoutSeconds }}
         command:
         - /vault-secrets-operator
-        resources: {{- toYaml .Values.controller.manager.resources | nindent 10 }}
+        {{- with .Values.hooks.resources  }}
+        resources:
+        {{- toYaml . | nindent 10 }}
+        {{- end}}
+        {{- with  .Values.controller.securityContext }}
         securityContext:
-          {{- toYaml .Values.controller.securityContext | nindent 10 }}
+        {{- toYaml .| nindent 10 }}
+        {{- end}}
       restartPolicy: Never
-      {{- if .Values.controller.nodeSelector }}
+      {{- with .Values.controller.nodeSelector }}
       nodeSelector:
-      {{- toYaml .Values.controller.nodeSelector | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.controller.tolerations }}
+      {{- with .Values.controller.tolerations }}
       tolerations:
-      {{- toYaml .Values.controller.tolerations | nindent 8 }}
+      {{- toYaml .| nindent 8 }}
       {{- end }}

--- a/chart/templates/hook-upgrade-crds.yaml
+++ b/chart/templates/hook-upgrade-crds.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.hooks.upgradeCRDs.enabled -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "vso.chart.fullname" . }}-upgrade-crds
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: controller-manager
+{{ include "vso.chart.labels" . | indent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
+    helm.sh/hook-weight: "1"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "vso.chart.fullname" . }}-upgrade-crds
+  labels:
+    app.kubernetes.io/component: rbac
+{{ include "vso.chart.labels" . | indent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
+    helm.sh/hook-weight: "2"
+rules:
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "vso.chart.fullname" . }}-upgrade-crds
+  labels:
+    app.kubernetes.io/component: rbac
+{{ include "vso.chart.labels" . | indent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
+    helm.sh/hook-weight: "2"
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "vso.chart.fullname" . }}-upgrade-crds
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "vso.chart.fullname" . }}-upgrade-crds
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-%s" "upgrade-crds" (include "vso.chart.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: controller-manager
+  {{- include "vso.chart.labels" . | nindent 4 }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
+    helm.sh/hook-weight: "99"
+    {{- if .Values.controller.annotations }}
+      {{- toYaml .Values.controller.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.hooks.upgradeCRDs.backoffLimit | default 5 }}
+  template:
+    metadata:
+      name: {{ printf "%s-%s" "upgrade-crds" (include "vso.chart.fullname" .) | trunc 63 | trimSuffix "-" }}
+    spec:
+      serviceAccountName: {{ template "vso.chart.fullname" . }}-upgrade-crds
+      securityContext:
+        {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
+      containers:
+      - name: pre-upgrade-crds
+        image: {{ .Values.controller.manager.image.repository }}:{{ .Values.controller.manager.image.tag }}
+        env:
+        - name: VSO_UPGRADE_CRDS_TIMEOUT
+          value: .Values.hooks.upgradeCRDs.executionTimeout
+        command:
+        - /scripts/upgrade-crds
+        {{- with .Values.hooks.resources  }}
+        resources:
+        {{- toYaml . | nindent 10 }}
+        {{- end}}
+        {{- with  .Values.controller.securityContext }}
+        securityContext:
+        {{- toYaml .| nindent 10 }}
+        {{- end}}
+      restartPolicy: Never
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+      {{- toYaml .| nindent 8 }}
+      {{- end }}
+{{- end -}}

--- a/chart/templates/hook-upgrade-crds.yaml
+++ b/chart/templates/hook-upgrade-crds.yaml
@@ -88,7 +88,7 @@ spec:
         image: {{ .Values.controller.manager.image.repository }}:{{ .Values.controller.manager.image.tag }}
         env:
         - name: VSO_UPGRADE_CRDS_TIMEOUT
-          value: .Values.hooks.upgradeCRDs.executionTimeout
+          value: {{ .Values.hooks.upgradeCRDs.executionTimeout }}
         command:
         - /scripts/upgrade-crds
         {{- with .Values.hooks.resources  }}

--- a/chart/templates/hook-upgrade-crds.yaml
+++ b/chart/templates/hook-upgrade-crds.yaml
@@ -1,3 +1,8 @@
+{{- /*
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+*/ -}}
+
 {{- if .Values.hooks.upgradeCRDs.enabled -}}
 ---
 apiVersion: v1

--- a/chart/templates/tests/test-runner.yaml
+++ b/chart/templates/tests/test-runner.yaml
@@ -9,6 +9,7 @@ metadata:
   name: {{ template "vso.chart.fullname" . }}-test
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/component: controller-manager
     app: {{ template "vso.chart.name" . }}
     chart: {{ template "vso.chart.chart" . }}
     heritage: {{ .Release.Service }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,7 +4,6 @@
 # Top level configuration for the vault secrets operator deployment.
 # This consists of a controller and a kube rbac proxy container.
 controller:
-
   # Set the number of replicas for the operator.
   # @type: integer
   replicas: 1
@@ -752,6 +751,33 @@ telemetry:
     # Timeout for Prometheus scrapes
     # @type: string
     scrapeTimeout: 10s
+
+# Configure the behaviour of Helm hooks.
+hooks:
+  # Resources common to all hooks.
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  # Configure the Helm pre-upgrade hook that handles custom resource definition (CRD) upgrades.
+  upgradeCRDs:
+    # Set to true to automatically upgrade the CRDs.
+    # Disabling this will require manual intervention to upgrade the CRDs, so it is recommended to
+    # always leave it enabled.
+    # @type: boolean
+    enabled: true
+
+    # Limit the number of retries for the CRD upgrade.
+    # @type: integer
+    backoffLimit:  5
+
+    # Set the timeout for the CRD upgrade. The operation should typically take less than 5s
+    # to complete.
+    # @type: string
+    executionTimeout: 30s
 
 ## Used by unit tests, and will not be rendered except when using `helm template`, this can be safely ignored.
 tests:

--- a/go.mod
+++ b/go.mod
@@ -29,12 +29,13 @@ require (
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.23.0
 	google.golang.org/api v0.181.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.1
+	k8s.io/apiextensions-apiserver v0.30.1
 	k8s.io/apimachinery v0.30.1
 	k8s.io/client-go v0.30.1
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.18.3
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -167,10 +168,9 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/apiextensions-apiserver v0.30.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.23.0
 	google.golang.org/api v0.181.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.1
 	k8s.io/apiextensions-apiserver v0.30.1
 	k8s.io/apimachinery v0.30.1
@@ -168,7 +169,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -240,7 +240,7 @@ metadata:
 			otherManifests: []string{"foo:\n-bar"},
 			createDir:      true,
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, `yaml: line 3: could not find expected ':'`)
+				return assert.ErrorContains(t, err, `yaml: line 2: could not find expected ':'`)
 			},
 		},
 	}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -4,9 +4,19 @@
 package utils
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetCurrentNamespace(t *testing.T) {
@@ -68,6 +78,220 @@ func TestGetCurrentNamespace(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("GetCurrentNamespace() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpgradeCRDs(t *testing.T) {
+	t.Parallel()
+
+	manifests := []string{
+		`apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hcpauths.secrets.hashicorp.com
+spec:
+  group: secrets.hashicorp.com
+  names:
+    kind: HCPAuth
+    listKind: HCPAuthList
+    plural: hcpauths
+    singular: hcpauth
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+`,
+	}
+
+	manifestsUpdated := []string{
+		`apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hcpauths.secrets.hashicorp.com
+spec:
+  group: secrets.hashicorp.com
+  names:
+    kind: HCPAuth
+    listKind: HCPAuthList
+    plural: hcpauths
+    singular: hcpauth
+  scope: Cluster
+  versions:
+  - name: v1beta2
+`,
+	}
+
+	others := []string{
+		`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo
+`,
+	}
+
+	wantCRD := &apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hcpauths.secrets.hashicorp.com",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "secrets.hashicorp.com",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     "HCPAuth",
+				ListKind: "HCPAuthList",
+				Plural:   "hcpauths",
+				Singular: "hcpauth",
+			},
+			Scope: "Namespaced",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name: "v1beta1",
+				},
+			},
+		},
+	}
+
+	wantCRDUpdated := wantCRD.DeepCopy()
+	wantCRDUpdated.Spec.Scope = "Cluster"
+	wantCRDUpdated.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{
+		{
+			Name: "v1beta2",
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, apiextensionsv1.AddToScheme(scheme))
+
+	root := t.TempDir()
+	ctx := context.Background()
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	tests := []struct {
+		name           string
+		c              client.Client
+		create         []*apiextensionsv1.CustomResourceDefinition
+		createDir      bool
+		manifests      []string
+		otherManifests []string
+		subDirs        int
+		canaries       int
+		want           []*apiextensionsv1.CustomResourceDefinition
+		wantErr        assert.ErrorAssertionFunc
+	}{
+		{
+			name:           "create",
+			c:              builder.Build(),
+			createDir:      true,
+			subDirs:        2,
+			canaries:       2,
+			otherManifests: others,
+			manifests:      manifests,
+			want: []*apiextensionsv1.CustomResourceDefinition{
+				wantCRD.DeepCopy(),
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name:           "upgrade",
+			c:              builder.Build(),
+			createDir:      true,
+			subDirs:        2,
+			canaries:       2,
+			manifests:      manifestsUpdated,
+			otherManifests: others,
+			create: []*apiextensionsv1.CustomResourceDefinition{
+				wantCRD.DeepCopy(),
+			},
+			want: []*apiextensionsv1.CustomResourceDefinition{
+				wantCRDUpdated.DeepCopy(),
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name:      "invalid-scheme-not-registered",
+			c:         fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
+			createDir: true,
+			manifests: manifests,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err,
+					"no kind is registered for the type v1.CustomResourceDefinition in scheme")
+			},
+		},
+		{
+			name: "invalid-no-dir", wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorIs(t, err, os.ErrNotExist)
+			},
+		},
+		{
+			name:           "invalid-no-crds-found",
+			otherManifests: others,
+			createDir:      true,
+			subDirs:        2,
+			canaries:       2,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "no CRDs found in directory")
+			},
+		},
+		{
+			name:           "invalid-yaml-parse-error",
+			otherManifests: []string{"foo:\n-bar"},
+			createDir:      true,
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, `yaml: line 3: could not find expected ':'`)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := filepath.Join(root, tt.name)
+			if tt.createDir {
+				require.NoError(t, os.MkdirAll(dir, 0o700))
+				t.Cleanup(func() {
+					require.NoError(t, os.RemoveAll(dir))
+				})
+			}
+
+			if len(tt.manifests) > 0 || len(tt.otherManifests) > 0 || tt.subDirs > 0 || tt.canaries > 0 {
+				require.True(t, tt.createDir, "createDir cannot be false")
+			}
+
+			for idx, mft := range tt.otherManifests {
+				filename := filepath.Join(dir, fmt.Sprintf("other-%d.yaml", idx))
+				require.NoError(t, os.WriteFile(filename, []byte(mft), 0o600))
+			}
+
+			for i := 0; i < tt.subDirs; i++ {
+				subDir := filepath.Join(dir, fmt.Sprintf("dir-%d", i))
+				require.NoError(t, os.Mkdir(subDir, 0o700))
+			}
+
+			for i := 0; i < tt.subDirs; i++ {
+				filename := filepath.Join(dir, fmt.Sprintf("canary-%d", i))
+				require.NoError(t, os.WriteFile(filename, []byte{}, 0o600))
+			}
+
+			for idx, mft := range tt.manifests {
+				filename := filepath.Join(dir, fmt.Sprintf("manifest-%d.yaml", idx))
+				require.NoError(t, os.WriteFile(filename, []byte(mft), 0o600))
+			}
+
+			for _, crd := range tt.create {
+				require.NoError(t, tt.c.Create(ctx, crd))
+			}
+
+			if !tt.wantErr(t, UpgradeCRDs(ctx, tt.c, dir), fmt.Sprintf("UpgradeCRDs(%v, %v, %v)",
+				ctx, tt.c, dir)) {
+				return
+			}
+
+			for _, w := range tt.want {
+				var crd apiextensionsv1.CustomResourceDefinition
+				require.NoError(t, tt.c.Get(ctx, client.ObjectKey{Name: w.Name}, &crd))
+				assert.Equal(t, w.TypeMeta, crd.TypeMeta)
+				assert.Equal(t, w.Spec, crd.Spec)
 			}
 		})
 	}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -268,7 +268,7 @@ metadata:
 				require.NoError(t, os.Mkdir(subDir, 0o700))
 			}
 
-			for i := 0; i < tt.subDirs; i++ {
+			for i := 0; i < tt.canaries; i++ {
 				filename := filepath.Join(dir, fmt.Sprintf("canary-%d", i))
 				require.NoError(t, os.WriteFile(filename, []byte{}, 0o600))
 			}

--- a/main.go
+++ b/main.go
@@ -110,6 +110,7 @@ func main() {
 		// utility jobs like this.
 		var exitCode int
 		if err := upgradeCRDs(); err != nil {
+			exitCode = 1
 			os.Stderr.WriteString(fmt.Sprintf("failed to upgrade CRDs, err=%s\n", err))
 		}
 		os.Exit(exitCode)

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -17,13 +18,14 @@ import (
 	argorolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/yaml.v3"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/yaml"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -38,6 +40,7 @@ import (
 	"github.com/hashicorp/vault-secrets-operator/internal/helpers"
 	"github.com/hashicorp/vault-secrets-operator/internal/metrics"
 	"github.com/hashicorp/vault-secrets-operator/internal/options"
+	"github.com/hashicorp/vault-secrets-operator/internal/utils"
 	vclient "github.com/hashicorp/vault-secrets-operator/internal/vault"
 	"github.com/hashicorp/vault-secrets-operator/internal/version"
 	//+kubebuilder:scaffold:imports
@@ -65,7 +68,53 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
+// upgradeCRDs upgrades the CRDs in the cluster to the latest version.
+func upgradeCRDs() error {
+	root, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		return err
+	}
+
+	var c client.Client
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	s := runtime.NewScheme()
+	if apiextensionsv1.AddToScheme(s) != nil {
+		return err
+	}
+
+	c, err = client.New(config, client.Options{Scheme: s})
+	if err != nil {
+		return err
+	}
+
+	timeout := time.Second * 30
+	if v := os.Getenv("VSO_UPGRADE_CRDS_TIMEOUT"); v != "" {
+		if to, err := time.ParseDuration(v); err == nil {
+			timeout = to
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return utils.UpgradeCRDs(ctx, c, filepath.Join(root, "crds"))
+}
+
 func main() {
+	if filepath.Base(os.Args[0]) == "upgrade-crds" {
+		// If the binary is named "upgrade-crds" then we are running in a job to upgrade
+		// CRDs and exit. The docker image will contain a symlink to the binary with this
+		// name. Following this pattern allows us to need only one image for executing
+		// utility jobs like this.
+		var exitCode int
+		if err := upgradeCRDs(); err != nil {
+			os.Stderr.WriteString(fmt.Sprintf("failed to upgrade CRDs, err=%s\n", err))
+		}
+		os.Exit(exitCode)
+	}
+
 	persistenceModelNone := "none"
 	persistenceModelDirectUnencrypted := "direct-unencrypted"
 	persistenceModelDirectEncrypted := "direct-encrypted"

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -1,0 +1,266 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package chart
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	ctrlruntime "k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/hashicorp/vault-secrets-operator/internal/utils"
+)
+
+var (
+	testRoot             string
+	chartPath            string
+	onlyOneSignalHandler = make(chan struct{})
+	shutdownSignals      = []os.Signal{os.Interrupt, syscall.SIGTERM}
+	vsoNamespace         = "vault-secrets-operator-system"
+	// kindClusterName is set in TestMain
+	kindClusterName string
+	// set in TestMain
+	client ctrlclient.Client
+	scheme = ctrlruntime.NewScheme()
+)
+
+func init() {
+	_, curFilePath, _, _ := runtime.Caller(0)
+	testRoot = path.Dir(curFilePath)
+
+	var err error
+	chartPath, err = filepath.Abs(filepath.Join(testRoot, "..", "..", "chart"))
+	if err != nil {
+		panic(err)
+	}
+
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+}
+
+func TestMain(m *testing.M) {
+	if os.Getenv("INTEGRATION_TESTS") == "" {
+		os.Exit(0)
+	}
+
+	kindClusterName = fmt.Sprintf("vso-chart-%d", time.Now().UnixNano())
+
+	var err error
+	var result int
+
+	var tempDir string
+	tempDir, err = os.MkdirTemp(os.TempDir(), "MainTestChart")
+	if err != nil {
+		log.Printf("ERROR: Failed to create tempdir: %s", err)
+		os.Exit(1)
+	}
+
+	kubeConfig := filepath.Join(tempDir, ".kube-config")
+	os.Setenv("KUBECONFIG", kubeConfig)
+	cleanupFunc := func() {
+		if tempDir != "" {
+			os.RemoveAll(tempDir)
+		}
+
+		cmd := exec.Command("kind",
+			"delete", "cluster", "--name", kindClusterName,
+		)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err = cmd.Run(); err != nil {
+			result = 1
+			log.Printf("WARN: Failed to delete the kind cluster: %s", err)
+		}
+	}
+
+	cmd := exec.Command("kind",
+		"create", "cluster",
+		"--name", kindClusterName,
+		"--kubeconfig", kubeConfig,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	ctx, cancel := setupSignalHandler()
+	{
+		go func() {
+			select {
+			case <-ctx.Done():
+				cleanupFunc()
+				wg.Done()
+			}
+		}()
+	}
+
+	err = cmd.Run()
+	if err != nil {
+		log.Printf("ERROR: Failed to create kind cluster: %s", err)
+		os.Exit(1)
+	}
+
+	config := ctrl.GetConfigOrDie()
+	client, err = ctrlclient.New(config, ctrlclient.Options{Scheme: scheme})
+	if err != nil {
+		log.Printf("ERROR: Failed to setup k8s client: %s", err)
+		os.Exit(1)
+	}
+
+	result = m.Run()
+
+	cancel()
+	wg.Wait()
+	os.Exit(result)
+}
+
+func TestChart_upgradeCRDs(t *testing.T) {
+	releaseName := strings.Replace(strings.ToLower(t.Name()), "_", "-", -1)
+	ctx := context.Background()
+	t.Cleanup(func() {
+		assert.NoError(t, uninstallVSO(t, ctx,
+			"--wait",
+			"--namespace", vsoNamespace,
+			releaseName,
+		))
+	})
+
+	require.NoError(t, runKind(t, ctx,
+		"load", "docker-image", "hashicorp/vault-secrets-operator:0.0.0-dev",
+		"--name", kindClusterName,
+	))
+
+	require.NoError(t, installVSO(t, ctx,
+		"--wait",
+		"--create-namespace",
+		"--namespace", vsoNamespace,
+		// picking a lower version to ensure we see some CRD changes.
+		"--version", "0.2.0",
+		releaseName,
+		"hashicorp/vault-secrets-operator",
+	))
+
+	var origCRDs apiextensionsv1.CustomResourceDefinitionList
+	require.NoError(t, client.List(ctx, &origCRDs))
+
+	origCRDsByName := map[string]apiextensionsv1.CustomResourceDefinition{}
+	for _, o := range origCRDs.Items {
+		origCRDsByName[o.Name] = o
+	}
+
+	require.NoError(t, upgradeVSO(t, ctx,
+		"--wait",
+		"--namespace", vsoNamespace,
+		"--set", "controller.manager.image.tag=0.0.0-dev",
+		releaseName,
+		chartPath,
+	))
+
+	crdsDir := filepath.Join(chartPath, "crds")
+	wantCRDs, err := utils.LoadCRDsFromDir(crdsDir)
+	require.NoError(t, err, "failed to load CRDs from %q", crdsDir)
+	require.Greater(t, len(wantCRDs), 0, "no CRDs found in %q", crdsDir)
+
+	var updatedCRDs apiextensionsv1.CustomResourceDefinitionList
+	require.NoError(t, client.List(ctx, &updatedCRDs))
+	assert.NotEqual(t, origCRDs.Items, updatedCRDs.Items)
+
+	for _, wantCRD := range wantCRDs {
+		var updatedCRD apiextensionsv1.CustomResourceDefinition
+		require.NoError(t, client.Get(ctx, ctrlclient.ObjectKeyFromObject(&wantCRD), &updatedCRD))
+		if wantCRD.Spec.Conversion == nil {
+			updatedCRD.Spec.Conversion = nil
+		}
+
+		if o, ok := origCRDsByName[wantCRD.Name]; ok {
+			assert.Greater(t, updatedCRD.Generation, o.Generation)
+			assert.Equal(t, o.UID, updatedCRD.UID)
+		} else {
+			assert.Equal(t, int64(1), updatedCRD.Generation)
+		}
+
+		assert.Equal(t, wantCRD.Spec, updatedCRD.Spec, "CRD %q .spec mismatch", wantCRD.Name)
+		assert.Equal(t, wantCRD.Labels, updatedCRD.Labels, "CRD %q .metadata.labels mismatch", wantCRD.Name)
+		assert.Equal(t, wantCRD.Annotations, updatedCRD.Annotations, "CRD %q .metadata.annotations mismatch", wantCRD.Name)
+	}
+}
+
+func installVSO(t *testing.T, ctx context.Context, extraArgs ...string) error {
+	t.Helper()
+	ctx_, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
+	return runHelm(t, ctx_, append([]string{"install"}, extraArgs...)...)
+}
+
+func upgradeVSO(t *testing.T, ctx context.Context, extraArgs ...string) error {
+	t.Helper()
+	ctx_, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
+	return runHelm(t, ctx_, append([]string{"upgrade"}, extraArgs...)...)
+}
+
+func uninstallVSO(t *testing.T, ctx context.Context, extraArgs ...string) error {
+	t.Helper()
+	ctx_, cancel := context.WithTimeout(ctx, time.Minute*3)
+	defer cancel()
+	return runHelm(t, ctx_, append([]string{"uninstall"}, extraArgs...)...)
+}
+
+func runHelm(t *testing.T, ctx context.Context, args ...string) error {
+	t.Helper()
+	return runCommand(t, ctx, "helm", args...)
+}
+
+func runKind(t *testing.T, ctx context.Context, args ...string) error {
+	ctx_, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
+	t.Helper()
+	return runCommand(t, ctx_, "kind", args...)
+}
+
+func runCommand(t *testing.T, ctx context.Context, name string, args ...string) error {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	t.Logf("Running command %q", cmd)
+	return cmd.Run()
+}
+
+// // setupSignalHandler registers for SIGTERM and SIGINT. A context is returned
+// // which is canceled on one of these signals. If a second signal is caught, the program
+// // is terminated with exit code 1.
+func setupSignalHandler() (context.Context, context.CancelFunc) {
+	close(onlyOneSignalHandler) // panics when called twice
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, shutdownSignals...)
+	go func() {
+		<-c
+		cancel()
+		<-c
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return ctx, cancel
+}

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -133,6 +133,17 @@ func TestMain(m *testing.M) {
 }
 
 func TestChart_upgradeCRDs(t *testing.T) {
+	startChartVersion := os.Getenv("TEST_START_CHART_VERSION")
+	if startChartVersion == "" {
+		startChartVersion = "0.2.0"
+	}
+
+	// IMG is set in the Makefile
+	image := os.Getenv("IMG")
+	if image == "" {
+		image = "hashicorp/vault-secrets-operator:0.0.0-dev"
+	}
+
 	releaseName := strings.Replace(strings.ToLower(t.Name()), "_", "-", -1)
 	ctx := context.Background()
 	t.Cleanup(func() {
@@ -144,7 +155,7 @@ func TestChart_upgradeCRDs(t *testing.T) {
 	})
 
 	require.NoError(t, runKind(t, ctx,
-		"load", "docker-image", "hashicorp/vault-secrets-operator:0.0.0-dev",
+		"load", "docker-image", image,
 		"--name", kindClusterName,
 	))
 
@@ -153,7 +164,7 @@ func TestChart_upgradeCRDs(t *testing.T) {
 		"--create-namespace",
 		"--namespace", vsoNamespace,
 		// picking a lower version to ensure we see some CRD changes.
-		"--version", "0.2.0",
+		"--version", startChartVersion,
 		releaseName,
 		"hashicorp/vault-secrets-operator",
 	))

--- a/test/unit/deployment.bats
+++ b/test/unit/deployment.bats
@@ -101,6 +101,10 @@ load _helpers
       --set 'controller.manager.resources.requests.cpu=100m' \
       --set 'controller.manager.resources.limits.memory=200Mi' \
       --set 'controller.manager.resources.limits.cpu=200m' \
+      --set 'hooks.resources.requests.memory=256Mi' \
+      --set 'hooks.resources.requests.cpu=200m' \
+      --set 'hooks.resources.limits.memory=400Mi' \
+      --set 'hooks.resources.limits.cpu=400m' \
       . | tee /dev/stderr |
       yq '.' | tee /dev/stderr)
 
@@ -115,14 +119,15 @@ load _helpers
     [ "${actual}" = "200m" ]
    actual=$(echo "$controller" | yq '.limits.memory' | tee /dev/stderr)
     [ "${actual}" = "200Mi" ]
+
    actual=$(echo "$job" | yq '.requests.cpu' | tee /dev/stderr)
-    [ "${actual}" = "100m" ]
-   actual=$(echo "$job" | yq '.requests.memory' | tee /dev/stderr)
-    [ "${actual}" = "100Mi" ]
-   actual=$(echo "$job" | yq '.limits.cpu' | tee /dev/stderr)
     [ "${actual}" = "200m" ]
+   actual=$(echo "$job" | yq '.requests.memory' | tee /dev/stderr)
+    [ "${actual}" = "256Mi" ]
+   actual=$(echo "$job" | yq '.limits.cpu' | tee /dev/stderr)
+    [ "${actual}" = "400m" ]
    actual=$(echo "$job" | yq '.limits.memory' | tee /dev/stderr)
-    [ "${actual}" = "200Mi" ]
+    [ "${actual}" = "400Mi" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/helpers.bats
+++ b/test/unit/helpers.bats
@@ -65,13 +65,10 @@ load _helpers
 #--------------------------------------------------------------------
 # component label
 #
-# This test ensures that we set "component" labels in every file.
-# If this test fails, you're likely missing setting that label somewhere.
-#
-
-@test "helper/app.kubernetes.io/component label: used everywhere" {
+@test "helper/app.kubernetes.io/component label: included in all resources" {
   cd `chart_dir`
-  # Grep for files that don't have 'component: ' in them
-  local actual=$(grep -L 'app.kubernetes.io/component: ' templates/*.yaml | tee /dev/stderr )
-  [ "${actual}" = '' ]
+  local actual=$(helm template . |  \
+   yq '({"match": .metadata.labels | has("app.kubernetes.io/component"), "doc": document_index, "name": .metadata.name, "kind": .kind, "apiVersion": .apiVersion})' \
+     | tee /dev/stderr | grep -c 'match: false')
+  [ "${actual}" = '0' ]
 }

--- a/test/unit/hook-upgrade-crds.bats
+++ b/test/unit/hook-upgrade-crds.bats
@@ -125,8 +125,6 @@ load _helpers
     [ "$(echo "${job}" | \
       yq '(.spec.template.spec.containers | length) == "1"')" = "true" ]
     [ "$(echo "${job}" | \
-      yq '(.spec.template.spec.containers | length) == "1"')" = "true" ]
-    [ "$(echo "${job}" | \
       yq '.spec.template.spec.containers[0].command[0] == "/scripts/upgrade-crds"')" = "true" ]
     [ "$(echo "${job}" | \
       yq '(.spec.template.spec.containers[0].resources | length) == 2')" = "true" ]
@@ -149,8 +147,6 @@ load _helpers
     [ "$(echo "${job}" | yq '.kind == "Job"')" = "true" ]
     [ "$(echo "${job}" | \
       yq '.spec.backoffLimit == 5')" = "true" ]
-    [ "$(echo "${job}" | \
-      yq '(.spec.template.spec.containers | length) == "1"')" = "true" ]
     [ "$(echo "${job}" | \
       yq '(.spec.template.spec.containers | length) == "1"')" = "true" ]
     [ "$(echo "${job}" | \
@@ -182,8 +178,6 @@ load _helpers
     [ "$(echo "${job}" | \
       yq '.spec.backoffLimit == 10')" = "true" ]
     [ "$(echo "${job}" | yq '.kind == "Job"')" = "true" ]
-    [ "$(echo "${job}" | \
-      yq '(.spec.template.spec.containers | length) == "1"')" = "true" ]
     [ "$(echo "${job}" | \
       yq '(.spec.template.spec.containers | length) == "1"')" = "true" ]
     [ "$(echo "${job}" | \

--- a/test/unit/hook-upgrade-crds.bats
+++ b/test/unit/hook-upgrade-crds.bats
@@ -1,0 +1,207 @@
+#!/usr/bin/env bats
+
+#
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+#
+
+load _helpers
+
+#--------------------------------------------------------------------
+@test "hookUpgradeCRDs: disabled" {
+    cd "$(chart_dir)"
+    local actual
+    actual=$(helm template \
+        -s templates/hook-upgrade-crds.yaml \
+        --set hooks.upgradeCRDs.enabled=false \
+        . | tee /dev/stderr |
+    yq '. | length' | tee /dev/stderr)
+    [ "${actual}" = "0" ]
+}
+
+@test "hookUpgradeCRDs: enabled by default" {
+    pushd "$(chart_dir)" > /dev/stderr
+    local object
+    object=$(helm template \
+        -s templates/hook-upgrade-crds.yaml \
+        . | tee /dev/stderr)
+
+    # assert that we have 4 documents using an base 0 index
+    [ "$(echo "${object}" | yq '. | di' | tee /dev/stderr | tail -n1)" = "3" ]
+
+    local sa
+    sa="$(echo "${object}" | yq 'select(di == 0)' | tee /dev/stderr)"
+    [ "$(echo "${sa}" | \
+      yq '.kind == "ServiceAccount"')" = "true" ]
+    [ "$(echo "${sa}" | \
+      yq '.metadata.annotations | length')" = "3" ]
+    [ "$(echo "${sa}" | \
+      yq '.metadata.annotations."helm.sh/hook" == "pre-upgrade"')" = "true" ]
+    [ "$(echo "${sa}" | \
+      yq '.metadata.annotations."helm.sh/hook-delete-policy" == "hook-succeeded,before-hook-creation"')" = "true" ]
+    [ "$(echo "${sa}" | \
+      yq '.metadata.annotations."helm.sh/hook-weight" == "1"')" = "true" ]
+
+    local cr
+    cr="$(echo "${object}" | yq 'select(di == 1)' | tee /dev/stderr)"
+    [ "$(echo "${cr}" | yq '.kind == "ClusterRole"')" = "true" ]
+    [ "$(echo "${cr}" | \
+      yq '.metadata.annotations | length')" = "3" ]
+    [ "$(echo "${cr}" | \
+      yq '.metadata.annotations."helm.sh/hook" == "pre-upgrade"')" = "true" ]
+    [ "$(echo "${cr}" | \
+      yq '.metadata.annotations."helm.sh/hook-delete-policy" == "hook-succeeded,before-hook-creation"')" = "true" ]
+    [ "$(echo "${cr}" | \
+      yq '.metadata.annotations."helm.sh/hook-weight" == "2"')" = "true" ]
+
+    local crb
+    crb="$(echo "${object}" | yq 'select(di == 2)' | tee /dev/stderr)"
+    [ "$(echo "${crb}" | yq '.kind == "ClusterRoleBinding"')" = "true" ]
+    [ "$(echo "${crb}" | \
+      yq '.metadata.annotations | length')" = "3" ]
+    [ "$(echo "${crb}"  | \
+      yq '.metadata.annotations."helm.sh/hook" == "pre-upgrade"')" = "true" ]
+    [ "$(echo "${crb}"  | \
+      yq '.metadata.annotations."helm.sh/hook-delete-policy" == "hook-succeeded,before-hook-creation"')" = "true" ]
+    [ "$(echo "${crb}"  | \
+      yq '.metadata.annotations."helm.sh/hook-weight" == "2"')" = "true" ]
+
+    local job
+    job="$(echo "${object}" | yq 'select(di == 3)' | tee /dev/stderr)"
+    [ "$(echo "${job}" | yq '.kind == "Job"')" = "true" ]
+    [ "$(echo "${job}"  | \
+      yq '.metadata.annotations | length')" = "3" ]
+    [ "$(echo "${job}"  | \
+      yq '.metadata.annotations."helm.sh/hook" == "pre-upgrade"')" = "true" ]
+    [ "$(echo "${job}"  | \
+      yq '.metadata.annotations."helm.sh/hook-delete-policy" == "hook-succeeded,before-hook-creation"')" = "true" ]
+    [ "$(echo "${job}"  | \
+      yq '.metadata.annotations."helm.sh/hook-weight" == "99"')" = "true" ]
+}
+
+
+@test "hookUpgradeCRDs: ClusterRole extended" {
+    pushd "$(chart_dir)" > /dev/stderr
+    local object
+    object=$(helm template \
+        -s templates/hook-upgrade-crds.yaml \
+        . )
+
+    # assert that we have 4 documents using an base 0 index
+    [ "$(echo "${object}" | yq '. | di' | tee /dev/stderr | tail -n1)" = "3" ]
+
+    local cr
+    cr="$(echo "${object}" | yq 'select(di == 1)')"
+    [ "$(echo "${cr}" | yq '.kind == "ClusterRole"')" = "true" ]
+    [ "$(echo "${cr}" | yq '(.rules | length) == 1')" = "true" ]
+    [ "$(echo "${cr}" | yq '(.rules[0] | length) == 3')" = "true" ]
+    [ "$(echo "${cr}" | yq '.rules[0].apiGroups[0] == "apiextensions.k8s.io"')" = "true" ]
+    [ "$(echo "${cr}" | yq '(.rules[0].resources | length) == 1')" = "true" ]
+    [ "$(echo "${cr}" | yq '.rules[0].resources[0] == "customresourcedefinitions"')" = "true" ]
+    [ "$(echo "${cr}" | yq '(.rules[0].verbs | length) == 6')" = "true" ]
+    [ "$(echo "${cr}" | yq '.rules[0].verbs[0] == "create"')" = "true" ]
+    [ "$(echo "${cr}" | yq '.rules[0].verbs[1] == "delete"')" = "true" ]
+    [ "$(echo "${cr}" | yq '.rules[0].verbs[2] == "get"')" = "true" ]
+    [ "$(echo "${cr}" | yq '.rules[0].verbs[3] == "list"')" = "true" ]
+    [ "$(echo "${cr}" | yq '.rules[0].verbs[4] == "patch"')" = "true" ]
+    [ "$(echo "${cr}" | yq '.rules[0].verbs[5] == "update"')" = "true" ]
+}
+
+@test "hookUpgradeCRDs: Job extended" {
+    pushd "$(chart_dir)" > /dev/stderr
+    local object
+    object=$(helm template \
+        -s templates/hook-upgrade-crds.yaml \
+        . )
+
+    # assert that we have 4 documents using an base 0 index
+    [ "$(echo "${object}" | yq '. | di' | tee /dev/stderr | tail -n1)" = "3" ]
+
+    local job
+    job="$(echo "${object}" | yq 'select(di == 3)' | tee /dev/stderr)"
+    [ "$(echo "${job}" | yq '.kind == "Job"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '.spec.backoffLimit == 5')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '(.spec.template.spec.containers | length) == "1"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '(.spec.template.spec.containers | length) == "1"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '.spec.template.spec.containers[0].command[0] == "/scripts/upgrade-crds"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '(.spec.template.spec.containers[0].resources | length) == 2')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '(.spec.template.spec.containers[0].env | length == 1)')" = "true" ]
+}
+
+@test "hookUpgradeCRDs: Job extended with defaults" {
+    pushd "$(chart_dir)" > /dev/stderr
+    local object
+    object=$(helm template \
+        -s templates/hook-upgrade-crds.yaml \
+        . )
+
+    # assert that we have 4 documents using an base 0 index
+    [ "$(echo "${object}" | yq '. | di' | tee /dev/stderr | tail -n1)" = "3" ]
+
+    local job
+    job="$(echo "${object}" | yq 'select(di == 3)' | tee /dev/stderr)"
+    [ "$(echo "${job}" | yq '.kind == "Job"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '.spec.backoffLimit == 5')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '(.spec.template.spec.containers | length) == "1"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '(.spec.template.spec.containers | length) == "1"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '.spec.template.spec.containers[0].command[0] == "/scripts/upgrade-crds"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '(.spec.template.spec.containers[0].resources | length) == 2')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '(.spec.template.spec.containers[0].env | length == 1)')" = "true" ]
+}
+
+@test "hookUpgradeCRDs: Job extended with custom values" {
+    pushd "$(chart_dir)" > /dev/stderr
+    local object
+    object=$(helm template \
+        -s templates/hook-upgrade-crds.yaml \
+        --set hooks.upgradeCRDs.backoffLimit=10 \
+        --set hooks.upgradeCRDs.executionTimeout='64s' \
+        --set hooks.resources.limits.cpu='501m' \
+        --set hooks.resources.limits.memory='129Mi' \
+        --set hooks.resources.requests.cpu='11m' \
+        --set hooks.resources.requests.memory='65Mi' \
+        . )
+
+    # assert that we have 4 documents using an base 0 index
+    [ "$(echo "${object}" | yq '. | di' | tee /dev/stderr | tail -n1)" = "3" ]
+
+    local job
+    job="$(echo "${object}" | yq 'select(di == 3)' | tee /dev/stderr)"
+    [ "$(echo "${job}" | \
+      yq '.spec.backoffLimit == 10')" = "true" ]
+    [ "$(echo "${job}" | yq '.kind == "Job"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '(.spec.template.spec.containers | length) == "1"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '(.spec.template.spec.containers | length) == "1"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '.spec.template.spec.containers[0].command[0] == "/scripts/upgrade-crds"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '(.spec.template.spec.containers[0].resources | length) == 2')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '.spec.template.spec.containers[0].resources.limits.cpu == "501m"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '.spec.template.spec.containers[0].resources.limits.memory == "129Mi"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '.spec.template.spec.containers[0].resources.requests.cpu == "11m"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '.spec.template.spec.containers[0].resources.requests.memory == "65Mi"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '(.spec.template.spec.containers[0].env | length == 1)')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '.spec.template.spec.containers[0].env[0].name == "VSO_UPGRADE_CRDS_TIMEOUT"')" = "true" ]
+    [ "$(echo "${job}" | \
+      yq '.spec.template.spec.containers[0].env[0].value == "64s"')" = "true" ]
+}


### PR DESCRIPTION
Introduces a pre-upgrade hook that will upgrade/create any of the CRD manifests that are bundled in the vso docker image.

Other fixes:
- make the component label test more reliable by checking all documents individually.
- configure a backoff in the pre-delete "pdcc" Job.


Overview of the approach:

- Extend VSO to support upgrading the CRDs directly
- Include the CRD manifests in the VSO image
- Extend the Helm chart to deploy a pre-upgrade hook that invokes the upgrade process

Out of scope:
- support for rollback/downgrades.
- removal of obsolete CRDs

Update to the Helm values:
```yaml
# Configure the behaviour of Helm hooks.
hooks:
  # Resources common to all hooks.
  resources:
    limits:
      cpu: 500m
      memory: 128Mi
    requests:
      cpu: 10m
      memory: 64Mi
  # Configure the Helm pre-upgrade hook that handles custom resource definition (CRD) upgrades.
  upgradeCRDs:
    # Set to true to automatically upgrade the CRDs.
    # Disabling this will require manual intervention to upgrade the CRDs, so it is recommended to
    # always leave it enabled.
    # @type: boolean
    enabled: true

    # Limit the number of retries for the CRD upgrade.
    # @type: integer
    backoffLimit:  5

    # Set the timeout for the CRD upgrade. The operation should typically take less than 5s
    # to complete.
    # @type: string
    executionTimeout: 30s
```