### PR TITLE
VDS: properly handle the clone cache key variant during client callback execution

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -114,7 +114,7 @@ runs:
           make_target+='-ent'
           export VAULT_IMAGE_TAG='${{ inputs.vault-version }}-ent'
         fi
-        make $make_target VERSION=${{ inputs.version }} INTEGRATION_TESTS_PARALLEL=true SUPPRESS_TF_OUTPUT= EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
+        make $make_target VERSION=${{ inputs.version }} INTEGRATION_TESTS_PARALLEL=true SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
     - name: Store kind cluster logs
       if: success()
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -114,7 +114,7 @@ runs:
           make_target+='-ent'
           export VAULT_IMAGE_TAG='${{ inputs.vault-version }}-ent'
         fi
-        make $make_target VERSION=${{ inputs.version }} INTEGRATION_TESTS_PARALLEL=true SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
+        make $make_target VERSION=${{ inputs.version }} INTEGRATION_TESTS_PARALLEL=true SUPPRESS_TF_OUTPUT= EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
     - name: Store kind cluster logs
       if: success()
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -73,20 +73,20 @@ type VaultDynamicSecretReconciler struct {
 	runtimePodUID types.UID
 }
 
-//+kubebuilder:rbac:groups=secrets.hashicorp.com,resources=vaultdynamicsecrets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=secrets.hashicorp.com,resources=vaultdynamicsecrets/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=secrets.hashicorp.com,resources=vaultdynamicsecrets/finalizers,verbs=update
-//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=secrets.hashicorp.com,resources=vaultdynamicsecrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=secrets.hashicorp.com,resources=vaultdynamicsecrets/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=secrets.hashicorp.com,resources=vaultdynamicsecrets/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
 //
 // required for rollout-restart
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch
-//+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;patch
-//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;patch
-//+kubebuilder:rbac:groups=argoproj.io,resources=rollouts,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=argoproj.io,resources=rollouts,verbs=get;list;watch;patch
 //
 // needed for managing cached Clients, duplicated in vaultconnection_controller.go
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;delete;update;patch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;delete;update;patch
 
 // Reconcile ensures that the VaultDynamicSecret Custom Resource is synced from Vault to its
 // configured Kubernetes secret. The resource will periodically be reconciled to renew the
