### PR TITLE
Add extra arguments to the kube-rbac-proxy through helm chart values.

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
+        {{- with .Values.controller.kubeRbacProxy.extraArgs }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ .Values.controller.kubernetesClusterDomain }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -136,6 +136,15 @@ controller:
         cpu: 5m
         memory: 64Mi
 
+    # Defines additional commandline arguments to be passed to the kube-rbac-proxy container.
+    # Example:
+    # ```yaml
+    # extraArgs:
+    #   - --client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    # ```
+    # @type: array
+    extraArgs: []
+
   # Image pull secret to use for private container registry authentication which will be applied to the controllers
   # service account. Alternatively, the value may be specified as an array of strings.
   # Example:


### PR DESCRIPTION
Enhance the kube-rbac-proxy configuration by adding additional arguments through the helm chart values.

Fixes https://github.com/hashicorp/vault-secrets-operator/issues/1055