### PR TITLE
fix: update pdb selector to match the controller deployment

### DIFF
--- a/chart/templates/poddisruptionbudget.yaml
+++ b/chart/templates/poddisruptionbudget.yaml
@@ -22,7 +22,7 @@ spec:
 
   {{/* If maxUnavailable is set, use it */}}
   {{- if not (empty $maxUnavailable) }}
-  maxUnavailable: 
+  maxUnavailable:
     {{- if contains "%" $maxUnavailable }}
     "{{ $maxUnavailable }}"
     {{- else }}
@@ -32,7 +32,7 @@ spec:
 
   {{/* If minAvailable is set, use it */}}
   {{- if not (empty $minAvailable) }}
-  minAvailable: 
+  minAvailable:
     {{- if contains "%" $minAvailable }}
     "{{ $minAvailable }}"
     {{- else }}
@@ -42,5 +42,6 @@ spec:
 
   selector:
     matchLabels:
+      control-plane: controller-manager
       {{- include "vso.chart.selectorLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
## Description

Controller Manager deployment is created with the following selector labels:
```
spec:
  selector:
    matchLabels:
      app.kubernetes.io/instance: vault-secrets-operator
      app.kubernetes.io/name: vault-secrets-operator
      control-plane: controller-manager
```

PDB only uses `vso.chart.selectorLabels` helper, which is missing the control-plane label and thus makes PDB invalid.

This PR makes sure PDB is created with the missing label so it is valid.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
