### PR TITLE
Extract swagger and openapi specs

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -44,6 +44,10 @@ inputs:
   github-token:
     description: 'GitHub token'
     required: true
+  publish-swagger:
+    description: 'Optional: Publish Swagger and OpenAPI spec artifacts'
+    required: false
+    default: false  
 runs:
   using: "composite"
   steps:
@@ -115,6 +119,34 @@ runs:
           export VAULT_IMAGE_TAG='${{ inputs.vault-version }}-ent'
         fi
         make $make_target VERSION=${{ inputs.version }} INTEGRATION_TESTS_PARALLEL=true SUPPRESS_TF_OUTPUT=true EXPORT_KIND_LOGS_ROOT=${{ steps.create_kind_export_log_root.outputs.log_root }}
+    - name: Setup kubectl
+      if: success()
+      uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4.0.0
+      with:
+        version: latest
+    - name: Install swagger2openapi
+      if: success()
+      run: |
+      npm install -g swagger2openapi    
+    - name: Retrieve and convert Kubernetes Swagger spec
+      if: success()
+      run: |
+        kubectl proxy &
+        sleep 5
+        curl http://localhost:8001/openapi/v2 > build/k8s-swagger-v2.json
+        swagger2openapi --outfile build/k8s-openapi-v3.json build/k8s-swagger-v2.json
+    - name: Store k8s-swagger-v2.json artifact
+      if: success() && inputs.publish-swagger == 'true'
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      with:
+        name: k8s-swagger-v2.json
+        path: build/k8s-swagger-v2.json
+    - name: Store k8s-openapi-v3.json artifact
+      if: success() && inputs.publish-swagger == 'true'
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      with:
+        name: k8s-openapi-v3.json
+        path: build/k8s-openapi-v3.json
     - name: Store kind cluster logs
       if: success()
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -126,10 +126,12 @@ runs:
         version: latest
     - name: Install swagger2openapi
       if: success()
+      shell: bash
       run: |
         npm install -g swagger2openapi    
     - name: Retrieve and convert Kubernetes Swagger spec
       if: success()
+      shell: bash
       run: |
         kubectl proxy &
         sleep 5

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -127,7 +127,7 @@ runs:
     - name: Install swagger2openapi
       if: success()
       run: |
-      npm install -g swagger2openapi    
+        npm install -g swagger2openapi    
     - name: Retrieve and convert Kubernetes Swagger spec
       if: success()
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -418,6 +418,7 @@ jobs:
           hcp-client-secret: ${{ secrets.HCP_CLIENT_SECRET }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           log-prefix: "latest-k8s-"
+          publish-swagger: "true"
 
   # This job is used as a requirement for the repo's branch protection setup.
   build-done:


### PR DESCRIPTION
This PR automates the retrieval and conversion of the Kubernetes Swagger v2 spec to OpenAPI v3 within the VSO build workflow, only executing these steps after successful integration tests. It conditionally publishes the artifacts based on a new publish-swagger input, and manually installs kubectl to comply with organization restrictions. 

current issue:
I need to setup `kubectl`, but I can't do that currently cause the `azure/setup-kubectl` action isn't allowed. If we can't allow it, we can still install `kubectl` manually 
```
- name: Install kubectl
  shell: bash
  run: |
    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
    chmod +x kubectl
    sudo mv kubectl /usr/local/bin/
    kubectl version --client
```
