### PR TITLE
Include dynamic/rotating values in K8s secret data

### DIFF
--- a/helpers/secrets.go
+++ b/helpers/secrets.go
@@ -516,7 +516,12 @@ func (s *SecretDataBuilder) WithHVSAppSecrets(resp *hvsclient.OpenAppSecretsOK, 
 				prefixedKey := fmt.Sprintf("%s_%s", v.Name, rotatingKey)
 				secrets[prefixedKey] = rotatingValue
 			}
-			secrets[v.Name] = v.RotatingVersion.Values
+
+			vals := make(map[string]any, len(v.RotatingVersion.Values))
+			for k, v := range v.RotatingVersion.Values {
+				vals[k] = v
+			}
+			secrets[v.Name] = vals
 		case HVSSecretTypeDynamic:
 			if v.DynamicInstance == nil {
 				return nil, fmt.Errorf("dynamic secret %s has no DynamicInstance", v.Name)
@@ -527,7 +532,12 @@ func (s *SecretDataBuilder) WithHVSAppSecrets(resp *hvsclient.OpenAppSecretsOK, 
 				prefixedKey := fmt.Sprintf("%s_%s", v.Name, dynamicKey)
 				secrets[prefixedKey] = dynamicValue
 			}
-			secrets[v.Name] = v.DynamicInstance.Values
+
+			vals := make(map[string]any, len(v.DynamicInstance.Values))
+			for k, v := range v.DynamicInstance.Values {
+				vals[k] = v
+			}
+			secrets[v.Name] = vals
 		default:
 			continue
 		}

--- a/helpers/secrets.go
+++ b/helpers/secrets.go
@@ -507,19 +507,27 @@ func (s *SecretDataBuilder) WithHVSAppSecrets(resp *hvsclient.OpenAppSecretsOK, 
 		case HVSSecretTypeKV:
 			secrets[v.Name] = v.StaticVersion.Value
 		case HVSSecretTypeRotating:
+			if v.RotatingVersion == nil {
+				return nil, fmt.Errorf("rotating secret %s has no RotatingVersion", v.Name)
+			}
 			// Since rotating secrets have multiple values, prefix each key with
 			// the secret name to avoid collisions.
 			for rotatingKey, rotatingValue := range v.RotatingVersion.Values {
 				prefixedKey := fmt.Sprintf("%s_%s", v.Name, rotatingKey)
 				secrets[prefixedKey] = rotatingValue
 			}
+			secrets[v.Name] = v.RotatingVersion.Values
 		case HVSSecretTypeDynamic:
+			if v.DynamicInstance == nil {
+				return nil, fmt.Errorf("dynamic secret %s has no DynamicInstance", v.Name)
+			}
 			// Since dynamic secrets have multiple values, prefix each key with
 			// the secret name to avoid collisions.
 			for dynamicKey, dynamicValue := range v.DynamicInstance.Values {
 				prefixedKey := fmt.Sprintf("%s_%s", v.Name, dynamicKey)
 				secrets[prefixedKey] = dynamicValue
 			}
+			secrets[v.Name] = v.DynamicInstance.Values
 		default:
 			continue
 		}
@@ -563,6 +571,15 @@ func (s *SecretDataBuilder) makeHVSMetadata(v *models.Secrets20231128OpenSecret)
 	var ss models.Secrets20231128Secret
 	if err := json.Unmarshal(b, &ss); err != nil {
 		return nil, err
+	}
+
+	if v.Type == HVSSecretTypeDynamic {
+		// open dynamic secrets do not share the same fields as the non-open secrets, so
+		// we need to convert them here.
+		if ss.DynamicConfig == nil {
+			ss.DynamicConfig = &models.Secrets20231128SecretDynamicConfig{}
+		}
+		ss.DynamicConfig.TTL = v.DynamicInstance.TTL
 	}
 
 	sv, err := ss.MarshalBinary()

--- a/helpers/secrets_test.go
+++ b/helpers/secrets_test.go
@@ -1327,12 +1327,41 @@ func TestSecretDataBuilder_WithHVSAppSecrets(t *testing.T) {
 					},
 					Type: HVSSecretTypeRotating,
 				},
+				{
+					CreatedAt:     strfmt.NewDateTime(),
+					CreatedByID:   "vso-3 uuid",
+					LatestVersion: 1,
+					Name:          "dyn",
+					Provider:      "providerfoo",
+					SyncStatus:    nil,
+					DynamicInstance: &models.Secrets20231128OpenSecretDynamicInstance{
+						TTL:       "1h",
+						CreatedAt: strfmt.DateTime{},
+						ExpiresAt: strfmt.DateTime{},
+						Values: map[string]string{
+							"val_one": "123456",
+							"val_two": "654321",
+						},
+					},
+					Type: HVSSecretTypeDynamic,
+				},
 			},
 		},
 	}
 
 	rawValid, err := respValid.GetPayload().MarshalBinary()
 	require.NoError(t, err)