@@ -790,7 +790,14 @@ func (r *VaultDynamicSecretReconciler) vaultClientCallback(ctx context.Context, 
 
 	reqs := map[client.ObjectKey]empty{}
 	for _, o := range l.Items {
-		if o.Status.VaultClientMeta.CacheKey == cacheKey.String() {
+		if o.Status.VaultClientMeta.CacheKey == "" {
+			logger.V(consts.LogLevelWarning).Info("Skipping, cacheKey is empty",
+				client.ObjectKeyFromObject(&o))
+			continue
+		}
+
+		curCacheKey := vault.ClientCacheKey(o.Status.VaultClientMeta.CacheKey)
+		if ok, err := curCacheKey.SameParent(cacheKey); ok {
 			evt := event.GenericEvent{
 				Object: &secretsv1beta1.VaultDynamicSecret{
 					ObjectMeta: metav1.ObjectMeta{
@@ -811,6 +818,9 @@ func (r *VaultDynamicSecretReconciler) vaultClientCallback(ctx context.Context, 
 					"Sending GenericEvent to the SourceCh", "evt", evt)
 				r.SourceCh <- evt
 			}
+		} else if err != nil {
+			logger.V(consts.LogLevelWarning).Info(
+				"Skipping, cacheKey error", "error", err)
 		}
 	}
 }

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -792,7 +792,7 @@ func (r *VaultDynamicSecretReconciler) vaultClientCallback(ctx context.Context, 
 	for _, o := range l.Items {
 		if o.Status.VaultClientMeta.CacheKey == "" {
 			logger.V(consts.LogLevelWarning).Info("Skipping, cacheKey is empty",
-				client.ObjectKeyFromObject(&o))
+				"object", client.ObjectKeyFromObject(&o))
 			continue
 		}
 

--- a/internal/vault/cache_key_test.go
+++ b/internal/vault/cache_key_test.go
@@ -18,10 +18,11 @@ import (
 )
 
 const (
-	authUID      = types.UID("c4fad6b9-e7bb-4ed8-bc38-67fd6dc85a35")
-	connUID      = types.UID("c4fad6b9-e7bb-4ed8-bc38-67fd6dc85a36")
-	providerUID  = types.UID("c4fad6b9-e7bb-4ed8-bc38-67fd6dc85a37")
-	computedHash = "2a8108711ae49ac0faa724"
+	authUID       = types.UID("c4fad6b9-e7bb-4ed8-bc38-67fd6dc85a35")
+	connUID       = types.UID("c4fad6b9-e7bb-4ed8-bc38-67fd6dc85a36")
+	providerUID   = types.UID("c4fad6b9-e7bb-4ed8-bc38-67fd6dc85a37")
+	computedHash  = "2a8108711ae49ac0faa724"
+	computedHash2 = "2a8108711ae49ac0faa725"
 )
 
 type computeClientCacheKeyTest struct {
@@ -334,6 +335,128 @@ func TestClientCacheKeyClone(t *testing.T) {
 				return
 			}
 			assert.Equalf(t, tt.want, got, "ClientCacheKeyClone(%v, %v)", tt.key, tt.namespace)
+		})
+	}
+}
+
+func TestClientCacheKey_SameParent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		key     ClientCacheKey
+		other   ClientCacheKey
+		want    bool
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "same-parent-equal",
+			key: ClientCacheKey(fmt.Sprintf("%s-%s",
+				consts.ProviderMethodKubernetes, computedHash),
+			),
+			other: ClientCacheKey(fmt.Sprintf("%s-%s",
+				consts.ProviderMethodKubernetes, computedHash),
+			),
+			want:    true,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "same-parent-clone",
+			key: ClientCacheKey(fmt.Sprintf("%s-%s-/ns1/ns2",
+				consts.ProviderMethodKubernetes, computedHash),
+			),
+			other: ClientCacheKey(fmt.Sprintf("%s-%s-/ns3/ns4",
+				consts.ProviderMethodKubernetes, computedHash),
+			),
+			want:    true,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "other-parent-clone",
+			key: ClientCacheKey(fmt.Sprintf("%s-%s-/ns1/ns2",
+				consts.ProviderMethodKubernetes, computedHash),
+			),
+			other: ClientCacheKey(fmt.Sprintf("%s-%s-/ns3/ns4",
+				consts.ProviderMethodKubernetes, computedHash2),
+			),
+			want:    false,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "invalid-self-hash",
+			key: ClientCacheKey(fmt.Sprintf("%s-%s",
+				consts.ProviderMethodKubernetes, computedHash[len(computedHash)-1:]),
+			),
+			other: ClientCacheKey(fmt.Sprintf("%s-%s",
+				consts.ProviderMethodKubernetes, computedHash),
+			),
+			want:    false,
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid-other-hash",
+			key: ClientCacheKey(fmt.Sprintf("%s-%s",
+				consts.ProviderMethodKubernetes, computedHash),
+			),
+			other: ClientCacheKey(fmt.Sprintf("%s-%s",
+				consts.ProviderMethodKubernetes, computedHash[len(computedHash)-1:]),
+			),
+			want:    false,
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid-other-method-clone",
+			key: ClientCacheKey(fmt.Sprintf("%s-%s-/ns1/ns2",
+				"invalid", computedHash),
+			),
+			other: ClientCacheKey(fmt.Sprintf("%s-%s-/ns3/ns4",
+				consts.ProviderMethodKubernetes, computedHash),
+			),
+			want:    false,
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid-other-method-clone",
+			key: ClientCacheKey(fmt.Sprintf("%s-%s-/ns1/ns2",
+				consts.ProviderMethodKubernetes, computedHash),
+			),
+			other: ClientCacheKey(fmt.Sprintf("%s-%s-/ns3/ns4",
+				"invalid", computedHash),
+			),
+			want:    false,
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid-self-hash-clone",
+			key: ClientCacheKey(fmt.Sprintf("%s-%s-/ns1/ns2",
+				consts.ProviderMethodKubernetes, computedHash[len(computedHash)-1:]),
+			),
+			other: ClientCacheKey(fmt.Sprintf("%s-%s-/ns3/ns4",
+				consts.ProviderMethodKubernetes, computedHash),
+			),
+			want:    false,
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid-other-hash-clone",
+			key: ClientCacheKey(fmt.Sprintf("%s-%s-/ns1/ns2",
+				consts.ProviderMethodKubernetes, computedHash),
+			),
+			other: ClientCacheKey(fmt.Sprintf("%s-%s-/ns3/ns4",
+				consts.ProviderMethodKubernetes, computedHash[len(computedHash)-1:]),
+			),
+			want:    false,
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.key.SameParent(tt.other)
+			if !tt.wantErr(t, err, fmt.Sprintf("SameParent(%v)", tt.other)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got,
+				"SameParent(%v)", tt.other)
 		})
 	}
 }

