### PR TITLE
Fix multiple topologySpreadConstraints

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -472,11 +472,16 @@ topologySpreadConstraints appends the "vso.chart.selectorLabels" to .Values.cont
 */}}
 {{- define "vso.topologySpreadConstraints" -}}
 {{- $defaultLabelSelector := dict "labelSelector" (dict "matchLabels" (include "vso.chart.selectorLabels" . | fromYaml)) -}}
-{{- range $topologySpreadConstraint := .Values.controller.topologySpreadConstraints -}}
-{{- if hasKey $topologySpreadConstraint "labelSelector" -}}
-{{- $topologySpreadConstraint | list | toYaml -}}
-{{- else -}}
-{{- merge $topologySpreadConstraint $defaultLabelSelector | list | toYaml -}}
+{{- $topologySpreadConstraints := list -}}
+{{- range $t := .Values.controller.topologySpreadConstraints }}
+  {{- if hasKey $t "labelSelector" }}
+    {{- $topologySpreadConstraints = append $topologySpreadConstraints $t }}
+  {{- else }}
+    {{- $merged := merge $t $defaultLabelSelector }}
+    {{- $topologySpreadConstraints = append $topologySpreadConstraints $merged }}
+  {{- end -}}
 {{- end -}}
+{{- if $topologySpreadConstraints -}}
+{{- $topologySpreadConstraints | toYaml -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Helm chart's deployment template is broken when using multiple `topologySpreadConstraints`.

Steps to reproduce:

```shell
cat > custom.values.yaml <<EOF
controller:
  topologySpreadConstraints:
    - topologyKey: topology.kubernetes.io/zone
      maxSkew: 1
      whenUnsatisfiable: ScheduleAnyway
    - topologyKey: kubernetes.io/hostname
      maxSkew: 1
      whenUnsatisfiable: ScheduleAnyway
      labelSelector:
        matchLabels:
          app.kubernetes.io/name: example
EOF

helm template vault-secrets-operator ./chart -f custom.values.yaml
```

```text
Error: YAML parse error on vault-secrets-operator/templates/deployment.yaml: error converting YAML to JSON: yaml: line 119: mapping values are not allowed in this context

Use --debug flag to render out invalid YAML
```

Let's see what broken YAML was actually produced here:

```shell
helm template vault-secrets-operator ./chart -f custom.values.yaml --debug | grep -B1 -A15 'topologySpreadConstraints'
```

```text
      terminationGracePeriodSeconds: 120
      topologySpreadConstraints:
        - labelSelector:
            matchLabels:
              app.kubernetes.io/instance: vault-secrets-operator
              app.kubernetes.io/name: vault-secrets-operator
          maxSkew: 1
          topologyKey: topology.kubernetes.io/zone
          whenUnsatisfiable: ScheduleAnyway- labelSelector:
            matchLabels:
              app.kubernetes.io/name: example
          maxSkew: 1
          topologyKey: kubernetes.io/hostname
          whenUnsatisfiable: ScheduleAnyway
      volumes:
      - downwardAPI:
          items:
```

You can see the new-line being removed and 2 constraints merged into one block:

```text
whenUnsatisfiable: ScheduleAnyway- labelSelector:
```

Let's apply the fix and try again:

```shell
helm template vault-secrets-operator ./chart -f custom.values.yaml | grep -B1 -A15 'topologySpreadConstraints'
```

```text
      terminationGracePeriodSeconds: 120
      topologySpreadConstraints:
        - labelSelector:
            matchLabels:
              app.kubernetes.io/instance: vault-secrets-operator
              app.kubernetes.io/name: vault-secrets-operator
          maxSkew: 1
          topologyKey: topology.kubernetes.io/zone
          whenUnsatisfiable: ScheduleAnyway
        - labelSelector:
            matchLabels:
              app.kubernetes.io/name: example
          maxSkew: 1
          topologyKey: kubernetes.io/hostname
          whenUnsatisfiable: ScheduleAnyway
      volumes:
      - downwardAPI:
```

The fix works fine with multiple `topologySpreadConstraints`, a single one or no at all.
Please merge the proposed changes.