+
+	rotatingValueRaw, err := marshalJSON(map[string]string{
+		"api_key_one": "123456",
+		"api_key_two": "654321",
+	})
+	require.NoError(t, err)
+
+	dynValueRaw, err := marshalJSON(map[string]string{
+		"val_one": "123456",
+		"val_two": "654321",
+	})
 
 	respValidUnsupportedType := &hvsclient.OpenAppSecretsOK{
 		Payload: &models.Secrets20231128OpenAppSecretsResponse{
@@ -1393,6 +1422,10 @@ func TestSecretDataBuilder_WithHVSAppSecrets(t *testing.T) {
 				"foo":                     []byte("qux"),
 				"rotatingfoo_api_key_one": []byte("123456"),
 				"rotatingfoo_api_key_two": []byte("654321"),
+				"rotatingfoo":             rotatingValueRaw,
+				"dyn":                     dynValueRaw,
+				"dyn_val_one":             []byte("123456"),
+				"dyn_val_two":             []byte("654321"),
 				SecretDataKeyRaw:          rawValid,
 			},
 			wantErr: assert.NoError,
@@ -1416,6 +1449,10 @@ func TestSecretDataBuilder_WithHVSAppSecrets(t *testing.T) {
 				"foo":                     []byte("qux"),
 				"rotatingfoo_api_key_one": []byte("123456"),
 				"rotatingfoo_api_key_two": []byte("654321"),
+				"rotatingfoo":             rotatingValueRaw,
+				"dyn":                     dynValueRaw,
+				"dyn_val_one":             []byte("123456"),
+				"dyn_val_two":             []byte("654321"),
 				SecretDataKeyRaw:          rawValid,
 			},
 			wantErr: assert.NoError,
@@ -1445,6 +1482,16 @@ func TestSecretDataBuilder_WithHVSAppSecrets(t *testing.T) {
       "version": 1
     },
     "type": "kv"
+  },
+  "dyn": {
+    "created_at": "1970-01-01T00:00:00.000Z",
+    "dynamic_config": {
+      "ttl": "1h"
+    },
+    "latest_version": 1,
+    "name": "dyn",
+    "provider": "providerfoo",
+    "type": "dynamic"
   },
   "foo": {
     "created_at": "1970-01-01T00:00:00.000Z",
@@ -1479,6 +1526,10 @@ func TestSecretDataBuilder_WithHVSAppSecrets(t *testing.T) {
 				"foo":                     []byte("qux"),
 				"rotatingfoo_api_key_one": []byte("123456"),
 				"rotatingfoo_api_key_two": []byte("654321"),
+				"rotatingfoo":             rotatingValueRaw,
+				"dyn":                     dynValueRaw,
+				"dyn_val_one":             []byte("123456"),
+				"dyn_val_two":             []byte("654321"),
 				SecretDataKeyRaw:          rawValid,
 			},
 			wantErr: assert.NoError,
@@ -1500,6 +1551,9 @@ func TestSecretDataBuilder_WithHVSAppSecrets(t *testing.T) {
 			},
 			want: map[string][]byte{
 				"bar":            []byte("FOO"),
+				"dyn":            dynValueRaw,
+				"dyn_val_one":    []byte("123456"),
+				"dyn_val_two":    []byte("654321"),
 				SecretDataKeyRaw: rawValid,
 			},
 			wantErr: assert.NoError,
@@ -1514,6 +1568,7 @@ func TestSecretDataBuilder_WithHVSAppSecrets(t *testing.T) {
 				"foo":                     []byte("qux"),
 				"rotatingfoo_api_key_one": []byte("123456"),
 				"rotatingfoo_api_key_two": []byte("654321"),
+				"rotatingfoo":             rotatingValueRaw,
 				SecretDataKeyRaw:          rawValid,
 			},
 			wantErr: assert.NoError,
@@ -1526,6 +1581,9 @@ func TestSecretDataBuilder_WithHVSAppSecrets(t *testing.T) {
 			},
 			want: map[string][]byte{
 				"bar":            []byte("foo"),
+				"dyn":            dynValueRaw,
+				"dyn_val_one":    []byte("123456"),
+				"dyn_val_two":    []byte("654321"),
 				SecretDataKeyRaw: rawValid,
 			},
 			wantErr: assert.NoError,
@@ -1569,6 +1627,10 @@ func TestSecretDataBuilder_WithHVSAppSecrets(t *testing.T) {
 				"foo":                     []byte("qux"),
 				"rotatingfoo_api_key_one": []byte("123456"),
 				"rotatingfoo_api_key_two": []byte("654321"),
+				"rotatingfoo":             rotatingValueRaw,
+				"dyn":                     dynValueRaw,
+				"dyn_val_one":             []byte("123456"),
+				"dyn_val_two":             []byte("654321"),
 			},
 			wantErr: assert.NoError,
 		},
@@ -1580,6 +1642,7 @@ func TestSecretDataBuilder_WithHVSAppSecrets(t *testing.T) {
 
 			s := &SecretDataBuilder{}
 			got, err := s.WithHVSAppSecrets(tt.resp, tt.opt)
+			assert.Equalf(t, tt.want["metadata.json"], got["metadata.json"], "WithHVSAppSecrets(%v, %v)", tt.resp, tt.opt)
 			if !tt.wantErr(t, err, fmt.Sprintf("WithHVSAppSecrets(%v, %v)", tt.resp, tt.opt)) {
 				return
 			}

--- a/helpers/secrets_test.go
+++ b/helpers/secrets_test.go
@@ -1565,7 +1565,7 @@ func TestSecretDataBuilder_WithHVSAppSecrets(t *testing.T) {
 						Key: "dyn_template_val_two",
 						Template: secretsv1beta1.Template{
 							Name: "tmpl3",
-							Text: `{{- get (get .Secrets "dyn") "val_two" -}}`,
+							Text: `{{- dig "dyn" "val_two" "<missing>" .Secrets -}}`,
 						},
 					},
 				},


### PR DESCRIPTION
Include the values for dynamic and rotating secrets in the destination k8s data. The previous behavior of including prefixed/flattened key values is preserved.

Other fixes:
- guard against nil RotatingVersion and DynamicInstance
- add DynamicInstance tests
- include valid DynamicInstance metadata
