### PR TITLE
Log build info on startup

### DIFF
--- a/internal/vault/client_factory_test.go
+++ b/internal/vault/client_factory_test.go
@@ -335,6 +335,8 @@ type storageEncryptionClientTest struct {
 }
 
 func Test_cachingClientFactory_storageEncryptionClient(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	builder := testutils.NewFakeClientBuilder()
 	vcObj := &secretsv1beta1.VaultConnection{
@@ -383,6 +385,7 @@ func Test_cachingClientFactory_storageEncryptionClient(t *testing.T) {
 
 	authHandlerFunc := func(t *testHandler, w http.ResponseWriter, req *http.Request) {
 		if req.Method == http.MethodPut {
+			w.WriteHeader(http.StatusOK)
 			s := &api.Secret{
 				Auth: &api.SecretAuth{
 					LeaseDuration: 100,
@@ -399,7 +402,6 @@ func Test_cachingClientFactory_storageEncryptionClient(t *testing.T) {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
-			w.WriteHeader(http.StatusOK)
 			return
 		} else {
 			w.WriteHeader(http.StatusMethodNotAllowed)

--- a/main.go
+++ b/main.go
@@ -566,6 +566,12 @@ func main() {
 	}
 
 	setupLog.Info("Starting manager",
+		"gitVersion", versionInfo.GitVersion,
+		"gitCommit", versionInfo.GitCommit,
+		"gitTreeState", versionInfo.GitTreeState,
+		"buildDate", versionInfo.BuildDate,
+		"goVersion", versionInfo.GoVersion,
+		"platform", versionInfo.Platform,
 		"clientCachePersistenceModel", clientCachePersistenceModel,
 		"clientCacheSize", cfc.ClientCacheSize,
 		"backoffMultiplier", backoffMultiplier,


### PR DESCRIPTION
Extends the runtime info log to include the build info of the running VSO instance:
```json
{
  "level": "info",
  "ts": "2024-07-25T21:41:51Z",
  "logger": "setup",
  "msg": "Starting manager",
  "gitVersion": "v0.7.0-66-gfdf6a90",
  "gitCommit": "fdf6a9031e268644bdb9c07fb221fd46fc7474b4",
  "gitTreeState": "dirty",
  "buildDate": "2024-07-25T21:38:05+0000",
  "goVersion": "go1.22.5",
  "platform": "linux/amd64",
  "clientCachePersistenceModel": "direct-encrypted",
  "clientCacheSize": 10000,
  "backoffMultiplier": 1.5,
  "backoffMaxInterval": 60,
  "backoffMaxElapsedTime": 0,
  "backoffInitialInterval": 5,
  "backoffRandomizationFactor": 0.5,
  "globalTransformationOptions": "",
  "globalVaultAuthOptions": "allow-default-globals"
}
```