### PR TITLE
Enhance default manifests in helm chart

### DIFF
--- a/chart/templates/default-vault-auth-global.yaml
+++ b/chart/templates/default-vault-auth-global.yaml
@@ -1,0 +1,30 @@
+{{- /*
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+*/ -}}
+
+{{- if .Values.defaultAuthGlobal.enabled }}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuthGlobal
+metadata:
+  name: default
+  namespace: {{ .Release.Namespace }}
+  labels:
+    control-plane: controller-manager
+    component: controller-manager
+    app.kubernetes.io/component: controller-manager
+  {{- include "vso.chart.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.defaultAuthGlobal.defaultVaultNamespace }}
+  defaultVaultNamespace: {{ .Values.defaultAuthGlobal.defaultVaultNamespace }}
+  {{- end }}
+  {{- if .Values.defaultAuthGlobal.allowedNamespaces }}
+  allowedNamespaces:
+  {{- toYaml .Values.defaultAuthGlobal.allowedNamespaces | nindent 4 }}
+  {{- end }}
+  defaultAuthMethod: {{ .Values.defaultAuthGlobal.defaultAuthMethod }}
+  defaultMount: {{ .Values.defaultAuthGlobal.defaultMount }}
+  {{- if .Values.defaultAuthGlobal.methods }}
+  {{- toYaml .Values.defaultAuthGlobal.methods | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/extra-manifests.yaml
+++ b/chart/templates/extra-manifests.yaml
@@ -1,0 +1,9 @@
+{{- /*
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+*/ -}}
+
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -909,6 +909,12 @@ hooks:
     # @type: string
     executionTimeout: 30s
 
+# A list of additional kubernetes manifests to be installed alongside the operator.
+# For example, this could be used to install a Secret containing the CA certificate referenced in the default VaultConnection.
+# @type: array
+extraManifests: []
+
+
 ## Used by unit tests, and will not be rendered except when using `helm template`, this can be safely ignored.
 tests:
   # @type: boolean

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -780,6 +780,61 @@ defaultAuthMethod:
       params: none
 
 
+# Configures and deploys the default VaultAuthGlobal CR. The name is 'default' and will
+# always be installed in the same namespace as the operator.
+# NOTE:
+# * It is strongly recommended to deploy the vault secrets operator in a secure Vault environment
+#   which includes a configuration utilizing TLS and installing Vault into its own restricted namespace.
+defaultAuthGlobal:
+  # toggles the deployment of the VaultAuthGlobal CR
+  # @type: boolean
+  enabled: false
+
+  # Default Vault namespace for the VaultAuthGlobal CR
+  # @type: string
+  defaultVaultNamespace: ""
+
+  # Kubernetes namespace glob patterns which are allow-listed for use with the default VaultAuthGlobal.
+  # @type: array<string>
+  allowedNamespaces: []
+
+  # Default Vault Auth method to be used with the VaultAuthGlobal CR
+  # @type: string
+  defaultAuthMethod: kubernetes
+
+  # Default Mount path for the Vault Auth Method.
+  # @type: string
+  defaultMount: kubernetes
+
+  # Params to use when authenticating to Vault
+  # params:
+  #   param-something1: "foo"
+  # @type: map
+  params: {}
+
+  # Headers to be included in all Vault requests.
+  # headers:
+  #   X-vault-something1: "foo"
+  # @type: map
+  headers: {}
+
+  # Vault Auth method settings to include in the VaultAuthGlobal CR.
+  # The value is a map of auth methods (kubernetes, jwt, appRole, aws and gcp) and its configuration spec.
+  # ref:
+  # - https://developer.hashicorp.com/vault/docs/platform/k8s/vso/api-reference#vaultauthglobalconfigkubernetes
+  # - https://developer.hashicorp.com/vault/docs/platform/k8s/vso/api-reference#vaultauthglobalconfigjwt
+  # - https://developer.hashicorp.com/vault/docs/platform/k8s/vso/api-reference#vaultauthglobalconfigapprole
+  # - https://developer.hashicorp.com/vault/docs/platform/k8s/vso/api-reference#vaultauthglobalconfigaws
+  # - https://developer.hashicorp.com/vault/docs/platform/k8s/vso/api-reference#vaultauthglobalconfiggcp
+  # @type: map
+  # Example:
+  # methods:
+  #  kubernetes:
+  #    role: "auth-role"
+  #    serviceAccount: "default"
+  methods: {}
+
+
 # Configures a Prometheus ServiceMonitor
 telemetry:
   serviceMonitor:


### PR DESCRIPTION
The helm chart currently contains some templates to deploy default resources for `VaultConnection` and `VaultAuth`. Since the operator also supports a default `VaultAuthGlobal` resource in the namespaces of the controller, it would be great to have a template for that as well.

Additionally, it would be convenient to have a possibility to install some generic manifests together with the helm chart. This could be used for example to install a Secret containing the vault ca-certificate, which is required by the default `VaultConnection`. There might also be other use-cases where generics manifests are helpful.

Please let me know what you think about these changes.