### PR TITLE
Add InvalidMergeError wrapper

### DIFF
--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -1207,8 +1207,12 @@ func Test_MergeInVaultAuthGlobal(t *testing.T) {
 			},
 			gObj: gObj.DeepCopy(),
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.EqualError(t, err,
-					`unsupported auth method "invalid" for global auth merge`)
+				var wantErr *InvalidMergeError
+				if assert.ErrorAs(t, err, &wantErr) {
+					return assert.EqualError(t, wantErr.Err,
+						`unsupported auth method "invalid" for global auth merge`)
+				}
+				return false
 			},
 		},
 		{


### PR DESCRIPTION
Adds an error wrapper for common VaultAuthGlobal merge errors. This is useful for including error patterns in user facing documentation.