### PR TITLE
Add OffsetAfter field to VaultDynamicSecret for Rotation Delay

### DIFF
--- a/api/v1beta1/vaultdynamicsecret_types.go
+++ b/api/v1beta1/vaultdynamicsecret_types.go
@@ -70,6 +70,12 @@ type VaultDynamicSecretSpec struct {
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(s|m|h))$`
 	RefreshAfter string `json:"refreshAfter,omitempty"`
+	// OffsetAfter specifies a duration to wait after the completion of a Vault
+	// rotation schedule before syncing the source secret data, in duration notation
+	// e.g. 30s, 1m, 24h. This value is only used when AllowStaticCreds is true.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(s|m|h))$`
+	OffsetAfter string `json:"offsetAfter,omitempty"`
 }
 
 // VaultDynamicSecretStatus defines the observed state of VaultDynamicSecret

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -204,6 +204,13 @@ spec:
                   Namespace of the secrets engine mount in Vault. If not set, the namespace that's
                   part of VaultAuth resource will be inferred.
                 type: string
+              offsetAfter:
+                description: |-
+                  OffsetAfter specifies a duration to wait after the completion of a Vault
+                  rotation schedule before syncing the source secret data, in duration notation
+                  e.g. 30s, 1m, 24h. This value is only used when AllowStaticCreds is true.
+                pattern: ^([0-9]+(\.[0-9]+)?(s|m|h))$
+                type: string
               params:
                 additionalProperties:
                   type: string

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -204,6 +204,13 @@ spec:
                   Namespace of the secrets engine mount in Vault. If not set, the namespace that's
                   part of VaultAuth resource will be inferred.
                 type: string
+              offsetAfter:
+                description: |-
+                  OffsetAfter specifies a duration to wait after the completion of a Vault
+                  rotation schedule before syncing the source secret data, in duration notation
+                  e.g. 30s, 1m, 24h. This value is only used when AllowStaticCreds is true.
+                pattern: ^([0-9]+(\.[0-9]+)?(s|m|h))$
+                type: string
               params:
                 additionalProperties:
                   type: string

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -757,6 +757,10 @@ func getRotationDuration(o *secretsv1beta1.VaultDynamicSecret) time.Duration {
 	var d time.Duration
 	if o.Spec.AllowStaticCreds {
 		d = time.Duration(o.Status.StaticCredsMetaData.TTL) * time.Second
+		if o.Spec.OffsetAfter != "" {
+			offset, _ := parseDurationString(o.Spec.OffsetAfter, ".spec.offsetAfter", 0)
+			d += offset
+		}
 	} else {
 		d = time.Duration(o.Status.SecretLease.LeaseDuration) * time.Second
 		if d <= 0 && o.Spec.RefreshAfter != "" {

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -745,6 +745,21 @@ func Test_computeRotationTime(t *testing.T) {
 			},
 			want: then.Add(time.Minute),
 		},
+		{
+			name: "invalid-offsetAfter-value",
+			vds: &secretsv1beta1.VaultDynamicSecret{
+				Status: secretsv1beta1.VaultDynamicSecretStatus{
+					StaticCredsMetaData: secretsv1beta1.VaultStaticCredsMetaData{
+						TTL: then.Unix(),
+					},
+				},
+				Spec: secretsv1beta1.VaultDynamicSecretSpec{
+					OffsetAfter:      "x",
+					AllowStaticCreds: true,
+				},
+			},
+			want: then,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -730,6 +730,21 @@ func Test_computeRotationTime(t *testing.T) {
 			},
 			want: then,
 		},
+		{
+			name: "rotation-with-one-minute-offset",
+			vds: &secretsv1beta1.VaultDynamicSecret{
+				Status: secretsv1beta1.VaultDynamicSecretStatus{
+					StaticCredsMetaData: secretsv1beta1.VaultStaticCredsMetaData{
+						TTL: then.Unix(),
+					},
+				},
+				Spec: secretsv1beta1.VaultDynamicSecretSpec{
+					OffsetAfter:      "1m",
+					AllowStaticCreds: true,
+				},
+			},
+			want: then.Add(time.Minute),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -1003,6 +1003,7 @@ _Appears in:_
 | `rolloutRestartTargets` _[RolloutRestartTarget](#rolloutrestarttarget) array_ | RolloutRestartTargets should be configured whenever the application(s) consuming the Vault secret does<br />not support dynamically reloading a rotated secret.<br />In that case one, or more RolloutRestartTarget(s) can be configured here. The Operator will<br />trigger a "rollout-restart" for each target whenever the Vault secret changes between reconciliation events.<br />See RolloutRestartTarget for more details. |  |  |
 | `destination` _[Destination](#destination)_ | Destination provides configuration necessary for syncing the Vault secret to Kubernetes. |  |  |
 | `refreshAfter` _string_ | RefreshAfter a period of time for VSO to sync the source secret data, in<br />duration notation e.g. 30s, 1m, 24h. This value only needs to be set when<br />syncing from a secret's engine that does not provide a lease TTL in its<br />response. The value should be within the secret engine's configured ttl or<br />max_ttl. The source secret's lease duration takes precedence over this<br />configuration when it is greater than 0. |  | Pattern: `^([0-9]+(\.[0-9]+)?(s|m|h))$` <br />Type: string <br /> |
+| `offsetAfter` _string_ | OffsetAfter specifies a duration to wait after the completion of a Vault<br />rotation schedule before syncing the source secret data, in duration notation<br />e.g. 30s, 1m, 24h. This value is only used when AllowStaticCreds is true. |  | Pattern: `^([0-9]+(\.[0-9]+)?(s|m|h))$` <br />Type: string <br /> |
 
 
 


### PR DESCRIPTION
## Problem
Currently, VSO only supports time-based secret refreshing through the `refreshAfter` property, which uses a fixed interval. This creates some challenges when working with Vault Static Secrets that have scheduled rotations:
- **Race Conditions**: VSO may fetch secrets during or immediately before Vault's rotation, retrieving old credentials. This happens in things like fetching a new database password.
- **API overhead**: To avoid the above problem, users must then set a `refreshAfter` interval but it can lead to excessive API calls to Vault depending on how many secrets are being rotated and handled.

## Proposed Solution
Introduce an `offsetAfter` property that allows VSO to wait for some duration of time after the completion of Vault's rotation schedule. This property only applies when `allowStaticSecrets: true`.

## Example Usage
```yaml
apiVersion: secrets.hashicorp.com/v1beta1
kind: VaultStaticSecret
metadata:
  name: database-credentials
spec:
  mount: database
  path: static-creds/postgres-app
  allowStaticCreds: true
  offsetAfter: "5m"  # Fetch 5 minutes after rotation completes
  destination:
    name: postgres-secret
    create: true
```

## Behavior
When `offsetAfter`is configured, VSO calculates the rotation duration to be the `TTL + offsetAfter`.