### PR TITLE
CI: use dependabot groups for Go deps

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,6 +15,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      gomod-breaking:
+        update-types:
+          - major
+      gomod-backward-compatible:
+        update-types:
+          - minor
+          - patch
     # Disable version updates and only check security updates for github
     # actions, since we can't bump the versions until they're on our allow-list
     open-pull-requests-limit: 0

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,10 +11,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
     groups:
       gomod-breaking:
         update-types:
@@ -23,6 +19,10 @@ updates:
         update-types:
           - minor
           - patch
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
     # Disable version updates and only check security updates for github
     # actions, since we can't bump the versions until they're on our allow-list
     open-pull-requests-limit: 0


### PR DESCRIPTION
Follows the work done in vault-csi-provider project: https://github.com/hashicorp/vault-csi-provider/blob/f8fdfd37090297e07a2796b44023bb6c02f12793/.github/dependabot.yaml#L15-L22

Hopefully this will reduce the number of Dependabot PRs and make those PRs more reliable in the case where some dependency update is incomplete.