--- a/internal/vault/cache_key_test.go
+++ b/internal/vault/cache_key_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -347,7 +348,7 @@ func TestClientCacheKey_SameParent(t *testing.T) {
 		key     ClientCacheKey
 		other   ClientCacheKey
 		want    bool
-		wantErr assert.ErrorAssertionFunc
+		wantErr require.ErrorAssertionFunc
 	}{
 		{
 			name: "same-parent-equal",
@@ -358,7 +359,7 @@ func TestClientCacheKey_SameParent(t *testing.T) {
 				consts.ProviderMethodKubernetes, computedHash),
 			),
 			want:    true,
-			wantErr: assert.NoError,
+			wantErr: require.NoError,
 		},
 		{
 			name: "same-parent-clone",
@@ -369,7 +370,7 @@ func TestClientCacheKey_SameParent(t *testing.T) {
 				consts.ProviderMethodKubernetes, computedHash),
 			),
 			want:    true,
-			wantErr: assert.NoError,
+			wantErr: require.NoError,
 		},
 		{
 			name: "other-parent-clone",
@@ -380,7 +381,7 @@ func TestClientCacheKey_SameParent(t *testing.T) {
 				consts.ProviderMethodKubernetes, computedHash2),
 			),
 			want:    false,
-			wantErr: assert.NoError,
+			wantErr: require.NoError,
 		},
 		{
 			name: "invalid-self-hash",
@@ -391,7 +392,7 @@ func TestClientCacheKey_SameParent(t *testing.T) {
 				consts.ProviderMethodKubernetes, computedHash),
 			),
 			want:    false,
-			wantErr: assert.Error,
+			wantErr: require.Error,
 		},
 		{
 			name: "invalid-other-hash",
@@ -402,7 +403,7 @@ func TestClientCacheKey_SameParent(t *testing.T) {
 				consts.ProviderMethodKubernetes, computedHash[len(computedHash)-1:]),
 			),
 			want:    false,
-			wantErr: assert.Error,
+			wantErr: require.Error,
 		},
 		{
 			name: "invalid-other-method-clone",
@@ -413,7 +414,7 @@ func TestClientCacheKey_SameParent(t *testing.T) {
 				consts.ProviderMethodKubernetes, computedHash),
 			),
 			want:    false,
-			wantErr: assert.Error,
+			wantErr: require.Error,
 		},
 		{
 			name: "invalid-other-method-clone",
@@ -424,7 +425,7 @@ func TestClientCacheKey_SameParent(t *testing.T) {
 				"invalid", computedHash),
 			),
 			want:    false,
-			wantErr: assert.Error,
+			wantErr: require.Error,
 		},
 		{
 			name: "invalid-self-hash-clone",
@@ -435,7 +436,7 @@ func TestClientCacheKey_SameParent(t *testing.T) {
 				consts.ProviderMethodKubernetes, computedHash),
 			),
 			want:    false,
-			wantErr: assert.Error,
+			wantErr: require.Error,
 		},
 		{
 			name: "invalid-other-hash-clone",
@@ -446,15 +447,13 @@ func TestClientCacheKey_SameParent(t *testing.T) {
 				consts.ProviderMethodKubernetes, computedHash[len(computedHash)-1:]),
 			),
 			want:    false,
-			wantErr: assert.Error,
+			wantErr: require.Error,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.key.SameParent(tt.other)
-			if !tt.wantErr(t, err, fmt.Sprintf("SameParent(%v)", tt.other)) {
-				return
-			}
+			tt.wantErr(t, err, fmt.Sprintf("SameParent(%v)", tt.other))
 			assert.Equalf(t, tt.want, got,
 				"SameParent(%v)", tt.other)
 		})

--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -282,6 +282,10 @@ func (c *defaultClient) Clone(namespace string) (Client, error) {
 		return nil, errors.New("namespace cannot be empty")
 	}
 
+	if c.isClone {
+		return nil, errors.New("cannot clone a clone")
+	}
+
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -299,6 +303,7 @@ func (c *defaultClient) Clone(namespace string) (Client, error) {
 		skipRenewal:        true,
 		targetNamespace:    c.targetNamespace,
 		credentialProvider: c.credentialProvider,
+		id:                 c.id,
 	}
 	client.SetNamespace(namespace)
 

