### PR TITLE
Helm vault namespace do not set if empty

### DIFF
--- a/chart/templates/default-transit-auth-method.yaml
+++ b/chart/templates/default-transit-auth-method.yaml
@@ -17,7 +17,9 @@ metadata:
   {{- include "vso.chart.labels" . | nindent 4 }}
 spec:
   vaultConnectionRef: {{ .Values.controller.manager.clientCache.storageEncryption.vaultConnectionRef }}
-  namespace: {{ .Values.controller.manager.clientCache.storageEncryption.namespace }}
+  {{- with .Values.controller.manager.clientCache.storageEncryption.namespace }}
+  namespace: {{ . | quote }}
+  {{- end }}
   method: {{ .Values.controller.manager.clientCache.storageEncryption.method }}
   mount: {{ .Values.controller.manager.clientCache.storageEncryption.mount }}
   {{- $kubeServiceAccount := .Values.controller.manager.clientCache.storageEncryption.kubernetes.serviceAccount | default (printf "%s-controller-manager" (include "vso.chart.fullname" .)) -}}

--- a/chart/templates/default-vault-auth-method.yaml
+++ b/chart/templates/default-vault-auth-method.yaml
@@ -15,7 +15,9 @@ metadata:
     app.kubernetes.io/component: controller-manager
   {{- include "vso.chart.labels" . | nindent 4 }}
 spec:
-  namespace: {{ .Values.defaultAuthMethod.namespace }}
+  {{- with .Values.defaultAuthMethod.namespace }}
+  namespace: {{ . | quote }}
+  {{- end }}
   {{- if .Values.defaultAuthMethod.allowedNamespaces }}
   allowedNamespaces:
   {{- toYaml .Values.defaultAuthMethod.allowedNamespaces | nindent 4 }}


### PR DESCRIPTION
When using server side diff with ArgoCD the default provided vault auths for both transit and the default fail to apply.

This is because they are set to null when rendered by ArgoCD because the value has not been quoted to take into account for empty strings.

ArgoCD will render the namespace as

```yaml
namespace: null
```

which fails to apply because the CRD says it must be a string.

This fix drops the namespace if its not set, which will fix this error for people using argocd with server side diff