### PR TITLE
Core: delete resource status metrics upon object deletion

### DIFF
--- a/controllers/hcpauth_controller.go
+++ b/controllers/hcpauth_controller.go
@@ -48,6 +48,12 @@ func (r *HCPAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	if o.GetDeletionTimestamp() != nil {
+		logger.Info("Got deletion timestamp", "obj", o)
+		metrics.DeleteResourceStatus("hcpauth", o)
+		return ctrl.Result{}, nil
+	}
+
 	// perform a rudimentary health check on the HCP host on port 443.
 	conn, err := net.DialTimeout("tcp",
 		fmt.Sprintf("%s:443", hvsclient.DefaultHost), time.Second*5)

--- a/controllers/secrettransformation_controller.go
+++ b/controllers/secrettransformation_controller.go
@@ -53,6 +53,12 @@ func (r *SecretTransformationReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{}, err
 	}
 
+	if o.GetDeletionTimestamp() != nil {
+		logger.Info("Got deletion timestamp", "obj", o)
+		metrics.DeleteResourceStatus("secrettransformation", o)
+		return ctrl.Result{}, nil
+	}
+
 	o.Status.Valid = true
 	o.Status.Error = ""
 	errs := ValidateSecretTransformation(ctx, o)

--- a/controllers/vaultauth_controller.go
+++ b/controllers/vaultauth_controller.go
@@ -69,6 +69,7 @@ func (r *VaultAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if o.GetDeletionTimestamp() != nil {
 		logger.Info("Got deletion timestamp", "obj", o)
 		r.referenceCache.Remove(VaultAuthGlobal, req.NamespacedName)
+		metrics.DeleteResourceStatus("vaultauth", o)
 		return r.handleFinalizer(ctx, o)
 	}
 

--- a/controllers/vaultconnection_controller.go
+++ b/controllers/vaultconnection_controller.go
@@ -61,6 +61,7 @@ func (r *VaultConnectionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if o.GetDeletionTimestamp() != nil {
 		logger.Info("Got deletion timestamp", "obj", o)
+		metrics.DeleteResourceStatus("vaultconnection", o)
 		return r.handleFinalizer(ctx, o)
 	}
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -67,6 +67,12 @@ func SetResourceStatus(controller string, o client.Object, valid bool) {
 	}
 }
 
+// DeleteResourceStatus deletes the client.Object from the set of resources
+// status metrics for the given controller.
+func DeleteResourceStatus(controller string, o client.Object) {
+	ResourceStatus.DeleteLabelValues(controller, o.GetName(), o.GetNamespace())
+}
+
 // NewBuildInfoGauge provides the Operator's build info as a Prometheus metric.
 func NewBuildInfoGauge(info apimachineryversion.Info) prometheus.Gauge {
 	metric := prometheus.NewGauge(


### PR DESCRIPTION
Previously, VSO would orphan the `controller_resource_status` metric for CRs that have been deleted from the cluster. The fix is to delete the metric for the corresponding controller, namespace, and object name.