--- a/internal/vault/client_factory.go
+++ b/internal/vault/client_factory.go
@@ -712,15 +712,21 @@ func (m *cachingClientFactory) startClientCallbackHandler(ctx context.Context) {
 					continue
 				}
 
-				if req.Client.IsClone() {
-					continue
-				}
-
 				cacheKey, err := req.Client.GetCacheKey()
 				if err != nil {
 					logger.Error(err, "Invalid client, client callbacks not executed",
 						"cacheKey", cacheKey)
 					continue
+				}
+
+				if cacheKey.IsClone() {
+					parentCacheKey, err := cacheKey.Parent()
+					if err != nil {
+						logger.Error(err, "Invalid client clone, client callbacks not executed",
+							"cacheKey", cacheKey)
+						continue
+					}
+					cacheKey = parentCacheKey
 				}
 
 				// remove the client from the cache, it will be recreated when a reconciler

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -238,6 +238,8 @@ func TestMain(m *testing.M) {
 						"Failed to k8s.KubectlDeleteFromKustomizeE(t, k8sOpts, kustomizeConfigPath), err=%s", err)
 				}
 			}
+		} else {
+			t.Logf("Skipping cleanup main, tfdir=%s", tfDir)
 		}
 	}
 
@@ -749,9 +751,9 @@ func assertRolloutRestarts(
 		assert.True(t, restartAt.Before(timeNow),
 			"timestamp value %q for %q is in the future, now=%q", restartAt, expectedAnnotation, timeNow)
 
-		//if s.ReadyReplicas != *s.Replicas {
+		// if s.ReadyReplicas != *s.Replicas {
 		//	errs = errors.Join(errs, fmt.Errorf("expected ready replicas %d, actual %d", s.Replicas, s.ReadyReplicas))
-		//}
+		// }
 
 		/*
 				=== NAME  TestVaultPKISecret/mixed/mixed-existing-0

--- a/test/integration/vaultdynamicsecret/terraform/locals.tf
+++ b/test/integration/vaultdynamicsecret/terraform/locals.tf
@@ -11,8 +11,10 @@ locals {
 
   # auth locals
   auth_mount         = "${local.name_prefix}-auth-mount"
+  auth_mount_xns     = "${local.name_prefix}-auth-mount-xns"
   auth_policy        = "${local.name_prefix}-auth-policy"
   auth_role          = "auth-role"
+  auth_role_xns      = "auth-role-xns"
   auth_role_operator = "auth-role-operator"
 
   # db locals
@@ -23,6 +25,11 @@ locals {
   db_role_static_scheduled      = "${local.db_role_static}-scheduled"
   db_role_static_user_scheduled = "${local.db_role_static}-user-scheduled"
   k8s_secret_role               = "k8s-secret"
+
+  xns_sa_count          = var.vault_enterprise ? 10 : 0
+  with_xns              = var.vault_enterprise && var.with_xns
+  xns_namespace         = local.with_xns ? vault_namespace.xns[0].path_fq : null
+  xns_member_entity_ids = local.with_xns ? one(vault_identity_group.xns-parent[*]).member_entity_ids : []
 
   dev_token_policies = concat(
     [

--- a/test/integration/vaultdynamicsecret/terraform/main.tf
+++ b/test/integration/vaultdynamicsecret/terraform/main.tf
@@ -69,7 +69,6 @@ resource "vault_kubernetes_auth_backend_config" "dev" {
   kubernetes_host        = var.k8s_host
   disable_iss_validation = true
 }
-
 resource "vault_kubernetes_auth_backend_role" "dev" {
   namespace         = vault_auth_backend.default.namespace
   backend           = vault_kubernetes_auth_backend_config.dev.backend
@@ -80,7 +79,7 @@ resource "vault_kubernetes_auth_backend_role" "dev" {
     # used by some tests that create their own service accounts
     "sa-*",
     # used by xns tests
-    "xns-*"
+    "${local.name_prefix}-xns-sa-*"
   ]
   bound_service_account_namespaces = [kubernetes_namespace.dev.metadata[0].name]
   token_period                     = var.vault_token_period

--- a/test/integration/vaultdynamicsecret/terraform/main.tf
+++ b/test/integration/vaultdynamicsecret/terraform/main.tf
@@ -79,6 +79,8 @@ resource "vault_kubernetes_auth_backend_role" "dev" {
     "default",
     # used by some tests that create their own service accounts
     "sa-*",
+    # used by xns tests
+    "xns-*"
   ]
   bound_service_account_namespaces = [kubernetes_namespace.dev.metadata[0].name]
   token_period                     = var.vault_token_period

--- a/test/integration/vaultdynamicsecret/terraform/outputs.tf
+++ b/test/integration/vaultdynamicsecret/terraform/outputs.tf
@@ -61,3 +61,19 @@ output "default_lease_ttl_seconds" {
 output "non_renewable_k8s_token_ttl" {
   value = vault_kubernetes_secret_backend_role.k8s_secrets.token_default_ttl
 }
+
+output "xns_k8s_sas" {
+  value = concat(kubernetes_service_account.xns[*].metadata[0].name)
+}
+
+output "xns_vault_ns" {
+  value = local.xns_namespace
+}
+
+output "with_xns" {
+  value = local.with_xns
+}
+
+output "xns_member_entity_ids" {
+  value = local.xns_member_entity_ids
+}

--- a/test/integration/vaultdynamicsecret/terraform/variables.tf
+++ b/test/integration/vaultdynamicsecret/terraform/variables.tf
@@ -84,3 +84,10 @@ variable "with_static_role_scheduled" {
   type    = bool
   default = true
 }
+
+# vault_xns is a boolean that determines if the test should run with cross-namespace support
+# requires vault_enterprise to be true
+variable "with_xns" {
+  type    = bool
+  default = false
+}

--- a/test/integration/vaultdynamicsecret/terraform/xns.tf
+++ b/test/integration/vaultdynamicsecret/terraform/xns.tf
@@ -1,0 +1,109 @@
+# Setup for cross namespace auth testing
+
+# sets the group policy application to work with with cross Vault namespace auth
+resource "vault_generic_endpoint" "sys-group-policy-application" {
+  count = local.with_xns ? 1 : 0
+  data_json = jsonencode(
+    {
+      group_policy_application_mode = "any"
+    }
+  )
+  path           = "sys/config/group-policy-application"
+  disable_delete = true
+}
+
+# default service account from the tenant namespace
+resource "kubernetes_service_account" "xns" {
+  count = local.xns_sa_count
+  metadata {
+    namespace = kubernetes_namespace.dev.metadata[0].name
+    name      = "xns-sa-${count.index}"
+    labels = {
+      "x-ns" : local.with_xns
+    }
+  }
+}
+
+resource "vault_namespace" "xns" {
+  count = local.with_xns ? 1 : 0
+  path  = "${local.name_prefix}-xns"
+}
+
+# identity entity that maps to the service account name
+# provides cross Vault namespace when the k8s auth role's alias_name_source = "serviceaccount_name"
+resource "vault_identity_entity" "xns" {
+  count     = local.xns_sa_count
+  namespace = local.namespace
+  name      = "${kubernetes_service_account.xns[count.index].metadata[0].namespace}/${kubernetes_service_account.xns[count.index].metadata[0].name}"
+}
+
+# identity entity alias that maps to the service account name
+# provides cross Vault namespace when the k8s auth role's alias_name_source = "serviceaccount_name"
+resource "vault_identity_entity_alias" "xns" {
+  count          = local.xns_sa_count
+  namespace      = local.namespace
+  mount_accessor = vault_auth_backend.default.accessor
+  name           = vault_identity_entity.xns[count.index].name
+  canonical_id   = vault_identity_entity.xns[count.index].id
+}
+
+# parent identity group that holds all vso tenant entities
+resource "vault_identity_group" "xns-parent" {
+  count             = local.with_xns ? 1 : 0
+  namespace         = local.namespace
+  name              = "vso-tenants-parent"
+  type              = "internal"
+  member_entity_ids = concat(vault_identity_entity_alias.xns[*].canonical_id)
+}
+# identity group that provides cross namespace support when local.with_xns is true
+resource "vault_identity_group" "xns" {
+  count            = local.with_xns ? 1 : 0
+  namespace        = local.xns_namespace
+  name             = "vso-tenants"
+  member_group_ids = [vault_identity_group.xns-parent[0].id]
+  policies = [
+    vault_policy.xns[0].name,
+  ]
+  type = "internal"
+}
+
+resource "vault_database_secrets_mount" "xns" {
+  count                     = local.with_xns ? 1 : 0
+  namespace                 = local.xns_namespace
+  path                      = "${local.name_prefix}-db"
+  default_lease_ttl_seconds = var.vault_db_default_lease_ttl
+
+  postgresql {
+    name              = "postgres"
+    username          = "postgres"
+    password          = data.kubernetes_secret.postgres.data["postgres-password"]
+    connection_url    = "postgresql://{{username}}:{{password}}@${local.postgres_host}/postgres?sslmode=disable"
+    verify_connection = false
+    allowed_roles = [
+      local.db_role,
+    ]
+  }
+}
+
+resource "vault_database_secret_backend_role" "xns" {
+  count     = local.with_xns ? 1 : 0
+  namespace = local.xns_namespace
+  backend   = vault_database_secrets_mount.xns[0].path
+  name      = local.db_role
+  db_name   = vault_database_secrets_mount.xns[0].postgresql[0].name
+  creation_statements = [
+    "CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';",
+    "GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";",
+  ]
+}
+
+resource "vault_policy" "xns" {
+  count     = local.with_xns ? 1 : 0
+  namespace = local.xns_namespace
+  name      = "${local.auth_policy}-db"
+  policy    = <<EOT
+path "${vault_database_secrets_mount.xns[0].path}/creds/${vault_database_secret_backend_role.xns[0].name}" {
+  capabilities = ["read"]
+}
+EOT
+}

--- a/test/integration/vaultdynamicsecret/terraform/xns.tf
+++ b/test/integration/vaultdynamicsecret/terraform/xns.tf
@@ -17,7 +17,7 @@ resource "kubernetes_service_account" "xns" {
   count = local.xns_sa_count
   metadata {
     namespace = kubernetes_namespace.dev.metadata[0].name
-    name      = "xns-sa-${count.index}"
+    name      = "${local.name_prefix}-xns-sa-${count.index}"
     labels = {
       "x-ns" : local.with_xns
     }

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -856,7 +856,7 @@ func TestVaultDynamicSecret_vaultClientCallback(t *testing.T) {
 			}
 
 			if tt.xns && !outputs.WithXns {
-				t.Skipf("skipping xns test %s, test infrastructre not supported", tt.name)
+				t.Skipf("skipping xns test %s, test infrastructure not supported", tt.name)
 			}
 
 			var objsCreated []*secretsv1beta1.VaultDynamicSecret

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -854,6 +854,10 @@ func TestVaultDynamicSecret_vaultClientCallback(t *testing.T) {
 				t.Skipf("skipping xns test %s, test infrastructre not supported", tt.name)
 			}
 
+			if outputs.WithXns && !tt.xns {
+				t.Skipf("skipping non-xns test %s, debugging CI", tt.name)
+			}
+
 			var objsCreated []*secretsv1beta1.VaultDynamicSecret
 			t.Cleanup(func() {
 				if !skipCleanup {

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -679,7 +679,8 @@ func TestVaultDynamicSecret_vaultClientCallback(t *testing.T) {
 			// set a high default lease ttl to avoid renewals during the test
 			"vault_db_default_lease_ttl": 600,
 			"with_static_role_scheduled": withStaticRoleScheduled,
-			"with_xns":                   true,
+			// disabling until https://github.com/hashicorp/terraform-provider-vault/pull/2289 is released
+			"with_xns": false,
 		},
 	}
 	if entTests {
@@ -850,12 +851,12 @@ func TestVaultDynamicSecret_vaultClientCallback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.xns && !outputs.WithXns {
-				t.Skipf("skipping xns test %s, test infrastructre not supported", tt.name)
+			if tt.xns {
+				t.Skipf("skipping xns test %s, until https://github.com/hashicorp/terraform-provider-vault/pull/2289 is released", tt.name)
 			}
 
-			if outputs.WithXns && !tt.xns {
-				t.Skipf("skipping non-xns test %s, debugging CI", tt.name)
+			if tt.xns && !outputs.WithXns {
+				t.Skipf("skipping xns test %s, test infrastructre not supported", tt.name)
 			}
 
 			var objsCreated []*secretsv1beta1.VaultDynamicSecret


### PR DESCRIPTION
In the case where a VaultDynamicSecret instance specifies a Vault namespace that is different from its VaultAuth the ClientCacheKey will be of the clone variant. The cache key format is different from its parent cache key and therefore a parent and a clone cannot be compared. Since the VDS controller stores the clone variant in its state, all instances of this type were ignored during a client callback reconciliation. This would leave unreconciled VDS instances upon client token expiration or other LifetimeWatcher errors.

- [x] Extend the VDS integration tests to include a cross-namespace scenario. (disabled until https://github.com/hashicorp/terraform-provider-vault/pull/2289 is released)