### PR TITLE
VSS: Add requeue configuration flags

### DIFF
--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -49,6 +49,7 @@ type VaultStaticSecretReconciler struct {
 	ClientFactory               vault.ClientFactory
 	SecretDataBuilder           *helpers.SecretDataBuilder
 	HMACValidator               helpers.HMACValidator
+	HMACHorizon                 time.Duration
 	referenceCache              ResourceReferenceCache
 	GlobalTransformationOptions *helpers.GlobalTransformationOptions
 	BackOffRegistry             *BackOffRegistry
@@ -153,8 +154,7 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		// we want to ensure that requeueAfter is set so that we can perform the proper drift detection during each reconciliation.
 		// setting up a watcher on the Secret is also possibility, but polling seems to be the simplest approach for now.
 		if requeueAfter == 0 {
-			// hardcoding a default horizon here, perhaps we will want to make this value public?
-			requeueAfter = computeHorizonWithJitter(time.Second * 60)
+			requeueAfter = computeHorizonWithJitter(r.HMACHorizon)
 		}
 
 		// doRolloutRestart only if this is not the first time this secret has been synced

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -51,6 +51,7 @@ type VaultStaticSecretReconciler struct {
 	HMACValidator               helpers.HMACValidator
 	HMACHorizon                 time.Duration
 	MinRefreshAfter             time.Duration
+	DefaultRefreshAfter         time.Duration
 	referenceCache              ResourceReferenceCache
 	GlobalTransformationOptions *helpers.GlobalTransformationOptions
 	BackOffRegistry             *BackOffRegistry
@@ -109,6 +110,8 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{RequeueAfter: computeHorizonWithJitter(requeueDurationOnError)}, nil
 		}
 		requeueAfter = computeHorizonWithJitter(d)
+	} else if r.DefaultRefreshAfter > 0 {
+		requeueAfter = computeHorizonWithJitter(r.DefaultRefreshAfter)
 	}
 
 	r.referenceCache.Set(SecretTransformation, req.NamespacedName,

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -50,6 +50,7 @@ type VaultStaticSecretReconciler struct {
 	SecretDataBuilder           *helpers.SecretDataBuilder
 	HMACValidator               helpers.HMACValidator
 	HMACHorizon                 time.Duration
+	MinRefreshAfter             time.Duration
 	referenceCache              ResourceReferenceCache
 	GlobalTransformationOptions *helpers.GlobalTransformationOptions
 	BackOffRegistry             *BackOffRegistry
@@ -100,7 +101,7 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	var requeueAfter time.Duration
 	if o.Spec.RefreshAfter != "" {
-		d, err := parseDurationString(o.Spec.RefreshAfter, ".spec.refreshAfter", 0)
+		d, err := parseDurationString(o.Spec.RefreshAfter, ".spec.refreshAfter", r.MinRefreshAfter)
 		if err != nil {
 			logger.Error(err, "Field validation failed")
 			r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonVaultStaticSecret,

--- a/main.go
+++ b/main.go
@@ -139,6 +139,7 @@ func main() {
 	var minRefreshAfterHVSA time.Duration
 	var hmacHorizonVSS time.Duration
 	var minRefreshAfterVSS time.Duration
+	var defaultRefreshAfterVSS time.Duration
 	var globalTransformationOpts string
 	var globalVaultAuthOpts string
 	var backoffInitialInterval time.Duration
@@ -179,6 +180,8 @@ func main() {
 		"Duration between VaultStaticSecret resource reconciliation, when using HMAC.")
 	flag.DurationVar(&minRefreshAfterVSS, "min-refresh-after-vss", 0,
 		"Minimum duration between VaultStaticSecret resource reconciliation.")
+	flag.DurationVar(&defaultRefreshAfterVSS, "default-refresh-after-vss", 0,
+		"Global default for refreshAfter of VaultStaticSecret resources. Set to 0 to disable.")
 	flag.StringVar(&globalTransformationOpts, "global-transformation-options", "",
 		fmt.Sprintf("Set global secret transformation options as a comma delimited string. "+
 			"Also set from environment variable VSO_GLOBAL_TRANSFORMATION_OPTIONS. "+
@@ -457,6 +460,7 @@ func main() {
 		HMACValidator:               hmacValidator,
 		HMACHorizon:                 hmacHorizonVSS,
 		MinRefreshAfter:             minRefreshAfterVSS,
+		DefaultRefreshAfter:         defaultRefreshAfterVSS,
 		ClientFactory:               clientFactory,
 		BackOffRegistry:             controllers.NewBackOffRegistry(backoffOpts...),
 		GlobalTransformationOptions: globalTransOptions,

--- a/main.go
+++ b/main.go
@@ -137,6 +137,7 @@ func main() {
 	var uninstall bool
 	var preDeleteHookTimeoutSeconds int
 	var minRefreshAfterHVSA time.Duration
+	var hmacHorizonVSS time.Duration
 	var globalTransformationOpts string
 	var globalVaultAuthOpts string
 	var backoffInitialInterval time.Duration
@@ -173,6 +174,8 @@ func main() {
 		"Pre-delete hook timeout in seconds")
 	flag.DurationVar(&minRefreshAfterHVSA, "min-refresh-after-hvsa", time.Second*30,
 		"Minimum duration between HCPVaultSecretsApp resource reconciliation.")
+	flag.DurationVar(&hmacHorizonVSS, "hmac-horizon-vss", time.Second*60,
+		"Duration between VaultStaticSecret resource reconciliation, when using HMAC.")
 	flag.StringVar(&globalTransformationOpts, "global-transformation-options", "",
 		fmt.Sprintf("Set global secret transformation options as a comma delimited string. "+
 			"Also set from environment variable VSO_GLOBAL_TRANSFORMATION_OPTIONS. "+
@@ -449,6 +452,7 @@ func main() {
 		Recorder:                    mgr.GetEventRecorderFor("VaultStaticSecret"),
 		SecretDataBuilder:           secretDataBuilder,
 		HMACValidator:               hmacValidator,
+		HMACHorizon:                 hmacHorizonVSS,
 		ClientFactory:               clientFactory,
 		BackOffRegistry:             controllers.NewBackOffRegistry(backoffOpts...),
 		GlobalTransformationOptions: globalTransOptions,

--- a/main.go
+++ b/main.go
@@ -138,6 +138,7 @@ func main() {
 	var preDeleteHookTimeoutSeconds int
 	var minRefreshAfterHVSA time.Duration
 	var hmacHorizonVSS time.Duration
+	var minRefreshAfterVSS time.Duration
 	var globalTransformationOpts string
 	var globalVaultAuthOpts string
 	var backoffInitialInterval time.Duration
@@ -176,6 +177,8 @@ func main() {
 		"Minimum duration between HCPVaultSecretsApp resource reconciliation.")
 	flag.DurationVar(&hmacHorizonVSS, "hmac-horizon-vss", time.Second*60,
 		"Duration between VaultStaticSecret resource reconciliation, when using HMAC.")
+	flag.DurationVar(&minRefreshAfterVSS, "min-refresh-after-vss", 0,
+		"Minimum duration between VaultStaticSecret resource reconciliation.")
 	flag.StringVar(&globalTransformationOpts, "global-transformation-options", "",
 		fmt.Sprintf("Set global secret transformation options as a comma delimited string. "+
 			"Also set from environment variable VSO_GLOBAL_TRANSFORMATION_OPTIONS. "+
@@ -453,6 +456,7 @@ func main() {
 		SecretDataBuilder:           secretDataBuilder,
 		HMACValidator:               hmacValidator,
 		HMACHorizon:                 hmacHorizonVSS,
+		MinRefreshAfter:             minRefreshAfterVSS,
 		ClientFactory:               clientFactory,
 		BackOffRegistry:             controllers.NewBackOffRegistry(backoffOpts...),
 		GlobalTransformationOptions: globalTransOptions,


### PR DESCRIPTION
When operating the vault-secrets-operator for multiple development teams, it would be great to have some more detailed control over the refresh interval of VaultStaticSecrets and the possible load that could be caused on the Vault server. Therefore, I would like to add the following parameters:
- `--min-refresh-after-vss` - To prevent users from trying to update secrets every second and causing a high load on the Vault server.
- `--default-refresh-after-vss` - To provide a cluster-wide default value for the refresh interval of VaultStaticSecrets for more convenience.
- `--hmac-horizon-vss` - To use some larger interval before the next drift detection happens in case most VaultStaticSecrets rely on instant updates.