### PR TITLE
CI: Bump test vault versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -343,9 +343,9 @@ jobs:
     outputs:
       # JSON encoded array of k8s versions
       K8S_VERSIONS: '["1.30.0", "1.29.4", "1.28.9", "1.27.13", "1.26.15"]'
-      VAULT_N: "1.16.3"
-      VAULT_N_1: "1.15.9"
-      VAULT_N_2: "1.14.13"
+      VAULT_N: "1.17.2"
+      VAULT_N_1: "1.16.6"
+      VAULT_N_2: "1.15.12"
   latest-vault:
     name: vault:${{ matrix.vault-version }} kind:${{ matrix.k8s-version }} ${{ matrix.installation-method }} enterprise=${{ matrix.vault-enterprise }}
     needs:


### PR DESCRIPTION
- Test against the latest 1.17.2 version for enterprise and community.
- Test against the latest 1.16.x and 1.15.x for enterprise.