### PR TITLE
Helm: add support for configuring user-facing roles

### DIFF
--- a/chart/templates/clusterrole-aggregated-editor.yaml
+++ b/chart/templates/clusterrole-aggregated-editor.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     vso.hashicorp.com/role-instance: aggregate-role-editor
+    {{- if .Values.controller.rbac.clusterRoleAggregation.userFacingRoles.edit }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    {{- end -}}
 {{- include "vso.chart.labels" . | nindent 4 }}
 aggregationRule:
   clusterRoleSelectors:

--- a/chart/templates/clusterrole-aggregated-viewer.yaml
+++ b/chart/templates/clusterrole-aggregated-viewer.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     vso.hashicorp.com/role-instance: aggregate-role-viewer
+    {{- if .Values.controller.rbac.clusterRoleAggregation.userFacingRoles.view }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    {{- end -}}
 {{- include "vso.chart.labels" . | nindent 4 }}
 aggregationRule:
   clusterRoleSelectors:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -101,6 +101,19 @@ controller:
       # @type: array<string>
       editorRoles: []
 
+      # userFacingRoles is a map of roles that will be aggregated into the viewer and editor ClusterRoles.
+      # See https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles for more information.
+      # @type: object
+      userFacingRoles:
+        # view controls whether the aggregated viewer ClusterRole will be made available to the user-facing
+        # 'view' ClusterRole. Requires the viewerRoles to be set.
+        # @type: boolean
+        view: false
+        # view controls whether the aggregated editor ClusterRole will be made available to the user-facing
+        # 'edit' ClusterRole. Requires the editorRoles to be set.
+        # @type: boolean
+        edit: false
+
   # Settings related to the kubeRbacProxy container. This container is an HTTP proxy for the
   # controller manager which performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
   kubeRbacProxy:


### PR DESCRIPTION
Extends the `clusterRoleAggregation` configuration to support enabling user-facing ClusterRoles

See https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles for more information.

E.g:

```
controller
  rbac:
    clusterRoleAggregation:
      [...]
      userFacingRoles:
        # view controls whether the aggregated viewer ClusterRole will be made available to the user-facing
        # 'view' ClusterRole.
        view: false
        # view controls whether the aggregated viewer ClusterRole will be made available to the user-facing
        # 'edit' ClusterRole.
        edit: false
```