### PR TITLE
Migrate to k8s.io/utils/ptr

### DIFF
--- a/controllers/hcpauth_controller.go
+++ b/controllers/hcpauth_controller.go
@@ -13,7 +13,7 @@ import (
 	hvsclient "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-06-13/client"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -70,10 +70,10 @@ func (r *HCPAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		logger.Error(err, "Validation failed")
 		errs = errors.Join(err)
 		o.Status.Error = err.Error()
-		o.Status.Valid = pointer.Bool(false)
+		o.Status.Valid = ptr.To(true)
 	} else {
 		o.Status.Error = ""
-		o.Status.Valid = pointer.Bool(true)
+		o.Status.Valid = ptr.To(true)
 	}
 
 	if err := r.updateStatus(ctx, o); err != nil {
@@ -92,7 +92,7 @@ func (r *HCPAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 func (r *HCPAuthReconciler) updateStatus(ctx context.Context, a *secretsv1beta1.HCPAuth) error {
 	logger := log.FromContext(ctx)
-	metrics.SetResourceStatus("hcpauth", a, pointer.BoolDeref(a.Status.Valid, false))
+	metrics.SetResourceStatus("hcpauth", a, ptr.Deref(a.Status.Valid, false))
 	if err := r.Status().Update(ctx, a); err != nil {
 		logger.Error(err, "Failed to update the resource's status")
 		return err

--- a/controllers/secrettransformation_controller.go
+++ b/controllers/secrettransformation_controller.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -60,11 +60,11 @@ func (r *SecretTransformationReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{}, nil
 	}
 
-	o.Status.Valid = pointer.Bool(true)
+	o.Status.Valid = ptr.To(true)
 	o.Status.Error = ""
 	errs := ValidateSecretTransformation(ctx, o)
 	if errs != nil {
-		o.Status.Valid = pointer.Bool(false)
+		o.Status.Valid = ptr.To(false)
 		o.Status.Error = errs.Error()
 		logger.Error(err, "Failed to validate configured templates")
 		r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonInvalidConfiguration,
@@ -80,7 +80,7 @@ func (r *SecretTransformationReconciler) Reconcile(ctx context.Context, req ctrl
 
 func (r *SecretTransformationReconciler) updateStatus(ctx context.Context, o *secretsv1beta1.SecretTransformation) error {
 	logger := log.FromContext(ctx)
-	metrics.SetResourceStatus("secrettransformation", o, pointer.BoolDeref(o.Status.Valid, false))
+	metrics.SetResourceStatus("secrettransformation", o, ptr.Deref(o.Status.Valid, false))
 	if err := r.Status().Update(ctx, o); err != nil {
 		logger.Error(err, "Failed to update the resource's status")
 		return err

--- a/controllers/vaultauth_controller.go
+++ b/controllers/vaultauth_controller.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -77,7 +77,7 @@ func (r *VaultAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// assume that status is always invalid
-	o.Status.Valid = pointer.Bool(false)
+	o.Status.Valid = ptr.To(false)
 	var errs error
 
 	var conditions []metav1.Condition
@@ -172,11 +172,11 @@ func (r *VaultAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	var horizon time.Duration
 	if errs != nil {
-		o.Status.Valid = pointer.Bool(false)
+		o.Status.Valid = ptr.To(false)
 		o.Status.Error = errs.Error()
 		horizon = computeHorizonWithJitter(requeueDurationOnError)
 	} else {
-		o.Status.Valid = pointer.Bool(true)
+		o.Status.Valid = ptr.To(true)
 		o.Status.Error = ""
 	}
 
@@ -199,7 +199,7 @@ func (r *VaultAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 func (r *VaultAuthReconciler) recordEvent(o *secretsv1beta1.VaultAuth, reason, msg string, i ...interface{}) {
 	eventType := corev1.EventTypeNormal
-	if !pointer.BoolDeref(o.Status.Valid, false) {
+	if !ptr.Deref(o.Status.Valid, false) {
 		eventType = corev1.EventTypeWarning
 	}
 
@@ -208,7 +208,7 @@ func (r *VaultAuthReconciler) recordEvent(o *secretsv1beta1.VaultAuth, reason, m
 
 func (r *VaultAuthReconciler) updateStatus(ctx context.Context, o *secretsv1beta1.VaultAuth, conditions ...metav1.Condition) error {
 	logger := log.FromContext(ctx)
-	metrics.SetResourceStatus("vaultauth", o, pointer.BoolDeref(o.Status.Valid, false))
+	metrics.SetResourceStatus("vaultauth", o, ptr.Deref(o.Status.Valid, false))
 	o.Status.Conditions = updateConditions(o.Status.Conditions, conditions...)
 	if err := r.Status().Update(ctx, o); err != nil {
 		logger.Error(err, "Failed to update the resource's status")

--- a/controllers/vaultconnection_controller.go
+++ b/controllers/vaultconnection_controller.go
@@ -7,14 +7,11 @@ import (
 	"context"
 	"errors"
 
-	"k8s.io/utils/pointer"
-
-	"github.com/hashicorp/vault-secrets-operator/internal/metrics"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -23,6 +20,7 @@ import (
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 	"github.com/hashicorp/vault-secrets-operator/internal/consts"
+	"github.com/hashicorp/vault-secrets-operator/internal/metrics"
 	"github.com/hashicorp/vault-secrets-operator/internal/vault"
 )
 
@@ -68,7 +66,7 @@ func (r *VaultConnectionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// assume that status is always invalid
-	o.Status.Valid = pointer.Bool(false)
+	o.Status.Valid = ptr.To(false)
 
 	vaultConfig := &vault.ClientConfig{
 		CACertSecretRef: o.Spec.CACertSecretRef,
@@ -94,7 +92,7 @@ func (r *VaultConnectionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			r.Recorder.Eventf(o, corev1.EventTypeWarning, "VaultClientError", "Failed to check Vault seal status: %s", err)
 			errs = errors.Join(errs, err)
 		} else {
-			o.Status.Valid = pointer.Bool(true)
+			o.Status.Valid = ptr.To(true)
 		}
 	}
 
@@ -126,7 +124,7 @@ func (r *VaultConnectionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 func (r *VaultConnectionReconciler) updateStatus(ctx context.Context, o *secretsv1beta1.VaultConnection) error {
 	logger := log.FromContext(ctx)
-	metrics.SetResourceStatus("vaultconnection", o, pointer.BoolDeref(o.Status.Valid, false))
+	metrics.SetResourceStatus("vaultconnection", o, ptr.Deref(o.Status.Valid, false))
 	if err := r.Status().Update(ctx, o); err != nil {
 		logger.Error(err, "Failed to update the resource's status")
 		return err

--- a/controllers/vaultpkisecret_controller.go
+++ b/controllers/vaultpkisecret_controller.go
@@ -18,7 +18,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -167,7 +167,7 @@ func (r *VaultPKISecretReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// assume that status is always invalid
-	o.Status.Valid = pointer.Bool(false)
+	o.Status.Valid = ptr.To(false)
 	logger.Info("Must sync", "reason", syncReason)
 	c, err := r.ClientFactory.Get(ctx, r.Client, o)
 	if err != nil {
@@ -295,7 +295,7 @@ func (r *VaultPKISecretReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	o.Status.Valid = pointer.Bool(true)
+	o.Status.Valid = ptr.To(true)
 	o.Status.Error = ""
 	o.Status.SerialNumber = certResp.SerialNumber
 	o.Status.Expiration = certResp.Expiration
@@ -419,7 +419,7 @@ func (r *VaultPKISecretReconciler) getPath(spec secretsv1beta1.VaultPKISecretSpe
 
 func (r *VaultPKISecretReconciler) recordEvent(o *secretsv1beta1.VaultPKISecret, reason, msg string, i ...interface{}) {
 	eventType := corev1.EventTypeNormal
-	if !pointer.BoolDeref(o.Status.Valid, false) {
+	if !ptr.Deref(o.Status.Valid, false) {
 		eventType = corev1.EventTypeWarning
 	}
 
@@ -430,7 +430,7 @@ func (r *VaultPKISecretReconciler) updateStatus(ctx context.Context, o *secretsv
 	logger := log.FromContext(ctx)
 	logger.V(consts.LogLevelTrace).Info("Update status called")
 
-	metrics.SetResourceStatus("vaultpkisecret", o, pointer.BoolDeref(o.Status.Valid, false))
+	metrics.SetResourceStatus("vaultpkisecret", o, ptr.Deref(o.Status.Valid, false))
 
 	o.Status.LastGeneration = o.GetGeneration()
 	if err := r.Status().Update(ctx, o); err != nil {

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -846,7 +846,7 @@ func Test_MergeInVaultAuthGlobal(t *testing.T) {
 	}
 
 	wantK8sUnionParamsOverrideDefaultRef := wantK8sUnionParamsOverride.DeepCopy()
-	wantK8sUnionParamsOverrideDefaultRef.Spec.VaultAuthGlobalRef.AllowDefault = pointer.Bool(true)
+	wantK8sUnionParamsOverrideDefaultRef.Spec.VaultAuthGlobalRef.AllowDefault = ptr.To(true)
 	wantK8sUnionParamsOverrideDefaultRef.Spec.VaultAuthGlobalRef.Name = ""
 	wantK8sUnionParamsOverrideDefaultRef.Spec.VaultAuthGlobalRef.Namespace = "baz"
 
@@ -1539,7 +1539,7 @@ func Test_MergeInVaultAuthGlobal(t *testing.T) {
 					},
 					VaultAuthGlobalRef: &secretsv1beta1.VaultAuthGlobalRef{
 						Namespace:    "baz",
-						AllowDefault: pointer.Bool(true),
+						AllowDefault: ptr.To(true),
 						MergeStrategy: &secretsv1beta1.MergeStrategy{
 							Params: "union",
 						},
@@ -1567,7 +1567,7 @@ func Test_MergeInVaultAuthGlobal(t *testing.T) {
 						"baz": "override",
 					},
 					VaultAuthGlobalRef: &secretsv1beta1.VaultAuthGlobalRef{
-						AllowDefault: pointer.Bool(true),
+						AllowDefault: ptr.To(true),
 						MergeStrategy: &secretsv1beta1.MergeStrategy{
 							Params: "union",
 						},
@@ -1595,7 +1595,7 @@ func Test_MergeInVaultAuthGlobal(t *testing.T) {
 						"baz": "override",
 					},
 					VaultAuthGlobalRef: &secretsv1beta1.VaultAuthGlobalRef{
-						AllowDefault: pointer.Bool(true),
+						AllowDefault: ptr.To(true),
 						MergeStrategy: &secretsv1beta1.MergeStrategy{
 							Params: "union",
 						},
@@ -1624,7 +1624,7 @@ func Test_MergeInVaultAuthGlobal(t *testing.T) {
 					},
 					VaultAuthGlobalRef: &secretsv1beta1.VaultAuthGlobalRef{
 						Namespace:    "baz",
-						AllowDefault: pointer.Bool(true),
+						AllowDefault: ptr.To(true),
 						MergeStrategy: &secretsv1beta1.MergeStrategy{
 							Params: "union",
 						},
@@ -1655,7 +1655,7 @@ func Test_MergeInVaultAuthGlobal(t *testing.T) {
 					},
 					VaultAuthGlobalRef: &secretsv1beta1.VaultAuthGlobalRef{
 						Namespace:    "baz",
-						AllowDefault: pointer.Bool(true),
+						AllowDefault: ptr.To(true),
 						MergeStrategy: &secretsv1beta1.MergeStrategy{
 							Params: "union",
 						},
@@ -1684,7 +1684,7 @@ func Test_MergeInVaultAuthGlobal(t *testing.T) {
 						"baz": "override",
 					},
 					VaultAuthGlobalRef: &secretsv1beta1.VaultAuthGlobalRef{
-						AllowDefault: pointer.Bool(true),
+						AllowDefault: ptr.To(true),
 						MergeStrategy: &secretsv1beta1.MergeStrategy{
 							Params: "union",
 						},

--- a/internal/helpers/hmac.go
+++ b/internal/helpers/hmac.go
@@ -15,7 +15,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -205,7 +205,7 @@ func createHMACKeySecret(ctx context.Context, client ctrlclient.Client, objKey c
 			Namespace: objKey.Namespace,
 			Labels:    hmacSecretLabels,
 		},
-		Immutable: pointer.Bool(true),
+		Immutable: ptr.To(true),
 		Data: map[string][]byte{
 			HMACKeyName: key,
 		},

--- a/internal/helpers/serviceaccount.go
+++ b/internal/helpers/serviceaccount.go
@@ -9,7 +9,7 @@ import (
 	v12 "k8s.io/api/authentication/v1"
 	"k8s.io/api/core/v1"
 	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/hashicorp/vault-secrets-operator/internal/common"
@@ -24,7 +24,7 @@ func RequestSAToken(ctx context.Context, client client.Client, sa *v1.ServiceAcc
 			GenerateName: TokenGenerateName,
 		},
 		Spec: v12.TokenRequestSpec{
-			ExpirationSeconds: pointer.Int64(expirationSeconds),
+			ExpirationSeconds: ptr.To(expirationSeconds),
 			Audiences:         audiences,
 		},
 		Status: v12.TokenRequestStatus{},

--- a/internal/helpers/template.go
+++ b/internal/helpers/template.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/golang-lru/v2"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
@@ -218,7 +218,7 @@ func gatherTemplates(ctx context.Context, client ctrlclient.Client, meta *common
 			continue
 		}
 
-		if !pointer.BoolDeref(obj.Status.Valid, false) {
+		if !ptr.Deref(obj.Status.Valid, false) {
 			errs = errors.Join(errs,
 				&InvalidSecretTransformationRefError{
 					objKey: objKey,

--- a/internal/helpers/template_test.go
+++ b/internal/helpers/template_test.go
@@ -13,7 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
@@ -563,7 +563,7 @@ func TestNewSecretTransformationOption(t *testing.T) {
 
 		if status == nil {
 			status = &secretsv1beta1.SecretTransformationStatus{
-				Valid: pointer.Bool(true),
+				Valid: ptr.To(true),
 			}
 		}
 
@@ -1212,7 +1212,7 @@ func TestNewSecretTransformationOption(t *testing.T) {
 						},
 					},
 					&secretsv1beta1.SecretTransformationStatus{
-						Valid: pointer.Bool(false),
+						Valid: ptr.To(false),
 						Error: "",
 					}),
 			},

--- a/internal/vault/cache.go
+++ b/internal/vault/cache.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/golang-lru/v2"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/internal/vault/cache_storage.go
+++ b/internal/vault/cache_storage.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -231,7 +231,7 @@ func (c *defaultClientCacheStorage) Store(ctx context.Context, client ctrlclient
 	}
 	s := &corev1.Secret{
 		// we always store Clients in an Immutable secret as an anti-tampering mitigation.
-		Immutable: pointer.Bool(true),
+		Immutable: ptr.To(true),
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(NamePrefixVCC + cacheKey.String()),
 			Namespace:       common.OperatorNamespace,

--- a/internal/vault/cache_storage_metrics_test.go
+++ b/internal/vault/cache_storage_metrics_test.go
@@ -17,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -104,38 +104,38 @@ func Test_clientCacheStorage_Metrics(t *testing.T) {
 
 	storeLabelPairs := []*io_prometheus_client.LabelPair{
 		{
-			Name:  pointer.String(metrics.LabelOperation),
-			Value: pointer.String(metrics.OperationStore),
+			Name:  ptr.To(metrics.LabelOperation),
+			Value: ptr.To(metrics.OperationStore),
 		},
 	}
 	restoreLabelPairs := []*io_prometheus_client.LabelPair{
 		{
-			Name:  pointer.String(metrics.LabelOperation),
-			Value: pointer.String(metrics.OperationRestore),
+			Name:  ptr.To(metrics.LabelOperation),
+			Value: ptr.To(metrics.OperationRestore),
 		},
 	}
 	purgeLabelPairs := []*io_prometheus_client.LabelPair{
 		{
-			Name:  pointer.String(metrics.LabelOperation),
-			Value: pointer.String(metrics.OperationPurge),
+			Name:  ptr.To(metrics.LabelOperation),
+			Value: ptr.To(metrics.OperationPurge),
 		},
 	}
 	pruneLabelPairs := []*io_prometheus_client.LabelPair{
 		{
-			Name:  pointer.String(metrics.LabelOperation),
-			Value: pointer.String(metrics.OperationPrune),
+			Name:  ptr.To(metrics.LabelOperation),
+			Value: ptr.To(metrics.OperationPrune),
 		},
 	}
 	deleteLabelPairs := []*io_prometheus_client.LabelPair{
 		{
-			Name:  pointer.String(metrics.LabelOperation),
-			Value: pointer.String(metrics.OperationDelete),
+			Name:  ptr.To(metrics.LabelOperation),
+			Value: ptr.To(metrics.OperationDelete),
 		},
 	}
 	configLabelPairs := []*io_prometheus_client.LabelPair{
 		{
-			Name:  pointer.String(metricsLabelEnforceEncryption),
-			Value: pointer.String("false"),
+			Name:  ptr.To(metricsLabelEnforceEncryption),
+			Value: ptr.To("false"),
 		},
 	}
 
@@ -179,13 +179,13 @@ func Test_clientCacheStorage_Metrics(t *testing.T) {
 			expectMetrics: expectMetrics{
 				store: &expected{
 					reqs: &expectedMetricVec{
-						total:       pointer.Float64(5),
+						total:       ptr.To[float64](5),
 						labelPairs:  storeLabelPairs,
-						errorsTotal: pointer.Float64(2),
+						errorsTotal: ptr.To[float64](2),
 					},
 					ops: &expectedMetricVec{
-						total:       pointer.Float64(5),
-						errorsTotal: pointer.Float64(2),
+						total:       ptr.To[float64](5),
+						errorsTotal: ptr.To[float64](2),
 						labelPairs:  storeLabelPairs,
 					},
 				},
@@ -200,23 +200,23 @@ func Test_clientCacheStorage_Metrics(t *testing.T) {
 			expectMetrics: expectMetrics{
 				store: &expected{
 					reqs: &expectedMetricVec{
-						total:      pointer.Float64(4),
+						total:      ptr.To[float64](4),
 						labelPairs: storeLabelPairs,
 					},
 					ops: &expectedMetricVec{
-						total:      pointer.Float64(4),
+						total:      ptr.To[float64](4),
 						labelPairs: storeLabelPairs,
 					},
 				},
 				restore: &expected{
 					reqs: &expectedMetricVec{
-						total:       pointer.Float64(2),
-						errorsTotal: pointer.Float64(4),
+						total:       ptr.To[float64](2),
+						errorsTotal: ptr.To[float64](4),
 						labelPairs:  restoreLabelPairs,
 					},
 					ops: &expectedMetricVec{
-						total:       pointer.Float64(2),
-						errorsTotal: pointer.Float64(4),
+						total:       ptr.To[float64](2),
+						errorsTotal: ptr.To[float64](4),
 						labelPairs:  restoreLabelPairs,
 					},
 				},
@@ -230,35 +230,35 @@ func Test_clientCacheStorage_Metrics(t *testing.T) {
 			expectMetrics: expectMetrics{
 				store: &expected{
 					reqs: &expectedMetricVec{
-						total:      pointer.Float64(4),
+						total:      ptr.To[float64](4),
 						labelPairs: storeLabelPairs,
 					},
 					ops: &expectedMetricVec{
-						total:      pointer.Float64(4),
+						total:      ptr.To[float64](4),
 						labelPairs: storeLabelPairs,
 					},
 				},
 				prune: &expected{
 					reqs: &expectedMetricVec{
-						total:       pointer.Float64(2),
-						errorsTotal: pointer.Float64(1),
+						total:       ptr.To[float64](2),
+						errorsTotal: ptr.To[float64](1),
 						labelPairs:  pruneLabelPairs,
 					},
 					ops: &expectedMetricVec{
-						total:       pointer.Float64(2),
-						errorsTotal: pointer.Float64(1),
+						total:       ptr.To[float64](2),
+						errorsTotal: ptr.To[float64](1),
 						labelPairs:  pruneLabelPairs,
 					},
 				},
 				delete: &expected{
 					reqs: &expectedMetricVec{
-						total:       pointer.Float64(2),
-						errorsTotal: pointer.Float64(1),
+						total:       ptr.To[float64](2),
+						errorsTotal: ptr.To[float64](1),
 						labelPairs:  deleteLabelPairs,
 					},
 					ops: &expectedMetricVec{
-						total:       pointer.Float64(2),
-						errorsTotal: pointer.Float64(1),
+						total:       ptr.To[float64](2),
+						errorsTotal: ptr.To[float64](1),
 						labelPairs:  deleteLabelPairs,
 					},
 				},
@@ -273,33 +273,33 @@ func Test_clientCacheStorage_Metrics(t *testing.T) {
 			expectMetrics: expectMetrics{
 				store: &expected{
 					reqs: &expectedMetricVec{
-						total:      pointer.Float64(4),
+						total:      ptr.To[float64](4),
 						labelPairs: storeLabelPairs,
 					},
 					ops: &expectedMetricVec{
-						total:      pointer.Float64(4),
+						total:      ptr.To[float64](4),
 						labelPairs: storeLabelPairs,
 					},
 				},
 				purge: &expected{
 					reqs: &expectedMetricVec{
-						total:       pointer.Float64(1),
-						errorsTotal: pointer.Float64(1),
+						total:       ptr.To[float64](1),
+						errorsTotal: ptr.To[float64](1),
 						labelPairs:  purgeLabelPairs,
 					},
 					ops: &expectedMetricVec{
-						total:       pointer.Float64(1),
-						errorsTotal: pointer.Float64(1),
+						total:       ptr.To[float64](1),
+						errorsTotal: ptr.To[float64](1),
 						labelPairs:  purgeLabelPairs,
 					},
 				},
 				prune: &expected{
 					reqs: &expectedMetricVec{
-						total:      pointer.Float64(4),
+						total:      ptr.To[float64](4),
 						labelPairs: pruneLabelPairs,
 					},
 					ops: &expectedMetricVec{
-						total:      pointer.Float64(4),
+						total:      ptr.To[float64](4),
 						labelPairs: pruneLabelPairs,
 					},
 				},
@@ -314,21 +314,21 @@ func Test_clientCacheStorage_Metrics(t *testing.T) {
 			expectMetrics: expectMetrics{
 				store: &expected{
 					reqs: &expectedMetricVec{
-						total:      pointer.Float64(4),
+						total:      ptr.To[float64](4),
 						labelPairs: storeLabelPairs,
 					},
 					ops: &expectedMetricVec{
-						total:      pointer.Float64(4),
+						total:      ptr.To[float64](4),
 						labelPairs: storeLabelPairs,
 					},
 				},
 				restore: &expected{
 					reqs: &expectedMetricVec{
-						total:      pointer.Float64(4),
+						total:      ptr.To[float64](4),
 						labelPairs: restoreLabelPairs,
 					},
 					ops: &expectedMetricVec{
-						total:      pointer.Float64(4),
+						total:      ptr.To[float64](4),
 						labelPairs: restoreLabelPairs,
 					},
 				},

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -45,7 +45,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -920,7 +920,7 @@ func createDeployment(t *testing.T, ctx context.Context, client ctrlclient.Clien
 					"test": key.Name,
 				},
 			},
-			Replicas: pointer.Int32(3),
+			Replicas: ptr.To[int32](3),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{
@@ -937,7 +937,7 @@ func createDeployment(t *testing.T, ctx context.Context, client ctrlclient.Clien
 							},
 						},
 					},
-					TerminationGracePeriodSeconds: pointer.Int64(2),
+					TerminationGracePeriodSeconds: ptr.To[int64](2),
 				},
 			},
 			Strategy: appsv1.DeploymentStrategy{
@@ -970,7 +970,7 @@ func createArgoRolloutV1alpha1(t *testing.T, ctx context.Context, client ctrlcli
 					"test": key.Name,
 				},
 			},
-			Replicas: pointer.Int32(2),
+			Replicas: ptr.To[int32](2),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{
@@ -987,14 +987,14 @@ func createArgoRolloutV1alpha1(t *testing.T, ctx context.Context, client ctrlcli
 							},
 						},
 					},
-					TerminationGracePeriodSeconds: pointer.Int64(2),
+					TerminationGracePeriodSeconds: ptr.To[int64](2),
 				},
 			},
 			Strategy: argorolloutsv1alpha1.RolloutStrategy{
 				Canary: &argorolloutsv1alpha1.CanaryStrategy{
 					Steps: []argorolloutsv1alpha1.CanaryStep{
 						{
-							SetWeight: pointer.Int32(50),
+							SetWeight: ptr.To[int32](50),
 						},
 						{
 							Pause: &argorolloutsv1alpha1.RolloutPause{


### PR DESCRIPTION
The `k8s.io/utils/pointer` package is deprecated, and is being replaced by `k8s.io/utils/ptr`.