### PR TITLE
Helm: support setting VaultAuthGlobalRef on VaultAuth

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -298,3 +298,39 @@ logging args
 {{- $ret | toYaml | nindent 8 -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+vaultAuthGlobalRef generates the global-vault-auth-global-ref flag for the manager.
+*/}}
+{{- define "vso.vaulAuthGlobalRef" -}}
+{{- if .Values.controller.manager.globalVaultAuthOptions.allowDefaultGlobals }}
+--global-vault-auth-global-ref
+{{- end -}}
+{{- end -}}
+
+{{/*
+vaultAuthGlobalRef generates the default VaultAuth spec.vaultAuthGlobalRef.
+*/}}
+{{- define "vso.vaultAuthGlobalRef" -}}
+{{- $ret := dict -}}
+{{- with .Values.defaultAuthMethod.vaultAuthGlobalRef -}}
+{{ $_ := set $ret "namespace" .namespace -}}
+{{ $_ = set $ret "name" .name -}}
+{{ if ne .allowDefault nil -}}
+{{- $_ = set $ret "allowDefault" .allowDefault -}}
+{{- end -}}
+{{- $strat := dict -}}
+{{- if .mergeStrategy.headers -}}
+{{- $_ = set $strat "headers" .mergeStrategy.headers -}}
+{{- end -}}
+{{- if .mergeStrategy.params -}}
+{{- $_ = set $strat "params" .mergeStrategy.params -}}
+{{- end -}}
+{{- if $strat -}}
+{{- $_ = set $ret "mergeStrategy" $strat -}}
+{{- end -}}
+{{- end -}}
+{{- if $ret -}}
+{{- $ret | toYaml | nindent 4 -}}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/default-vault-auth-method.yaml
+++ b/chart/templates/default-vault-auth-method.yaml
@@ -24,4 +24,8 @@ spec:
   mount: {{ .Values.defaultAuthMethod.mount }}
   {{- $kubeServiceAccount := .Values.defaultAuthMethod.kubernetes.serviceAccount }}
   {{- include "vso.vaultAuthMethod" (list .Values.defaultAuthMethod $kubeServiceAccount . ) }}
+  {{- if .Values.defaultAuthMethod.vaultAuthGlobalRef.enabled }}
+  vaultAuthGlobalRef:
+  {{- include "vso.vaultAuthGlobalRef" . }}
+  {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -746,6 +746,40 @@ defaultAuthMethod:
   # @type: map
   headers: {}
 
+  # VaultAuthGlobalRef
+  vaultAuthGlobalRef:
+    #  toggles the inclusion of the VaultAuthGlobal configuration in the
+    # default VaultAuth CR.
+    # @type: boolean
+    enabled: false
+    # Name of the VaultAuthGlobal CR to reference.
+    # @type: string
+    name: ""
+
+    # Namespace of the VaultAuthGlobal CR to reference.
+    # @type: string
+    namespace: ""
+
+    # allow default globals
+    # @type: boolean
+    allowDefault:
+
+    mergeStrategy:
+      # merge strategy for headers
+      # @type: string
+      # Valid values are: "replace", "merge", "none"
+      # Default: "replace"
+      # @type: string
+      headers: none
+
+      # merge strategy for params
+      # @type: string
+      # Valid values are: "replace", "merge", "none"
+      # Default: "replace"
+      # @type: string
+      params: none
+
+
 # Configures a Prometheus ServiceMonitor
 telemetry:
   serviceMonitor:

--- a/test/unit/default-vault-auth-method.bats
+++ b/test/unit/default-vault-auth-method.bats
@@ -404,7 +404,20 @@ load _helpers
     [ "${actual}" = "my-project" ]
 }
 
