### PR TITLE
VSS/instant-updates: Improve filtering of kv-v2 events

### DIFF
--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -469,10 +469,14 @@ func (r *VaultStaticSecretReconciler) streamStaticSecretEvents(ctx context.Conte
 				if o.Spec.Type == consts.KVSecretTypeV2 {
 					specPath = strings.Join([]string{o.Spec.Mount, "data", o.Spec.Path}, "/")
 				}
+				specNamespace := strings.Trim(o.Spec.Namespace, "/")
+				if o.Spec.Namespace == "" {
+					specNamespace = strings.Trim(wsClient.Namespace(), "/")
+				}
 				logger.V(consts.LogLevelTrace).Info("modified Event received from Vault",
-					"namespace", namespace, "path", path, "spec.namespace", o.Spec.Namespace,
+					"namespace", namespace, "path", path, "spec.namespace", specNamespace,
 					"spec path", specPath)
-				if namespace == o.Spec.Namespace && path == specPath {
+				if namespace == specNamespace && path == specPath {
 					logger.V(consts.LogLevelDebug).Info("Event matches, sending requeue",
 						"namespace", namespace, "path", path)
 					r.SourceCh <- event.GenericEvent{

--- a/vault/websocket.go
+++ b/vault/websocket.go
@@ -110,3 +110,9 @@ func (w *WebsocketClient) Connect(ctx context.Context) (*websocket.Conn, error) 
 
 	return conn, nil
 }
+
+// Namespace returns the namespace associated with the client.
+// If no namespace is set, an empty string is returned.
+func (w *WebsocketClient) Namespace() string {
+	return w.Headers.Get(api.NamespaceHeaderName)
+}


### PR DESCRIPTION
The VSS controller drops some events of kv-v2 secrets because it expects a wrong path to be set. Most events use the pattern `<secret-mount>/data/<secret-path>`, but some operations, like delete and undelete, will include the operation instead of `data` in its path. Therefore, it would be better if the controller also accepts `<secret-mount>/<operation>/<secret-path>` as a valid path.

Additionally, it would be helpful if the controller uses the namespaces configured in the referenced VaultAuth resource as fallback while filtering the events. This would reduce the required configuration if authentication and secrets are in the same namespace.