### PR TITLE
Use more generic language for Transformation destination

### DIFF
--- a/api/v1beta1/secrettransformation_types.go
+++ b/api/v1beta1/secrettransformation_types.go
@@ -28,18 +28,18 @@ type SecretTransformation struct {
 // SecretTransformationSpec defines the desired state of SecretTransformation
 type SecretTransformationSpec struct {
 	// Templates maps a template name to its Template. Templates are always included
-	// in the rendered K8s Secret with the specified key.
+	// in the rendered secret with the specified key.
 	Templates map[string]Template `json:"templates,omitempty"`
-	// SourceTemplates are never included in the rendered K8s Secret, they can be
+	// SourceTemplates are never included in the rendered secret, they can be
 	// used to provide common template definitions, etc.
 	SourceTemplates []SourceTemplate `json:"sourceTemplates,omitempty"`
 	// Includes contains regex patterns used to filter top-level source secret data
-	// fields for inclusion in the final K8s Secret data. These pattern filters are
+	// fields for inclusion in the final secret data. These pattern filters are
 	// never applied to templated fields as defined in Templates. They are always
 	// applied last.
 	Includes []string `json:"includes,omitempty"`
 	// Excludes contains regex patterns used to filter top-level source secret data
-	// fields for exclusion from the final K8s Secret data. These pattern filters are
+	// fields for exclusion from the final secret data. These pattern filters are
 	// never applied to templated fields as defined in Templates. They are always
 	// applied before any inclusion patterns. To exclude all source secret data
 	// fields, you can configure the single pattern ".*".

--- a/chart/crds/secrets.hashicorp.com_secrettransformations.yaml
+++ b/chart/crds/secrets.hashicorp.com_secrettransformations.yaml
@@ -46,7 +46,7 @@ spec:
               excludes:
                 description: |-
                   Excludes contains regex patterns used to filter top-level source secret data
-                  fields for exclusion from the final K8s Secret data. These pattern filters are
+                  fields for exclusion from the final secret data. These pattern filters are
                   never applied to templated fields as defined in Templates. They are always
                   applied before any inclusion patterns. To exclude all source secret data
                   fields, you can configure the single pattern ".*".
@@ -56,7 +56,7 @@ spec:
               includes:
                 description: |-
                   Includes contains regex patterns used to filter top-level source secret data
-                  fields for inclusion in the final K8s Secret data. These pattern filters are
+                  fields for inclusion in the final secret data. These pattern filters are
                   never applied to templated fields as defined in Templates. They are always
                   applied last.
                 items:
@@ -64,7 +64,7 @@ spec:
                 type: array
               sourceTemplates:
                 description: |-
-                  SourceTemplates are never included in the rendered K8s Secret, they can be
+                  SourceTemplates are never included in the rendered secret, they can be
                   used to provide common template definitions, etc.
                 items:
                   description: SourceTemplate provides source templating configuration.
@@ -99,7 +99,7 @@ spec:
                   type: object
                 description: |-
                   Templates maps a template name to its Template. Templates are always included
-                  in the rendered K8s Secret with the specified key.
+                  in the rendered secret with the specified key.
                 type: object
             type: object
           status:

--- a/config/crd/bases/secrets.hashicorp.com_secrettransformations.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_secrettransformations.yaml
@@ -46,7 +46,7 @@ spec:
               excludes:
                 description: |-
                   Excludes contains regex patterns used to filter top-level source secret data
-                  fields for exclusion from the final K8s Secret data. These pattern filters are
+                  fields for exclusion from the final secret data. These pattern filters are
                   never applied to templated fields as defined in Templates. They are always
                   applied before any inclusion patterns. To exclude all source secret data
                   fields, you can configure the single pattern ".*".
@@ -56,7 +56,7 @@ spec:
               includes:
                 description: |-
                   Includes contains regex patterns used to filter top-level source secret data
-                  fields for inclusion in the final K8s Secret data. These pattern filters are
+                  fields for inclusion in the final secret data. These pattern filters are
                   never applied to templated fields as defined in Templates. They are always
                   applied last.
                 items:
@@ -64,7 +64,7 @@ spec:
                 type: array
               sourceTemplates:
                 description: |-
-                  SourceTemplates are never included in the rendered K8s Secret, they can be
+                  SourceTemplates are never included in the rendered secret, they can be
                   used to provide common template definitions, etc.
                 items:
                   description: SourceTemplate provides source templating configuration.
@@ -99,7 +99,7 @@ spec:
                   type: object
                 description: |-
                   Templates maps a template name to its Template. Templates are always included
-                  in the rendered K8s Secret with the specified key.
+                  in the rendered secret with the specified key.
                 type: object
             type: object
           status:

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -476,10 +476,10 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `templates` _object (keys:string, values:[Template](#template))_ | Templates maps a template name to its Template. Templates are always included<br />in the rendered K8s Secret with the specified key. |  |  |
-| `sourceTemplates` _[SourceTemplate](#sourcetemplate) array_ | SourceTemplates are never included in the rendered K8s Secret, they can be<br />used to provide common template definitions, etc. |  |  |
-| `includes` _string array_ | Includes contains regex patterns used to filter top-level source secret data<br />fields for inclusion in the final K8s Secret data. These pattern filters are<br />never applied to templated fields as defined in Templates. They are always<br />applied last. |  |  |
-| `excludes` _string array_ | Excludes contains regex patterns used to filter top-level source secret data<br />fields for exclusion from the final K8s Secret data. These pattern filters are<br />never applied to templated fields as defined in Templates. They are always<br />applied before any inclusion patterns. To exclude all source secret data<br />fields, you can configure the single pattern ".*". |  |  |
+| `templates` _object (keys:string, values:[Template](#template))_ | Templates maps a template name to its Template. Templates are always included<br />in the rendered secret with the specified key. |  |  |
+| `sourceTemplates` _[SourceTemplate](#sourcetemplate) array_ | SourceTemplates are never included in the rendered secret, they can be<br />used to provide common template definitions, etc. |  |  |
+| `includes` _string array_ | Includes contains regex patterns used to filter top-level source secret data<br />fields for inclusion in the final secret data. These pattern filters are<br />never applied to templated fields as defined in Templates. They are always<br />applied last. |  |  |
+| `excludes` _string array_ | Excludes contains regex patterns used to filter top-level source secret data<br />fields for exclusion from the final secret data. These pattern filters are<br />never applied to templated fields as defined in Templates. They are always<br />applied before any inclusion patterns. To exclude all source secret data<br />fields, you can configure the single pattern ".*". |  |  |
 
 
 


### PR DESCRIPTION
This changes the API documentation for SecretTransformation to just use the word "secret" instead of "K8s Secret" in the description of the destination secret, to account for secrets synced by the CSI driver, which does not use K8s Secrets.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
