### PR TITLE
CI: let unit-tests run in parallel to the build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -113,7 +113,6 @@ jobs:
     needs:
       - get-product-version
       - build-pre-checks
-      - unit-tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -416,6 +415,7 @@ jobs:
       - build-docker-ubi
       - build-docker-ubi-redhat
       - chart-upgrade-tests
+      - unit-tests
       - latest-vault
       - latest-k8s
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,6 +45,10 @@ jobs:
         run: |
           go mod tidy
           test -z "$(git status --porcelain)"
+      - name: go mod download
+        run: |
+          go mod download
+          test -z "$(git status --porcelain)"
       - name: go fmt
         run: |
           make check-fmt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -410,6 +410,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           log-prefix: "latest-k8s-"
 
+  # This job is used as a requirement for the repo's branch protection setup.
   build-done:
     runs-on: ubuntu-latest
     if: always()
@@ -423,19 +424,9 @@ jobs:
       - latest-vault
       - latest-k8s
     steps:
-    - name: failed
-      if: ${{ contains(needs.*.result, 'failure') }}
-      run: exit 1
     - name: passed
       if: ${{ !(contains(needs.*.result, 'failure')) }}
       run: exit 0
-
-  # This job is used as a requirement for the repo's branch protection setup.
-  build-not-cancelled:
-    runs-on: ubuntu-latest
-    if: cancelled()
-    needs:
-      - build-done
-    steps:
-      - name: cancelled
-        run: exit 1
+    - name: failed
+      if: ${{ contains(needs.*.result, 'failure') }}
+      run: exit 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,10 +45,6 @@ jobs:
         run: |
           go mod tidy
           test -z "$(git status --porcelain)"
-      - name: go mod download
-        run: |
-          go mod download
-          test -z "$(git status --porcelain)"
       - name: go fmt
         run: |
           make check-fmt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -410,7 +410,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           log-prefix: "latest-k8s-"
 
-  # This job is used as a requirement for the repo's branch protection setup.
   build-done:
     runs-on: ubuntu-latest
     if: always()
@@ -424,9 +423,19 @@ jobs:
       - latest-vault
       - latest-k8s
     steps:
-    - name: passed
-      if: ${{ !(contains(needs.*.result, 'failure')) }}
-      run: exit 0
     - name: failed
       if: ${{ contains(needs.*.result, 'failure') }}
       run: exit 1
+    - name: passed
+      if: ${{ !(contains(needs.*.result, 'failure')) }}
+      run: exit 0
+
+  # This job is used as a requirement for the repo's branch protection setup.
+  build-not-cancelled:
+    runs-on: ubuntu-latest
+    if: cancelled()
+    needs:
+      - build-done
+    steps:
+      - name: cancelled
+        run: exit 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -424,6 +424,9 @@ jobs:
       - latest-vault
       - latest-k8s
     steps:
+    - name: cancelled
+      if: ${{ (contains(needs.*.result, 'cancelled')) }}
+      run: exit 2
     - name: passed
       if: ${{ !(contains(needs.*.result, 'failure')) }}
       run: exit 0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,6 +41,11 @@ jobs:
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: .go-version
+      - name: go mod download all
+        run: |
+          # download all dependencies to warm up the module cache
+          # make sure to run go mod tidy after this since the go.sum file will be updated
+          go mod download all
       - name: go mod tidy
         run: |
           go mod tidy


### PR DESCRIPTION
Since the build-done job determines pass/fail, we can update the build dependency to no longer require unit-tests. That allows us to get the results of the both integration unit tests independently. It also reduces the total workflow execution time by ~2m

Other fixes:
- fail build-done job on workflow cancellation.