### PR TITLE
ci: updating vault-helm to v0.31.0 and latest Vault versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -322,7 +322,7 @@ jobs:
       - name: Install kind
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          version: "v0.27.0"
+          version: "v0.30.0"
           install_only: true
       - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         id: setup-helm
@@ -349,10 +349,10 @@ jobs:
     outputs:
       # JSON encoded array of k8s versions
       K8S_VERSIONS: '["1.33.4", "1.32.8", "1.31.12", "1.30.13", "1.29.14"]'
-      VAULT_N: "1.20.3"
-      VAULT_N_1: "1.19.9"
-      VAULT_N_2: "1.18.14"
-      VAULT_LTS_1: "1.16.25"
+      VAULT_N: "1.20.4"
+      VAULT_N_1: "1.19.10"
+      VAULT_N_2: "1.18.15"
+      VAULT_LTS_1: "1.16.26"
   oom-tests:
     runs-on: ubuntu-latest
     needs:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ VAULT_IMAGE_TAG ?= latest
 VAULT_IMAGE_REPO ?=
 K8S_VAULT_NAMESPACE ?= vault
 KIND_K8S_VERSION ?= v1.32.3
-VAULT_HELM_VERSION ?= 0.29.1
+VAULT_HELM_VERSION ?= 0.31.0
 # Root directory to export kind cluster logs after each test run.
 EXPORT_KIND_LOGS_ROOT ?=
 

--- a/test/integration/infra/scale-testing/deployments/variables.tf
+++ b/test/integration/infra/scale-testing/deployments/variables.tf
@@ -44,7 +44,7 @@ variable "vault_enterprise" {
 }
 
 variable "vault_chart_version" {
-  default = "0.29.1"
+  default = "0.31.0"
 }
 
 variable "region" {

--- a/test/integration/infra/variables.tf
+++ b/test/integration/infra/variables.tf
@@ -47,7 +47,7 @@ variable "vault_enterprise" {
 }
 
 variable "vault_chart_version" {
-  default = "0.29.1"
+  default = "0.31.0"
 }
 
 variable "install_kube_prometheus" {

--- a/test/integration/modules/vault/variables.tf
+++ b/test/integration/modules/vault/variables.tf
@@ -47,7 +47,7 @@ variable "vault_enterprise" {
 }
 
 variable "vault_chart_version" {
-  default = "0.29.1"
+  default = "0.31.0"
 }
 
 variable "install_kube_prometheus" {


### PR DESCRIPTION
Vault Helm v0.31.0 has been released; updating it here for use in CI along with the latest Vault versions.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