-@test "defaultAuthMethod/CR: with vaultAuthGlobalRef" {
+@test "defaultAuthMethod/CR: with vaultAuthGlobalRef/default" {
+    cd "$(chart_dir)"
+    local actual
+    actual=$(helm template \
+        --debug \
+        -s templates/default-vault-auth-method.yaml  \
+        --set 'defaultAuthMethod.enabled=true' \
+        . | tee /dev/stderr |
+    yq '.spec' | tee /dev/stderr)
+
+    [ "$(echo "$actual" | yq '. | has("vaultAuthGlobalRef")')" = "false" ]
+}
+
+@test "defaultAuthMethod/CR: with vaultAuthGlobalRef/enabled" {
     cd "$(chart_dir)"
     local actual
     actual=$(helm template \
@@ -422,7 +435,11 @@ load _helpers
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.namespace')" = "baz" ]
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy.params')" = "none" ]
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy.headers')" = "none" ]
+}
 
+@test "defaultAuthMethod/CR: with vaultAuthGlobalRef/defaults/empty-params" {
+    cd "$(chart_dir)"
+    local actual
     actual=$(helm template \
         --debug \
         -s templates/default-vault-auth-method.yaml  \
@@ -439,7 +456,11 @@ load _helpers
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.namespace')" = "baz" ]
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy | has("params")')" = "false" ]
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy.headers')" = "none" ]
+}
 
+@test "defaultAuthMethod/CR: with vaultAuthGlobalRef/mergeStrategy/empty-headers" {
+    cd "$(chart_dir)"
+    local actual
     actual=$(helm template \
         --debug \
         -s templates/default-vault-auth-method.yaml  \
@@ -456,7 +477,11 @@ load _helpers
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.namespace')" = "baz" ]
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy.params')" = "none" ]
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy | has("headers")')" = "false" ]
+}
 
+@test "defaultAuthMethod/CR: with vaultAuthGlobalRef/allowDefault=true" {
+    cd "$(chart_dir)"
+    local actual
     actual=$(helm template \
         --debug \
         -s templates/default-vault-auth-method.yaml  \
@@ -471,7 +496,11 @@ load _helpers
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.allowDefault')" = "true" ]
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.name')" = "foo" ]
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.namespace')" = "baz" ]
+}
 
+@test "defaultAuthMethod/CR: with vaultAuthGlobalRef/allowDefault=false" {
+    cd "$(chart_dir)"
+    local actual
     actual=$(helm template \
         --debug \
         -s templates/default-vault-auth-method.yaml  \
@@ -486,7 +515,11 @@ load _helpers
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.allowDefault')" = "false" ]
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.name')" = "foo" ]
     [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.namespace')" = "baz" ]
+}
 
+@test "defaultAuthMethod/CR: with vaultAuthGlobalRef/mergeStrategy/params=union-headers=replace" {
+    cd "$(chart_dir)"
+    local actual
     actual=$(helm template \
         --debug \
         -s templates/default-vault-auth-method.yaml  \

--- a/test/unit/default-vault-auth-method.bats
+++ b/test/unit/default-vault-auth-method.bats
@@ -1,5 +1,10 @@
 #!/usr/bin/env bats
 
+#
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+#
+
 load _helpers
 
 #--------------------------------------------------------------------
@@ -397,4 +402,107 @@ load _helpers
     [ "${actual}" = "test-cluster" ]
     actual=$(echo "$object" | yq '.spec.gcp.projectID' | tee /dev/stderr)
     [ "${actual}" = "my-project" ]
+}
+
+@test "defaultAuthMethod/CR: with vaultAuthGlobalRef" {
+    cd "$(chart_dir)"
+    local actual
+    actual=$(helm template \
+        --debug \
+        -s templates/default-vault-auth-method.yaml  \
+        --set 'defaultAuthMethod.enabled=true' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.enabled=true' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.name=foo' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.namespace=baz' \
+        . | tee /dev/stderr |
+    yq '.spec' | tee /dev/stderr)
+
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef | has("allowDefault")')" = "false" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.name')" = "foo" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.namespace')" = "baz" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy.params')" = "none" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy.headers')" = "none" ]
+
+    actual=$(helm template \
+        --debug \
+        -s templates/default-vault-auth-method.yaml  \
+        --set 'defaultAuthMethod.enabled=true' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.enabled=true' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.name=foo' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.namespace=baz' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.mergeStrategy.params=' \
+        . | tee /dev/stderr |
+    yq '.spec' | tee /dev/stderr)
+
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef | has("allowDefault")')" = "false" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.name')" = "foo" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.namespace')" = "baz" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy | has("params")')" = "false" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy.headers')" = "none" ]
+
+    actual=$(helm template \
+        --debug \
+        -s templates/default-vault-auth-method.yaml  \
+        --set 'defaultAuthMethod.enabled=true' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.enabled=true' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.name=foo' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.namespace=baz' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.mergeStrategy.headers=' \
+        . | tee /dev/stderr |
+    yq '.spec' | tee /dev/stderr)
+
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef | has("allowDefault")')" = "false" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.name')" = "foo" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.namespace')" = "baz" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy.params')" = "none" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy | has("headers")')" = "false" ]
+
+    actual=$(helm template \
+        --debug \
+        -s templates/default-vault-auth-method.yaml  \
+        --set 'defaultAuthMethod.enabled=true' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.enabled=true' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.name=foo' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.namespace=baz' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.allowDefault=true' \
+        . | tee /dev/stderr |
+    yq '.spec' | tee /dev/stderr)
+
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.allowDefault')" = "true" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.name')" = "foo" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.namespace')" = "baz" ]
+
+    actual=$(helm template \
+        --debug \
+        -s templates/default-vault-auth-method.yaml  \
+        --set 'defaultAuthMethod.enabled=true' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.enabled=true' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.name=foo' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.namespace=baz' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.allowDefault=false' \
+        . | tee /dev/stderr |
+    yq '.spec' | tee /dev/stderr)
+
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.allowDefault')" = "false" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.name')" = "foo" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.namespace')" = "baz" ]
+
+    actual=$(helm template \
+        --debug \
+        -s templates/default-vault-auth-method.yaml  \
+        --set 'defaultAuthMethod.enabled=true' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.enabled=true' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.name=foo' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.namespace=baz' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.allowDefault=false' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.mergeStrategy.params=union' \
+        --set 'defaultAuthMethod.vaultAuthGlobalRef.mergeStrategy.headers=replace' \
+        . | tee /dev/stderr |
+    yq '.spec' | tee /dev/stderr)
+
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.allowDefault')" = "false" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.name')" = "foo" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.namespace')" = "baz" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy.params')" = "union" ]
+    [ "$(echo "$actual" | yq '.vaultAuthGlobalRef.mergeStrategy.headers')" = "replace" ]
 }


### PR DESCRIPTION
Add support for configuring the default VaultAuth's `.spec.vaultAuthGlobalRef` from Helm values.

```
helm install ... \
        --set 'defaultAuthMethod.enabled=true' \
        --set 'defaultAuthMethod.vaultAuthGlobalRef.enabled=true' \
        --set 'defaultAuthMethod.vaultAuthGlobalRef.name=foo' \
        --set 'defaultAuthMethod.vaultAuthGlobalRef.namespace=baz' \
```