### PR TITLE
CRT: suppress GO-2022-0635

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -4,13 +4,28 @@
 container {
 	dependencies = true
 	alpine_secdb = true
-	secrets      = true
+	secrets {
+		all = true
+	}
 }
 
 binary {
-	secrets      = true
+	secrets {
+		all = true
+	}
 	go_modules   = true
 	osv          = true
 	oss_index    = false
 	nvd          = false
+	triage {
+		suppress {
+			vulnerabilities = [
+				// GO-2022-0635 is of low severity, and VSO isn't using the affected functionalities
+				// Upgrading to latest version of go-secure-stdlib is not possible at this time.
+				// The required functionality was inadvertently dropped from
+				// github.com/hashicorp/go-secure-stdlib/awsutil during the migration to aws-sdk-go-v2.
+				"GO-2022-0635"
+			]
+		}
+	}
 }


### PR DESCRIPTION
Suppress GO-2022-0635 as it is of low severity and VSO isn't using the affected functionalities

Upgrading to latest version of go-secure-stdlib is not possible at this time. The required functionality was inadvertently dropped from github.com/hashicorp/go-secure-stdlib/awsutil during the migration to aws-sdk-go-v2.

Fixes: https://github.com/hashicorp/crt-workflows-common/actions/runs/12589451224/job/35089570078#step:9:1