### PR TITLE
Drop the tainted client gauge.

### DIFF
--- a/internal/vault/client_factory.go
+++ b/internal/vault/client_factory.go
@@ -122,7 +122,6 @@ type cachingClientFactory struct {
 	logger                 logr.Logger
 	requestCounterVec      *prometheus.CounterVec
 	requestErrorCounterVec *prometheus.CounterVec
-	taintedClientGauge     *prometheus.GaugeVec
 	revokeOnEvict          bool
 	pruneStorageOnEvict    bool
 	ctrlClient             ctrlclient.Client
@@ -356,21 +355,11 @@ func (m *cachingClientFactory) Get(ctx context.Context, client ctrlclient.Client
 	var err error
 	var cacheKey ClientCacheKey
 	var errs error
-	var tainted bool
 	defer func() {
 		m.incrementRequestCounter(metrics.OperationGet, errs)
 		clientFactoryOperationTimes.WithLabelValues(subsystemClientFactory, metrics.OperationGet).Observe(
 			time.Since(startTS).Seconds(),
 		)
-
-		mt := m.taintedClientGauge.WithLabelValues(
-			metrics.OperationGet, cacheKey.String(),
-		)
-		if tainted {
-			mt.Set(1)
-		} else {
-			mt.Set(0)
-		}
 	}()
 
 	cacheKey, err = ComputeClientCacheKeyFromObj(ctx, client, obj)
@@ -434,7 +423,7 @@ func (m *cachingClientFactory) Get(ctx context.Context, client ctrlclient.Client
 	c, ok := m.cache.Get(cacheKey)
 	if ok {
 		// return the Client from the cache if it is still Valid
-		tainted = c.Tainted()
+		tainted := c.Tainted()
 		logger.V(consts.LogLevelTrace).Info("Got client from cache",
 			"clientID", c.ID(), "tainted", tainted)
 		if err := c.Validate(ctx); err != nil {
@@ -825,15 +814,6 @@ func NewCachingClientFactory(ctx context.Context, client ctrlclient.Client, cach
 				metrics.LabelOperation,
 			},
 		),
-		taintedClientGauge: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: metricsFQNClientFactoryTaintedClients,
-				Help: "Client factory tainted clients",
-			}, []string{
-				metrics.LabelOperation,
-				metrics.LabelCacheKey,
-			},
-		),
 	}
 
 	if config.CollectClientCacheMetrics {
@@ -845,7 +825,6 @@ func NewCachingClientFactory(ctx context.Context, client ctrlclient.Client, cach
 		config.MetricsRegistry.MustRegister(
 			factory.requestCounterVec,
 			factory.requestErrorCounterVec,
-			factory.taintedClientGauge,
 			clientFactoryOperationTimes,
 		)
 	}

--- a/internal/vault/client_factory_metrics.go
+++ b/internal/vault/client_factory_metrics.go
@@ -22,9 +22,6 @@ var (
 	metricsFQNClientFactoryOpsTimeSeconds = prometheus.BuildFQName(
 		metrics.Namespace, subsystemClientFactory, metrics.NameOperationsTimeSeconds)
 
-	metricsFQNClientFactoryTaintedClients = prometheus.BuildFQName(
-		metrics.Namespace, subsystemClientFactory, metrics.NameTaintedClients)
-
 	// TODO: update to use Native Histograms once it is no longer an experimental Prometheus feature
 	// ref: https://github.com/prometheus/prometheus/milestone/10
 	clientFactoryOperationTimes = prometheus.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
In hindsight this metric doesn't make sense at this point. It also introduces another high cardinality metric that users probably don't want to have to manage. This metric is better implemented as a collector on the client cache itself, setting the total number of tainted clients would be more meaningful.