### PR TITLE
helm: fix numLocks incompatible type error

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -340,7 +340,7 @@ clientCache numLocks
 */}}
 {{- define "vso.clientCacheNumLocks" -}}
 {{- with .Values.controller.manager.clientCache -}}
-{{- if or .numLocks (eq .numLocks 0) -}}
+{{- if hasKey . "numLocks" -}}
 --client-cache-num-locks={{ .numLocks }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Got the same error as in #1028 and I thought of solving it this way as I don't understand the reason for the comparison with the value 0.