### PR TITLE
Add ability to pass useragent header in client config

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -21,6 +21,7 @@ import (
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 	"github.com/hashicorp/vault-secrets-operator/consts"
 	vaultcredsconsts "github.com/hashicorp/vault-secrets-operator/credentials/vault/consts"
+	"github.com/hashicorp/vault-secrets-operator/internal/version"
 	"github.com/hashicorp/vault-secrets-operator/utils"
 )
 
@@ -30,6 +31,7 @@ var (
 	InvalidObjectKeyError                      = fmt.Errorf("invalid objectKey")
 	InvalidObjectKeyErrorEmptyName             = fmt.Errorf("%w, empty name", InvalidObjectKeyError)
 	InvalidObjectKeyErrorEmptyNamespace        = fmt.Errorf("%w, empty namespace", InvalidObjectKeyError)
+	DefaultVSOUserAgent                        = fmt.Sprintf("vso/%s", version.Version().String())
 	defaultMaxRetries                   uint64 = 60
 	defaultRetryDuration                       = time.Millisecond * 500
 )

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -23,4 +23,5 @@ const (
 	AWSSessionToken    = "session_token"
 
 	AnnotationResync = "vso.hashicorp.com/resync"
+	HeaderUserAgent  = "User-Agent"
 )

--- a/controllers/hcpvaultsecretsapp_controller.go
+++ b/controllers/hcpvaultsecretsapp_controller.go
@@ -40,12 +40,10 @@ import (
 	"github.com/hashicorp/vault-secrets-operator/common"
 	"github.com/hashicorp/vault-secrets-operator/consts"
 	"github.com/hashicorp/vault-secrets-operator/helpers"
-	"github.com/hashicorp/vault-secrets-operator/internal/version"
 )
 
 const (
 	headerHVSRequester = "X-HVS-Requester"
-	headerUserAgent    = "User-Agent"
 
 	hcpVaultSecretsAppFinalizer = "hcpvaultsecretsapp.secrets.hashicorp.com/finalizer"
 
@@ -67,7 +65,6 @@ const (
 )
 
 var (
-	userAgent = fmt.Sprintf("vso/%s", version.Version().String())
 	// hvsErrorRe is a regexp to parse the error message from the HVS API
 	// The error message is expected to be in the format:
 	// [METHOD PATH_PATTERN][STATUS_CODE]
@@ -402,8 +399,8 @@ type transport struct {
 // RoundTrip is a wrapper implementation of the http.RoundTrip interface to
 // inject a header for identifying the requester type
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Add(headerUserAgent, userAgent)
-	req.Header.Add(headerHVSRequester, userAgent)
+	req.Header.Add(consts.HeaderUserAgent, common.DefaultVSOUserAgent)
+	req.Header.Add(headerHVSRequester, common.DefaultVSOUserAgent)
 	return t.child.RoundTrip(req)
 }
 

--- a/vault/config.go
+++ b/vault/config.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/vault/api"
@@ -38,7 +39,7 @@ type ClientConfig struct {
 	// VaultNamespace is the namespace in Vault to auth to
 	VaultNamespace string
 	// Headers are http headers to set on the Vault client
-	Headers map[string]string
+	Headers http.Header
 	// Timeout applied to all Vault requests. If not set, the default timeout from
 	// the Vault API client config is used.
 	Timeout *time.Duration
@@ -108,8 +109,10 @@ func MakeVaultClient(ctx context.Context, cfg *ClientConfig, client ctrlclient.C
 	if _, exists := cfg.Headers[vconsts.NamespaceHeaderName]; exists {
 		return nil, fmt.Errorf("setting header %q on VaultConnection is not permitted", vconsts.NamespaceHeaderName)
 	}
-	for k, v := range cfg.Headers {
-		c.AddHeader(k, v)
+	for k, values := range cfg.Headers {
+		for _, v := range values {
+			c.AddHeader(k, v)
+		}
 	}
 	if cfg.VaultNamespace != "" {
 		c.SetNamespace(cfg.VaultNamespace)

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -89,9 +89,9 @@ func TestMakeVaultClient(t *testing.T) {
 		},
 		"headers": {
 			vaultConfig: &ClientConfig{
-				Headers: map[string]string{
-					"X-Proxy-Setting": "yes",
-					"Y-Proxy-Setting": "no",
+				Headers: http.Header{
+					"X-Proxy-Setting": []string{"yes"},
+					"Y-Proxy-Setting": []string{"no"},
 				},
 				VaultNamespace: "vault-test-namespace",
 			},
@@ -100,10 +100,10 @@ func TestMakeVaultClient(t *testing.T) {
 		},
 		"headers can't override namespace": {
 			vaultConfig: &ClientConfig{
-				Headers: map[string]string{
-					"X-Proxy-Setting":           "yes",
-					"Y-Proxy-Setting":           "no",
-					vconsts.NamespaceHeaderName: "nope",
+				Headers: http.Header{
+					"X-Proxy-Setting":           []string{"yes"},
+					"Y-Proxy-Setting":           []string{"no"},
+					vconsts.NamespaceHeaderName: []string{"nope"},
 				},
 				VaultNamespace: "vault-test-namespace",
 			},
@@ -175,12 +175,14 @@ func TestMakeVaultClient(t *testing.T) {
 	}
 }
 
-func makeVaultHttpHeaders(t *testing.T, namespace string, headers map[string]string) http.Header {
+func makeVaultHttpHeaders(t *testing.T, namespace string, headers http.Header) http.Header {
 	t.Helper()
 
 	h := make(http.Header)
-	for k, v := range headers {
-		h.Set(k, v)
+	for k, values := range headers {
+		for _, v := range values {
+			h.Add(k, v)
+		}
 	}
 	h.Set("X-Vault-Request", "true")
 	if namespace != "" {


### PR DESCRIPTION
This PR adds a User-Agent header to all requests to Vault from the VSO Vault client. This is the initial work needed to understand how many people are using the VSO CSI Driver, but I've added a default for regular VSO as well, to allow us to better understand customer usage of each integration.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
