### PR TITLE
CSI: ensure securityContext.privileged is true on the DaemonSet.

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -482,3 +482,19 @@ topologySpreadConstraints appends the "vso.chart.selectorLabels" to .Values.cont
 {{- end -}}
 {{- toYaml $out -}}
 {{- end -}}
+
+
+{{/*
+vso.csi.securityContext extends the default security context for the CSI driver daemonset.
+The result will always set privileged to true regardless of user configuration.
+*/}}
+{{- define "vso.csi.securityContext" -}}
+{{- $sc := dict -}}
+{{- with .Values.csi.securityContext -}}
+{{- range $k, $v := . -}}
+{{- $_ := set $sc $k $v -}}
+{{- end -}}
+{{- end -}}
+{{- $_ := set $sc "privileged" "true" -}}
+{{- toYaml $sc -}}
+{{- end -}}

--- a/chart/templates/csi-driver.yaml
+++ b/chart/templates/csi-driver.yaml
@@ -61,10 +61,8 @@ spec:
       annotations:
       {{- include "vso.csi.annotations" . | nindent 8 }}
     spec:
-      {{- with.Values.csi.securityContext }}
       securityContext:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "vso.csi.securityContext" . | nindent 8 }}
       serviceAccountName: {{ include "vso.chart.fullname" . }}-csi
       {{- with .Values.csi.hostAliases }}
       hostAliases:


### PR DESCRIPTION
Fixes a regression where the securityContext was moved to an enpty value. The CSI driver requires that mountPropagation perms

Introduced in #1152  (unreleased at the time of regression detection)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
