### PR TITLE
Fix: encryption client deadlocking the factory

### DIFF
--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -13,13 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
+	"github.com/hashicorp/vault-secrets-operator/internal/testutils"
 )
 
 func Test_dynamicHorizon(t *testing.T) {
@@ -120,7 +117,6 @@ func Test_parseDurationString(t *testing.T) {
 }
 
 func Test_computeStartRenewingAt(t *testing.T) {
-	type args struct{}
 	tests := []struct {
 		name           string
 		leaseDuration  time.Duration
@@ -217,7 +213,7 @@ func Test_maybeAddFinalizer(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	clientBuilder := newClientBuilder()
+	clientBuilder := testutils.NewFakeClientBuilder()
 	deletionTimestamp := metav1.NewTime(time.Now())
 
 	tests := []struct {
@@ -371,14 +367,6 @@ func Test_maybeAddFinalizer(t *testing.T) {
 			}
 		})
 	}
-}
-
-// newClientBuilder copied from helpers.
-func newClientBuilder() *fake.ClientBuilder {
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(secretsv1beta1.AddToScheme(scheme))
-	return fake.NewClientBuilder().WithScheme(scheme)
 }
 
 func Test_waitForStoppedCh(t *testing.T) {

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/vault-secrets-operator/internal/credentials/provider"
 	"github.com/hashicorp/vault-secrets-operator/internal/credentials/vault/consts"
 	"github.com/hashicorp/vault-secrets-operator/internal/helpers"
+	"github.com/hashicorp/vault-secrets-operator/internal/testutils"
 	"github.com/hashicorp/vault-secrets-operator/internal/vault"
 )
 
@@ -1021,7 +1022,7 @@ func TestVaultDynamicSecretReconciler_vaultClientCallback(t *testing.T) {
 	key1 := fmt.Sprintf("%s-%s", consts.ProviderMethodKubernetes, "2a8108711ae49ac0faa724")
 	key2 := fmt.Sprintf("%s-%s", consts.ProviderMethodKubernetes, "2a8108711ae49ac0faa725")
 
-	builder := newClientBuilder()
+	builder := testutils.NewFakeClientBuilder()
 	// instances in the same namespace that should be included by the callback.
 	instances := []*secretsv1beta1.VaultDynamicSecret{
 		{

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -14,16 +14,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 	"github.com/hashicorp/vault-secrets-operator/internal/consts"
+	"github.com/hashicorp/vault-secrets-operator/internal/testutils"
 )
 
 func Test_GetConnectionNamespacedName(t *testing.T) {
@@ -321,9 +318,7 @@ func Test_isAllowedNamespace(t *testing.T) {
 func TestGetHCPAuthForObj(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	utilruntime.Must(secretsv1beta1.AddToScheme(scheme))
-	clientBuilder := fake.NewClientBuilder().WithScheme(scheme)
+	clientBuilder := testutils.NewFakeClientBuilder()
 
 	ctx := context.Background()
 	tests := []struct {
@@ -691,18 +686,11 @@ func TestNewSyncableSecretMetaData(t *testing.T) {
 	}
 }
 
-func newClientBuilder() *fake.ClientBuilder {
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(secretsv1beta1.AddToScheme(scheme))
-	return fake.NewClientBuilder().WithScheme(scheme)
-}
-
 func Test_MergeInVaultAuthGlobal(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	builder := newClientBuilder()
+	builder := testutils.NewFakeClientBuilder()
 
 	gObj := &secretsv1beta1.VaultAuthGlobal{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/credentials/fake.go
+++ b/internal/credentials/fake.go
@@ -1,0 +1,75 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package credentials
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
+	"github.com/hashicorp/vault-secrets-operator/internal/credentials/provider"
+	"github.com/hashicorp/vault-secrets-operator/internal/credentials/vault"
+)
+
+type FakeCredentialProviderFactory interface {
+	CredentialProviderFactory
+}
+
+type FakeCredentialProvider interface {
+	vault.CredentialProvider
+	WithUID(types.UID) FakeCredentialProvider
+}
+
+func NewFakeCredentialProvider() FakeCredentialProvider {
+	return &fakeCredentialProvider{}
+}
+
+var _ FakeCredentialProvider = (*fakeCredentialProvider)(nil)
+
+type fakeCredentialProvider struct {
+	uid types.UID
+}
+
+func (f *fakeCredentialProvider) WithUID(uid types.UID) FakeCredentialProvider {
+	f.uid = uid
+	return f
+}
+
+func (f *fakeCredentialProvider) GetUID() types.UID {
+	return f.uid
+}
+
+func (f *fakeCredentialProvider) GetNamespace() string {
+	return ""
+}
+
+func (f *fakeCredentialProvider) GetCreds(_ context.Context, _ ctrlclient.Client) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (f *fakeCredentialProvider) Init(_ context.Context, _ ctrlclient.Client, _ *secretsv1beta1.VaultAuth, _ string) error {
+	return nil
+}
+
+var _ FakeCredentialProviderFactory = (*fakeCredentialProviderFactory)(nil)
+
+type fakeCredentialProviderFactory struct {
+	factoryFunc CredentialProviderFactoryFunc
+}
+
+func (f *fakeCredentialProviderFactory) New(ctx context.Context, c ctrlclient.Client, obj ctrlclient.Object, providerNamespace string) (provider.CredentialProviderBase, error) {
+	return f.factoryFunc(ctx, c, obj, providerNamespace)
+}
+
+// NewFakeCredentialProviderFactory returns a new FakeCredentialProviderFactory
+// with the given factoryFunc. If factoryFunc is nil, a default factoryFunc is
+// used. The default factoryFunc returns a fakeCredentialProvider for
+// VaultAuth objects with the Kubernetes authentication method.
+func NewFakeCredentialProviderFactory(factoryFunc CredentialProviderFactoryFunc) CredentialProviderFactory {
+	return &fakeCredentialProviderFactory{
+		factoryFunc: factoryFunc,
+	}
+}

--- a/internal/helpers/hmac_test.go
+++ b/internal/helpers/hmac_test.go
@@ -19,10 +19,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
+	"github.com/hashicorp/vault-secrets-operator/internal/testutils"
 )
 
 var (
-	clientBuilder     = newClientBuilder()
+	clientBuilder     = testutils.NewFakeClientBuilder()
 	defaultHMACKey    []byte
 	defaultHMACObjKey = client.ObjectKey{
 		Namespace: "vso",

--- a/internal/helpers/rollout_restart_test.go
+++ b/internal/helpers/rollout_restart_test.go
@@ -17,13 +17,14 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/hashicorp/vault-secrets-operator/api/v1beta1"
+	"github.com/hashicorp/vault-secrets-operator/internal/testutils"
 )
 
 func TestRolloutRestart(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	builder := newClientBuilder()
+	builder := testutils.NewFakeClientBuilder()
 	// use one second ago timestamp to compare against rollout restartAt
 	// since argo.Rollout's Spec.RestartAt rounds down to the nearest second
 	// and often equals to time.Now()

--- a/internal/helpers/secrets_test.go
+++ b/internal/helpers/secrets_test.go
@@ -24,13 +24,14 @@ import (
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 	"github.com/hashicorp/vault-secrets-operator/internal/common"
+	"github.com/hashicorp/vault-secrets-operator/internal/testutils"
 )
 
 func TestFindSecretsOwnedByObj(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	clientBuilder := newClientBuilder()
+	clientBuilder := testutils.NewFakeClientBuilder()
 	defaultClient := clientBuilder.Build()
 
 	owner := &secretsv1beta1.VaultDynamicSecret{
@@ -187,7 +188,7 @@ func TestSyncSecret(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	clientBuilder := newClientBuilder()
+	clientBuilder := testutils.NewFakeClientBuilder()
 
 	defaultOwner := &secretsv1beta1.VaultDynamicSecret{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/helpers/template_test.go
+++ b/internal/helpers/template_test.go
@@ -17,6 +17,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
+	"github.com/hashicorp/vault-secrets-operator/internal/testutils"
 )
 
 func Test_renderTemplates(t *testing.T) {
@@ -575,7 +576,7 @@ func TestNewSecretTransformationOption(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	clientBuilder := newClientBuilder()
+	clientBuilder := testutils.NewFakeClientBuilder()
 
 	defaultKeyedTemplates := []*KeyedTemplate{
 		{

--- a/internal/helpers/testutils_test.go
+++ b/internal/helpers/testutils_test.go
@@ -7,23 +7,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	argorolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 )
-
-func newClientBuilder() *fake.ClientBuilder {
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(secretsv1beta1.AddToScheme(scheme))
-	utilruntime.Must(argorolloutsv1alpha1.AddToScheme(scheme))
-	return fake.NewClientBuilder().WithScheme(scheme)
-}
 
 func marshalRaw(t *testing.T, d any) []byte {
 	t.Helper()

--- a/internal/testutils/ctrlclient.go
+++ b/internal/testutils/ctrlclient.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package testutils
+
+import (
+	argorolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
+)
+
+// NewFakeClientBuilder returns a fake.ClientBuilder (controller Client) with
+// all VSO schemas added. It is useful for testing code that interacts with any
+// of the VSO resources.
+func NewFakeClientBuilder() *fake.ClientBuilder {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(secretsv1beta1.AddToScheme(scheme))
+	utilruntime.Must(argorolloutsv1alpha1.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme)
+}

--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -605,7 +605,7 @@ func (c *defaultClient) Login(ctx context.Context, client ctrlclient.Client) err
 
 	c.client.SetToken(secret.Auth.ClientToken)
 
-	c.authSecret = resp.Secret()
+	c.authSecret = secret
 	c.lastRenewal = time.Now().Unix()
 
 	id, err := c.hashAccessor()

--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -101,6 +101,7 @@ func NewClientWithLogin(ctx context.Context, client ctrlclient.Client, obj ctrlc
 // NewClientFromStorageEntry restores a Client from provided clientCacheStorageEntry.
 // If the restoration fails an error will be returned.
 func NewClientFromStorageEntry(ctx context.Context, client ctrlclient.Client, entry *clientCacheStorageEntry, opts *ClientOptions) (Client, error) {
+	logger := log.FromContext(ctx).WithName("newClientFromStorageEntry").WithValues("entry", entry)
 	authObj, err := common.FindVaultAuthByUID(ctx, client, entry.VaultAuthNamespace,
 		entry.VaultAuthUID, entry.VaultAuthGeneration)
 	if err != nil {
@@ -142,7 +143,9 @@ func NewClientFromStorageEntry(ctx context.Context, client ctrlclient.Client, en
 	c.Taint()
 	defer c.Untaint()
 
+	logger.V(consts.LogLevelDebug).Info("Validating restored client", "cacheKey", cacheKey)
 	if err := c.Validate(ctx); err != nil {
+		logger.V(consts.LogLevelDebug).Info("Invalid client after restoration", "cacheKey", cacheKey)
 		return nil, err
 	}
 

--- a/internal/vault/client_factory.go
+++ b/internal/vault/client_factory.go
@@ -768,7 +768,7 @@ func (m *cachingClientFactory) setEncryptionClient(ctx context.Context, client c
 		err = fmt.Errorf("failed to setup encryption client: %w", err)
 		return nil, err
 	case c := <-doneCh:
-		return c, err
+		return c, nil
 	}
 }
 

--- a/internal/vault/client_factory.go
+++ b/internal/vault/client_factory.go
@@ -665,7 +665,7 @@ func (m *cachingClientFactory) setupEncryptionClient(ctx context.Context, client
 	defer m.encClientLock.Unlock()
 
 	logger := log.FromContext(ctx).WithName("setupEncryptionClient")
-	logger.Info("Setting up Vault Client for storage encryption",
+	logger.V(consts.LogLevelTrace).Info("Setting up Vault Client for storage encryption",
 		"cacheKey", m.clientCacheKeyEncrypt)
 	encryptionVaultAuth, err := common.FindVaultAuthForStorageEncryption(ctx, client)
 	if err != nil {
@@ -686,12 +686,14 @@ func (m *cachingClientFactory) setupEncryptionClient(ctx context.Context, client
 	}
 
 	if m.clientCacheKeyEncrypt != "" && m.clientCacheKeyEncrypt != cacheKey {
-		logger.V(consts.LogLevelDebug).Info("Replacing old encryption client",
+		logger.V(consts.LogLevelTrace).Info("Replacing old encryption client",
 			"oldCacheKey", m.clientCacheKeyEncrypt, "newCacheKey", cacheKey)
 		m.cache.Remove(m.clientCacheKeyEncrypt)
 	}
 
 	m.clientCacheKeyEncrypt = cacheKey
+	logger.V(consts.LogLevelTrace).Info("Successfully setup Vault Client for storage encryption",
+		"cacheKey", m.clientCacheKeyEncrypt)
 	return vc, nil
 }
 

--- a/internal/vault/client_factory_test.go
+++ b/internal/vault/client_factory_test.go
@@ -585,7 +585,7 @@ func Test_cachingClientFactory_storageEncryptionClient(t *testing.T) {
 			switch tt.testScenario {
 			case 1, 2:
 				require.GreaterOrEqual(t, tt.callCount, 10, "not enough calls for test scenario")
-				ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+				ctx_, cancel := context.WithTimeout(ctx, time.Second*30)
 				go func() {
 					defer cancel()
 					time.Sleep(time.Second * 30)
@@ -621,7 +621,7 @@ func Test_cachingClientFactory_storageEncryptionClient(t *testing.T) {
 				var actualCallCount int
 				for i := 0; i < tt.callCount; i++ {
 					select {
-					case <-ctx.Done():
+					case <-ctx_.Done():
 						assert.Fail(t, "timeout waiting for client creation")
 						break
 					case <-doneCh:

--- a/internal/vault/client_factory_test.go
+++ b/internal/vault/client_factory_test.go
@@ -382,7 +382,6 @@ func Test_cachingClientFactory_storageEncryptionClient(t *testing.T) {
 
 	authHandlerFunc := func(t *testHandler, w http.ResponseWriter, req *http.Request) {
 		if req.Method == http.MethodPut {
-			w.WriteHeader(http.StatusOK)
 			s := &api.Secret{
 				Auth: &api.SecretAuth{
 					LeaseDuration: 100,

--- a/internal/vault/client_factory_test.go
+++ b/internal/vault/client_factory_test.go
@@ -332,6 +332,8 @@ type storageEncryptionClientTest struct {
 }
 
 func Test_cachingClientFactory_storageEncryptionClient(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	builder := testutils.NewFakeClientBuilder()
 	vcObj := &secretsv1beta1.VaultConnection{
@@ -380,6 +382,7 @@ func Test_cachingClientFactory_storageEncryptionClient(t *testing.T) {
 
 	authHandlerFunc := func(t *testHandler, w http.ResponseWriter, req *http.Request) {
 		if req.Method == http.MethodPut {
+			w.WriteHeader(http.StatusOK)
 			s := &api.Secret{
 				Auth: &api.SecretAuth{
 					LeaseDuration: 100,

--- a/internal/vault/client_factory_test.go
+++ b/internal/vault/client_factory_test.go
@@ -383,7 +383,6 @@ func Test_cachingClientFactory_storageEncryptionClient(t *testing.T) {
 
 	authHandlerFunc := func(t *testHandler, w http.ResponseWriter, req *http.Request) {
 		if req.Method == http.MethodPut {
-			w.WriteHeader(http.StatusOK)
 			s := &api.Secret{
 				Auth: &api.SecretAuth{
 					LeaseDuration: 100,
@@ -400,6 +399,7 @@ func Test_cachingClientFactory_storageEncryptionClient(t *testing.T) {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
+			w.WriteHeader(http.StatusOK)
 			return
 		} else {
 			w.WriteHeader(http.StatusMethodNotAllowed)

--- a/main.go
+++ b/main.go
@@ -566,6 +566,12 @@ func main() {
 	}
 
 	setupLog.Info("Starting manager",
+		"gitVersion", versionInfo.GitVersion,
+		"gitCommit", versionInfo.GitCommit,
+		"gitTreeState", versionInfo.GitTreeState,
+		"buildDate", versionInfo.BuildDate,
+		"goVersion", versionInfo.GoVersion,
+		"platform", versionInfo.Platform,
 		"clientCachePersistenceModel", clientCachePersistenceModel,
 		"clientCacheSize", cfc.ClientCacheSize,
 		"backoffMultiplier", backoffMultiplier,


### PR DESCRIPTION
Setting up the storage encryption client deadlocks the client factory if the client is deemed to be invalid. This causes all reconciliations to block forever.

The fix is to move the client setup code out of
storageEncryptionClient(). This gets rid of the vestigial recursive call to itself and allows for single locker.

- [x] add tests