### PR TITLE
CI: add done job for branch protection status checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -405,3 +405,23 @@ jobs:
           hcp-client-secret: ${{ secrets.HCP_CLIENT_SECRET }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           log-prefix: "latest-k8s-"
+
+  # This job is used as a requirement for the repo's branch protection setup.
+  build-done:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - build
+      - build-docker
+      - build-docker-ubi
+      - build-docker-ubi-redhat
+      - chart-upgrade-tests
+      - latest-vault
+      - latest-k8s
+    steps:
+    - name: passed
+      if: ${{ !(contains(needs.*.result, 'failure')) }}
+      run: exit 0
+    - name: failed
+      if: ${{ contains(needs.*.result, 'failure') }}
+      run: exit 1


### PR DESCRIPTION
Adds a job to denote the success/failure of the build workflow. Once this update is in we can make it a required check under the branch protections for `main`