### PR TITLE
[PSA-2298] bump kube-rbac-proxy to 0.18.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.0.0-dev
-KUBE_RBAC_PROXY_VERSION = v0.15.0
+KUBE_RBAC_PROXY_VERSION = v0.18.1
 
 GO_VERSION = $(shell cat .go-version)
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -121,7 +121,7 @@ controller:
     image:
       pullPolicy: IfNotPresent
       repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.15.0
+      tag: v0.18.1
 
     # Configures the default resources for the kube rbac proxy container.
     # For more information on configuring resources, see the K8s documentation:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -120,7 +120,7 @@ controller:
     # Image sets the repo and tag of the kube-rbac-proxy image to use for the controller.
     image:
       pullPolicy: IfNotPresent
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
+      repository: quay.io/brancz/kube-rbac-proxy
       tag: v0.18.1
 
     # Configures the default resources for the kube rbac proxy container.

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,7 +19,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.18.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,7 +19,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.18.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
Bumping kube-rbac-proxy to 0.18.1 which solves multiple vulnerabilities.

https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.18.1