### PR TITLE
Add new Client for caching VSO owned Secrets

### DIFF
--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -72,6 +72,7 @@ type VaultDynamicSecretReconciler struct {
 	// This is done via the downwardAPI. We get the current Pod's UID from either the
 	// OPERATOR_POD_UID environment variable, or the /var/run/podinfo/uid file; in that order.
 	runtimePodUID types.UID
+	SecretsClient client.Client
 }
 
 // +kubebuilder:rbac:groups=secrets.hashicorp.com,resources=vaultdynamicsecrets,verbs=get;list;watch;create;update;patch;delete
@@ -423,7 +424,7 @@ func (r *VaultDynamicSecretReconciler) syncSecret(ctx context.Context, c vault.C
 			delete(dataToMAC, k)
 		}
 
-		macsEqual, messageMAC, err := helpers.HandleSecretHMAC(ctx, r.Client, r.HMACValidator, o, dataToMAC)
+		macsEqual, messageMAC, err := helpers.HandleSecretHMAC(ctx, r.SecretsClient, r.HMACValidator, o, dataToMAC)
 		if err != nil {
 			return nil, false, err
 		}

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -48,6 +48,7 @@ type VaultStaticSecretReconciler struct {
 	Recorder                    record.EventRecorder
 	ClientFactory               vault.ClientFactory
 	SecretDataBuilder           *helpers.SecretDataBuilder
+	SecretsClient               client.Client
 	HMACValidator               helpers.HMACValidator
 	referenceCache              ResourceReferenceCache
 	GlobalTransformationOptions *helpers.GlobalTransformationOptions
@@ -160,7 +161,7 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		// doRolloutRestart only if this is not the first time this secret has been synced
 		doRolloutRestart = o.Status.SecretMAC != ""
 
-		macsEqual, messageMAC, err := helpers.HandleSecretHMAC(ctx, r.Client, r.HMACValidator, o, data)
+		macsEqual, messageMAC, err := helpers.HandleSecretHMAC(ctx, r.SecretsClient, r.HMACValidator, o, data)
 		if err != nil {
 			return ctrl.Result{RequeueAfter: computeHorizonWithJitter(requeueDurationOnError)}, nil
 		}

--- a/helpers/client.go
+++ b/helpers/client.go
@@ -1,0 +1,67 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewSecretsClientForManager creates a new client for interacting with secrets that match
+// the given selector. This client is useful to avoid caching all secrets in a
+// cluster. The client will cache only secrets that match the selector.
+// The ctrl.Manager needs to be started before client can be used.
+func NewSecretsClientForManager(ctx context.Context, mgr ctrl.Manager, selector labels.Selector) (ctrlclient.Client, error) {
+	if selector.Empty() {
+		return nil, fmt.Errorf("selector cannot be empty")
+	}
+
+	scheme := mgr.GetScheme()
+	httpClient := mgr.GetHTTPClient()
+	restMapper := mgr.GetRESTMapper()
+	cacheOpts := cache.Options{
+		ReaderFailOnMissingInformer: true,
+		HTTPClient:                  httpClient,
+		Scheme:                      scheme,
+		Mapper:                      restMapper,
+		ByObject: map[ctrlclient.Object]cache.ByObject{
+			&corev1.Secret{}: {
+				Label: selector,
+			},
+		},
+	}
+
+	newCache, err := cache.New(mgr.GetConfig(), cacheOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := newCache.GetInformer(ctx, &corev1.Secret{}); err != nil {
+		return nil, err
+	}
+
+	if err := mgr.Add(newCache); err != nil {
+		return nil, err
+	}
+
+	client, err := ctrlclient.New(mgr.GetConfig(), ctrlclient.Options{
+		HTTPClient: httpClient,
+		Scheme:     scheme,
+		Mapper:     restMapper,
+		Cache: &ctrlclient.CacheOptions{
+			Reader: newCache,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}

--- a/helpers/secrets.go
+++ b/helpers/secrets.go
@@ -34,6 +34,10 @@ const (
 	HVSSecretTypeKV       = "kv"
 	HVSSecretTypeRotating = "rotating"
 	HVSSecretTypeDynamic  = "dynamic"
+
+	ManagedByLabel = "app.kubernetes.io/managed-by"
+	AppNameLabel   = "app.kubernetes.io/name"
+	ComponentLabel = "app.kubernetes.io/component"
 )
 
 var SecretDataErrorContainsRaw = fmt.Errorf("key '%s' not permitted in Secret data", SecretDataKeyRaw)
@@ -48,10 +52,11 @@ var labelOwnerRefUID = fmt.Sprintf("%s/vso-ownerRefUID", secretsv1beta1.GroupVer
 // intersects with that of other components of the system, since this could lead to data loss.
 //
 // Make OwnerLabels public so that they can be accessed from tests.
+
 var OwnerLabels = map[string]string{
-	"app.kubernetes.io/name":       "vault-secrets-operator",
-	"app.kubernetes.io/managed-by": "hashicorp-vso",
-	"app.kubernetes.io/component":  "secret-sync",
+	ManagedByLabel: "hashicorp-vso",
+	AppNameLabel:   "vault-secrets-operator",
+	ComponentLabel: "secret-sync",
 }
 
 // OwnerLabelsForObj returns the canonical set of labels that should be set on


### PR DESCRIPTION
In #982 we disabled caching of all K8s Secrets to address issue where VSO being OOM killed due to the cluster having a large amount of secret data. That change had the side-effect of increasing the number API calls being made to K8s. This PR should reduce the number of calls needed on a cluster running thousands of Vault*Secret instances.

- [ ] add tests

Closes #1000 