### PR TITLE
Helm: fix invalid value name for telemetry.serviceMonitor.enabled (#786)

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -721,7 +721,7 @@ telemetry:
 
     # Enable deployment of the Vault Secrets Operator ServiceMonitor CustomResource.
     # @type: boolean
-    nabled: false
+    enabled: false
 
     # Selector labels to add to the ServiceMonitor.
     # When empty, defaults to:


### PR DESCRIPTION
Corrects an issue introduced in #778 

Backport of #786

git cherry-pick 21b17f6d911d84dfda76fa8117bf34b05d04fe77