### PR TITLE
ci: Update k8s and vault versions

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -67,7 +67,7 @@ runs:
         cluster_name: ${{ inputs.kind-cluster-name }}
         config: test/integration/kind/config.yaml
         node_image: kindest/node:v${{ inputs.k8s-version }}
-        version: "v0.27.0"
+        version: "v0.30.0"
     - name: Create kind export log root
       id: create_kind_export_log_root
       shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,7 +89,7 @@ jobs:
       - run: npm install -g bats@${BATS_VERSION}
         shell: bash
         env:
-          BATS_VERSION: '1.10.0'
+          BATS_VERSION: '1.12.0'
       - run: bats -v
         shell: bash
       - run: make unit-test
@@ -348,11 +348,11 @@ jobs:
       - run: echo "setting versions"
     outputs:
       # JSON encoded array of k8s versions
-      K8S_VERSIONS: '["1.32.3", "1.31.6", "1.30.10", "1.29.14", "1.28.15"]'
-      VAULT_N: "1.19.0"
-      VAULT_N_1: "1.18.5"
-      VAULT_N_2: "1.17.12"
-      VAULT_LTS_1: "1.16.16"
+      K8S_VERSIONS: '["1.33.4", "1.32.8", "1.31.12", "1.30.13", "1.29.14"]'
+      VAULT_N: "1.20.3"
+      VAULT_N_1: "1.19.9"
+      VAULT_N_2: "1.18.14"
+      VAULT_LTS_1: "1.16.25"
   oom-tests:
     runs-on: ubuntu-latest
     needs:
@@ -375,7 +375,7 @@ jobs:
       - name: Install kind
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          version: "v0.27.0"
+          version: "v0.30.0"
           install_only: true
       - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         id: setup-helm

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -14,4 +14,4 @@ jobs:
       JIRA_SYNC_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
       JIRA_SYNC_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
     with:
-      teams-array: '["ecosystem", "foundations-eco", "vault-eco"]'
+      teams-array: '["vault-eco-infra"]'


### PR DESCRIPTION
Test with k8s 1.33-1.29, latest versions of Vault 1.20-1.18, 1.16.

Also updates the jira-sync team.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
