### PR TITLE
VPS: add ca.crt from issuing CA for tls secret type

### DIFF
--- a/test/integration/vaultpkisecret/terraform/deployment.tf
+++ b/test/integration/vaultpkisecret/terraform/deployment.tf
@@ -41,8 +41,9 @@ resource "kubernetes_deployment" "vso" {
           }
         }
         container {
-          image = "nginx:latest"
-          name  = "example"
+          image             = "nginx:latest"
+          name              = "example"
+          image_pull_policy = "IfNotPresent"
 
           volume_mount {
             name       = "secrets"


### PR DESCRIPTION
This PR automatically includes the issuing CA from Vault in the K8s secret data when the secret's type is `kubernetes.io/tls`. It also modifies the rendering behaviour by omitting any key that does not have a corresponding field in the Vault PKI data.

Sample k8s secret data:
```
apiVersion: v1
data:
  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0[...]
  tls.crt: LS0tLS1CRUdJTiB[...]
  tls.key: LS0tLS1CRUdJTiB[...]
  [...]
kind: Secret
metadata:
  creationTimestamp: "2024-07-10T15:01:33Z"
  labels:
    app.kubernetes.io/component: secret-sync
    app.kubernetes.io/managed-by: hashicorp-vso
    app.kubernetes.io/name: vault-secrets-operator
    secrets.hashicorp.com/vso-ownerRefUID: 6a1d7956-7c5f-4f19-b5fe-2b2cf5114508
  name: create-tls-create-0
  namespace: vps-6f3gryr35xf21hpf-app
  ownerReferences:
  - apiVersion: secrets.hashicorp.com/v1beta1
    kind: VaultPKISecret
    name: create-tls-create-0
    uid: 6a1d7956-7c5f-4f19-b5fe-2b2cf5114508
  resourceVersion: "58680"
  uid: aeeec1c0-4f62-4102-b58f-09f854efb5f0
type: kubernetes.io/tls
```