### PR TITLE
CSI: ensure securityContext.privileged is true on the driver container.

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -483,14 +483,13 @@ topologySpreadConstraints appends the "vso.chart.selectorLabels" to .Values.cont
 {{- toYaml $out -}}
 {{- end -}}
 
-
 {{/*
-vso.csi.securityContext extends the default security context for the CSI driver daemonset.
-The result will always set privileged to true regardless of user configuration.
+vso.privileged.securityContext extends the given securithContext to always
+include privileged: true
 */}}
-{{- define "vso.csi.securityContext" -}}
+{{- define "vso.privileged.securityContext" -}}
 {{- $sc := dict -}}
-{{- with .Values.csi.securityContext -}}
+{{- with . -}}
 {{- range $k, $v := . -}}
 {{- $_ := set $sc $k $v -}}
 {{- end -}}

--- a/chart/templates/csi-driver.yaml
+++ b/chart/templates/csi-driver.yaml
@@ -62,7 +62,7 @@ spec:
       {{- include "vso.csi.annotations" . | nindent 8 }}
     spec:
       securityContext:
-      {{- include "vso.csi.securityContext" . | nindent 8 }}
+      {{- include "vso.privileged.securityContext" .Values.csi.securityContext | nindent 8 }}
       serviceAccountName: {{ include "vso.chart.fullname" . }}-csi
       {{- with .Values.csi.hostAliases }}
       hostAliases:
@@ -132,10 +132,8 @@ spec:
           value: {{ .value }}
         {{- end }}
         imagePullPolicy: {{ .Values.csi.driver.image.pullPolicy }}
-        {{- with .Values.csi.driver.securityContext }}
         securityContext:
-        {{- toYaml . | nindent 10 }}
-        {{- end }}
+        {{- include "vso.privileged.securityContext" .Values.csi.driver.securityContext | nindent 10 }}
         livenessProbe:
             failureThreshold: 5
             httpGet:


### PR DESCRIPTION
Fixes a regression where the securityContext was moved to an enpty value. The CSI driver requires that mountPropagation perms

Partially fixed in #1163

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
