### PR TITLE
Add Kubernetes client QPS and Burst configuration support.

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -98,6 +98,12 @@ spec:
         {{- with .Values.controller.manager.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if .Values.controller.manager.kubeClient.qps }}
+        - --kube-client-qps={{ .Values.controller.manager.kubeClient.qps }}
+        {{- end }}
+        {{- if .Values.controller.manager.kubeClient.burst }}
+        - --kube-client-burst={{ .Values.controller.manager.kubeClient.burst }}
+        {{- end }}
         command:
         - /vault-secrets-operator
         env:
@@ -113,7 +119,7 @@ spec:
           value: {{ .Values.controller.kubernetesClusterDomain }}
         {{- range .Values.controller.manager.extraEnv }}
         - name: {{ .name }}
-          value: {{ .value }}
+          value: {{ .value | quote }}
         {{- end }}
         image: {{ .Values.controller.manager.image.repository }}:{{ .Values.controller.manager.image.tag }}
         imagePullPolicy: {{ .Values.controller.manager.image.pullPolicy }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -465,6 +465,21 @@ controller:
     # @type: integer
     maxConcurrentReconciles:
 
+    kubeClient:
+      # QPS indicates the maximum QPS to the kubernetes API.
+      # When the value is 0, the kubernetes client's default is used.
+      # May also set via the `VSO_KUBE_CLIENT_QPS` environment variable.
+      # Default: 0
+      # @type: float
+      qps:
+
+      # Maximum burst for throttling requests to the kubernetes API.
+      # When the value is 0, the kubernetes client's default is used.
+      # May also set via the `VSO_KUBE_CLIENT_BURST` environment variable.
+      # Default: 0
+      # @type: int
+      burst:
+
     # Defines additional environment variables to be added to the
     # vault-secrets-operator manager container.
     # Example:

--- a/internal/options/env.go
+++ b/internal/options/env.go
@@ -49,6 +49,12 @@ type VSOEnvOptions struct {
 
 	// ClientCacheNumLocks is VSO_CLIENT_CACHE_NUM_LOCKS environment variable option
 	ClientCacheNumLocks *int `split_words:"true"`
+
+	// KubeClientQPS is the VSO_KUBE_CLIENT_QPS environment variable option
+	KubeClientQPS float64 `split_words:"true"`
+
+	// KubeClientBurst is the VSO_KUBE_CLIENT_BURST environment variable option
+	KubeClientBurst *int `split_words:"true"`
 }
 
 // Parse environment variable options, prefixed with "VSO_"

--- a/internal/options/env_test.go
+++ b/internal/options/env_test.go
@@ -35,6 +35,8 @@ func TestParse(t *testing.T) {
 				"VSO_GLOBAL_TRANSFORMATION_OPTIONS":  "gOpt1,gOpt2",
 				"VSO_GLOBAL_VAULT_AUTH_OPTIONS":      "vOpt1,vOpt2",
 				"VSO_CLIENT_CACHE_NUM_LOCKS":         "10",
+				"VSO_KUBE_CLIENT_QPS":                "100",
+				"VSO_KUBE_CLIENT_BURST":              "1000",
 			},
 			wantOptions: VSOEnvOptions{
 				OutputFormat:                "json",
@@ -49,6 +51,8 @@ func TestParse(t *testing.T) {
 				GlobalTransformationOptions: []string{"gOpt1", "gOpt2"},
 				GlobalVaultAuthOptions:      []string{"vOpt1", "vOpt2"},
 				ClientCacheNumLocks:         ptr.To(10),
+				KubeClientQPS:               100,
+				KubeClientBurst:             ptr.To(1000),
 			},
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -145,6 +145,8 @@ func main() {
 	var backoffRandomizationFactor float64
 	var backoffMultiplier float64
 	var backoffMaxElapsedTime time.Duration
+	var kubeClientQPS float64
+	var kubeClientBurst int
 
 	// command-line args and flags
 	flag.BoolVar(&printVersion, "version", false, "Print the operator version information")
@@ -214,6 +216,14 @@ func main() {
 			"All errors are tried using an exponential backoff strategy. "+
 			"The value must be greater than zero. "+
 			"Also set from environment variable VSO_BACKOFF_MULTIPLIER.")
+	flag.Float64Var(&kubeClientQPS, "kube-client-qps", 0,
+		"QPS indicates the maximum QPS to the kubernetes API. "+
+			"When the value is 0, the kubernetes client's default is used."+
+			"Also set from environment variable VSO_KUBE_CLIENT_QPS.")
+	flag.IntVar(&kubeClientBurst, "kube-client-burst", 0,
+		"Maximum burst for throttling requests to the kubernetes API."+
+			"When the value is 0, the kubernetes client's default is used."+
+			"Also set from environment variable VSO_KUBE_CLIENT_BURST.")
 
 	opts := zap.Options{
 		Development: os.Getenv("VSO_LOGGER_DEVELOPMENT_MODE") != "",
@@ -266,6 +276,12 @@ func main() {
 		globalVaultAuthOptsSet = vsoEnvOptions.GlobalVaultAuthOptions
 	} else if globalVaultAuthOpts != "" {
 		globalVaultAuthOptsSet = strings.Split(globalVaultAuthOpts, ",")
+	}
+	if vsoEnvOptions.KubeClientQPS != 0 {
+		kubeClientQPS = vsoEnvOptions.KubeClientQPS
+	}
+	if vsoEnvOptions.KubeClientBurst != nil {
+		kubeClientBurst = *vsoEnvOptions.KubeClientBurst
 	}
 
 	// versionInfo is used when setting up the buildInfo metric below
@@ -340,6 +356,12 @@ func main() {
 	cfc.GlobalVaultAuthOptions = globalVaultAuthOptions
 
 	config := ctrl.GetConfigOrDie()
+	if kubeClientQPS != 0 {
+		config.QPS = float32(kubeClientQPS)
+	}
+	if kubeClientBurst != 0 {
+		config.Burst = kubeClientBurst
+	}
 
 	defaultClient, err := client.NewWithWatch(config, client.Options{
 		Scheme: scheme,

--- a/test/unit/deployment.bats
+++ b/test/unit/deployment.bats
@@ -1292,3 +1292,60 @@ load _helpers
   [ "$(echo "${job}" | \
   yq '(.spec.template.spec.containers[0].imagePullPolicy == "IfNotPresent")')" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# kubeClient
+
+@test "controller/Deployment: kubeClient qps not set by default" {
+  cd `chart_dir`
+  local object
+  object=$(helm template \
+  -s templates/deployment.yaml  \
+  . | tee /dev/stderr |
+  yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo "$object" | yq 'contains(["--kube-client-qps"])' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "controller/Deployment: kubeClient qps can be set" {
+  cd `chart_dir`
+  local object
+  object=$(helm template \
+  -s templates/deployment.yaml  \
+  --set 'controller.manager.kubeClient.qps=200' \
+  . | tee /dev/stderr |
+  yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo "$object" | yq 'contains(["--kube-client-qps=200"])' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "controller/Deployment: kubeClient burst not set by default" {
+  cd `chart_dir`
+  local object
+  object=$(helm template \
+  -s templates/deployment.yaml  \
+  . | tee /dev/stderr |
+  yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo "$object" | yq 'contains(["--kube-client-burst"])' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "controller/Deployment: kubeClient burst can be set" {
+  cd `chart_dir`
+  local object
+  object=$(helm template \
+  -s templates/deployment.yaml  \
+  --set 'controller.manager.kubeClient.burst=2000' \
+  . | tee /dev/stderr |
+  yq 'select(.kind == "Deployment" and .metadata.labels."control-plane" == "controller-manager") | .spec.template.spec.containers[] | select(.name == "manager") | .args' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo "$object" | yq 'contains(["--kube-client-burst=2000"])' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}


### PR DESCRIPTION
In clusters with many VaultStaticSecrets, the default Kubernetes client QPS of 5 and Burst of 10 is insufficient, leading it to throttle its communications with the Kubernetes API.  This can cause brand-new deployments to roll out very slowly as their pods wait for their Kubernetes secrets to be created from their VaultStaticSecrets.

This change exposes the operator's Kubernetes client QPS and Burst configuration via cli arguments and environment variables, as well as explicitly via chart values.

- adds `--kube-client-qps` and `--kube-client-burst` cli args
- adds `VSO_KUBE_CLIENT_QPS` and `VSO_KUBE_CLIENT_BURST` env var support
- adds `.Values.controller.manager.kubeClient.qps` and `.burst` to chart
- adds chart tests
- fixes chart's handling of `.Values.controller.manager.extraEnv` values