### PR TITLE
create new DecryptCiphertextWithTransit func

### DIFF
--- a/vault/transit.go
+++ b/vault/transit.go
@@ -59,10 +59,15 @@ func DecryptWithTransit(ctx context.Context, vaultClient Client, mount, key stri
 		return nil, err
 	}
 
+	return DecryptCiphertextWithTransit(ctx, vaultClient, mount, key, v.Ciphertext)
+}
+
+// DecryptCiphertextWithTransit decrypts a ciphertext value using Vault Transit.
+func DecryptCiphertextWithTransit(ctx context.Context, vaultClient Client, mount, key, ciphertext string) ([]byte, error) {
 	path := fmt.Sprintf("%s/decrypt/%s", mount, key)
 	params := map[string]interface{}{
 		"name":       key,
-		"ciphertext": v.Ciphertext,
+		"ciphertext": ciphertext,
 	}
 
 	resp, err := vaultClient.Write(ctx, NewWriteRequest(path, params, nil))


### PR DESCRIPTION
The current `DecryptWithTransit` implementation assumes the ciphertext input is supplied as JSON matching the internal encryptResponse structure. This tightly couples decryption to a specific JSON encoding pattern and is not generic enough to allow other clients to use it freely. A new `DecryptCiphertextWithTransit` func has been created to allow clients to supply ciphertext directly.