### PR TITLE
Fix pattern: regex to support days (d)

### DIFF
--- a/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -216,7 +216,7 @@ spec:
                   ExpiryOffset to use for computing when the certificate should be renewed.
                   The rotation time will be difference between the expiration and the offset.
                   Should be in duration notation e.g. 30s, 120s, etc.
-                pattern: ^([0-9]+(\.[0-9]+)?(s|m|h))$
+                pattern: ^([0-9]+(\.[0-9]+)?(s|m|h|d))$
                 type: string
               format:
                 description: |-
@@ -316,7 +316,7 @@ spec:
                   Note: this only has an effect when generating a CA cert or signing a CA cert,
                   not when generating a CSR for an intermediate CA.
                   Should be in duration notation e.g. 120s, 2h, etc.
-                pattern: ^([0-9]+(\.[0-9]+)?(s|m|h))$
+                pattern: ^([0-9]+(\.[0-9]+)?(s|m|h|d))$
                 type: string
               uriSans:
                 description: The requested URI SANs.


### PR DESCRIPTION
While Vault API supports setting ttl and expiryOffset with d suffix CRD is not supporting that.