### PR TITLE
Allow running workflows from forked PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches-ignore:
       - 'docs/**'
+  pull_request_target:
+    types:
+      - opened
+      - reopened
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
See https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/approving-workflow-runs-from-public-forks#approving-workflow-runs-on-a-pull-request-from-a-public-fork for more info.