### PR TITLE
Fix VDS bug where 2 leases are being generated on initial deployment

### DIFF
--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -396,6 +396,21 @@ func (r *VaultDynamicSecretReconciler) syncSecret(ctx context.Context, c vault.C
 ) (*secretsv1beta1.VaultSecretLease, bool, error) {
 	logger := log.FromContext(ctx).WithName("syncSecret")
 
+	// check if lease already exists
+	if o.Status.SecretLease.ID != "" {
+		logger.V(consts.LogLevelDebug).Info("Lease already exists", "leaseID", o.Status.SecretLease.ID)
+		// if the lease is renewable, renew it
+		if o.Status.SecretLease.Renewable {
+			secretLease, err := r.renewLease(ctx, c, o)
+			if err != nil {
+				logger.Error(err, "Failed to renew lease")
+				return nil, false, err
+			}
+			o.Status.SecretLease = *secretLease
+			return secretLease, false, nil
+		}
+	}
+
 	resp, err := r.doVault(ctx, c, o)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
This PR addresses fixes a bug where two leases were being generated during the initial deployment of VaultDynamicSecret resources. The problem happened because of how the reconciliation logic is handling the scenario where a lease already existed but was being treated as a new lease creation.

With this fix, the operator checks for the existence of a lease and the new behavior is:
1. If the lease exists and is renewable, it will be renewed instead of creating a new lease.
2. If the lease exists but is not renewable, a new lease will be created to ensure valid credentials are available.

This fix prevents the creation of unnecessary leases and ensures that only one active lease exists for ach dynamic secret.

Logs posted in the [ticket](https://hashicorp.atlassian.net/browse/VAULT-35251).