### PR TITLE
VDS: give the reconciliation check a bit more time.

### DIFF
--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -1297,7 +1297,7 @@ func awaitDynamicSecretReconciled(t *testing.T, ctx context.Context, client ctrl
 			vdsObjFinal = vdsObj
 			return nil
 		},
-		backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond*500), 20),
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond*500), 60),
 	))
 	return &vdsObjFinal, valid
 }


### PR DESCRIPTION
Fixes flaky `TestVaultDynamicSecret_vaultClientCallback` integration test.


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
