### PR TITLE
add support for default user-facing ClusterRoles

### DIFF
--- a/chart/templates/clusterrole-aggregated-editor.yaml
+++ b/chart/templates/clusterrole-aggregated-editor.yaml
@@ -10,6 +10,7 @@ metadata:
   name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "aggregate-role-editor" }}
   labels:
     app.kubernetes.io/component: rbac
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
     vso.hashicorp.com/role-instance: aggregate-role-editor
 {{- include "vso.chart.labels" . | nindent 4 }}
 aggregationRule:

--- a/chart/templates/clusterrole-aggregated-viewer.yaml
+++ b/chart/templates/clusterrole-aggregated-viewer.yaml
@@ -10,6 +10,7 @@ metadata:
   name: {{ printf "%s-%s" (include "vso.chart.fullname" .) "aggregate-role-viewer" }}
   labels:
     app.kubernetes.io/component: rbac
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     vso.hashicorp.com/role-instance: aggregate-role-viewer
 {{- include "vso.chart.labels" . | nindent 4 }}
 aggregationRule:


### PR DESCRIPTION
The aggregated ClusterRoles implemented in #752 are missing the [default user-facing ClusterRoles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) labels. Without using them additional RoleBindings must be created to enable namespace editors to manage their resources like `VaultAuth` or `VaultStaticSecret`.