### PR TITLE
chart: Properly set the PodSecurityContext

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -487,7 +487,7 @@ topologySpreadConstraints appends the "vso.chart.selectorLabels" to .Values.cont
 vso.privileged.securityContext extends the given securithContext to always
 include privileged: true
 */}}
-{{- define "vso.privileged.securityContext" -}}
+{{- define "vso.privilegedContainer.securityContext" -}}
 {{- $sc := dict -}}
 {{- with . -}}
 {{- range $k, $v := . -}}

--- a/chart/templates/csi-driver.yaml
+++ b/chart/templates/csi-driver.yaml
@@ -61,8 +61,10 @@ spec:
       annotations:
       {{- include "vso.csi.annotations" . | nindent 8 }}
     spec:
+      {{- with .Values.csi.securityContext }}
       securityContext:
-      {{- include "vso.privileged.securityContext" .Values.csi.securityContext | nindent 8 }}
+      {{ toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "vso.chart.fullname" . }}-csi
       {{- with .Values.csi.hostAliases }}
       hostAliases:
@@ -133,7 +135,7 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.csi.driver.image.pullPolicy }}
         securityContext:
-        {{- include "vso.privileged.securityContext" .Values.csi.driver.securityContext | nindent 10 }}
+        {{- include "vso.privilegedContainer.securityContext" .Values.csi.driver.securityContext | nindent 10 }}
         livenessProbe:
             failureThreshold: 5
             httpGet:

--- a/test/unit/csi-driver.bats
+++ b/test/unit/csi-driver.bats
@@ -630,11 +630,8 @@ load _helpers
     yq 'select(.kind == "DaemonSet")' | tee /dev/stderr)
 
   local actual
-
   actual=$(echo "$object" | yq '.spec.template.spec.securityContext | length' | tee /dev/stderr)
-  [ "${actual}" = '1' ]
-  actual=$(echo "$object" | yq '.spec.template.spec.securityContext | .privileged | select(tag == "!!bool")' | tee /dev/stderr)
-  [ "${actual}" = 'true' ]
+  [ "${actual}" = '0' ]
 
   local driverObj
   driverObj=$(echo "$object" | yq '.spec.template.spec.containers[] | select(.name == "driver") | .securityContext')
@@ -650,17 +647,16 @@ load _helpers
   object=$(helm template \
     -s templates/csi-driver.yaml \
     --set 'csi.enabled=true' \
-    --set 'csi.securityContext.privileged=foo' \
+    --set 'csi.securityContext.fsGroup=101' \
     --set 'csi.driver.securityContext.privileged=baz' \
     . | tee /dev/stderr |
     yq 'select(.kind == "DaemonSet")' | tee /dev/stderr)
 
   local actual
-
   actual=$(echo "$object" | yq '.spec.template.spec.securityContext | length' | tee /dev/stderr)
   [ "${actual}" = '1' ]
-  actual=$(echo "$object" | yq '.spec.template.spec.securityContext | .privileged | select(tag == "!!bool")' | tee /dev/stderr)
-  [ "${actual}" = 'true' ]
+  actual=$(echo "$object" | yq '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
+  [ "${actual}" = '101' ]
 
   local driverObj
   driverObj=$(echo "$object" | yq '.spec.template.spec.containers[] | select(.name == "driver") | .securityContext')
@@ -677,16 +673,17 @@ load _helpers
     -s templates/csi-driver.yaml \
     --set 'csi.enabled=true' \
     --set 'csi.securityContext.allowPrivilegeEscalation=false' \
+    --set 'csi.securityContext.fsGroup=101' \
     . | tee /dev/stderr |
     yq 'select(.kind == "DaemonSet")' | tee /dev/stderr)
 
   local actual
   actual=$(echo "$object" | yq '.spec.template.spec.securityContext | length' | tee /dev/stderr)
   [ "${actual}" = '2' ]
-  actual=$(echo "$object" | yq '.spec.template.spec.securityContext | .privileged | select(tag == "!!bool")' | tee /dev/stderr)
-  [ "${actual}" = 'true' ]
   actual=$(echo "$object" | yq '.spec.template.spec.securityContext | .allowPrivilegeEscalation | select(tag == "!!bool")' | tee /dev/stderr)
   [ "${actual}" = 'false' ]
+  actual=$(echo "$object" | yq '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
+  [ "${actual}" = '101' ]
 
   local driverObj
   driverObj=$(echo "$object" | yq '.spec.template.spec.containers[] | select(.name == "driver") | .securityContext')
@@ -702,7 +699,8 @@ load _helpers
   object=$(helm template \
     -s templates/csi-driver.yaml \
     --set 'csi.enabled=true' \
-    --set 'csi.driver.securityContext.privileged=true' \
+    --set 'csi.securityContext.runAsNonRoot=true' \
+    --set 'csi.securityContext.fsGroup=101' \
     --set 'csi.driver.securityContext.allowPrivilegeEscalation=false' \
     . | tee /dev/stderr |
     yq 'select(.kind == "DaemonSet")' \
@@ -710,9 +708,11 @@ load _helpers
 
   local actual
   actual=$(echo "$object" | yq '.spec.template.spec.securityContext | length' | tee /dev/stderr)
-  [ "${actual}" = '1' ]
-  actual=$(echo "$object" | yq '.spec.template.spec.securityContext | .privileged | select(tag == "!!bool")' | tee /dev/stderr)
+  [ "${actual}" = '2' ]
+  actual=$(echo "$object" | yq '.spec.template.spec.securityContext | .runAsNonRoot | select(tag == "!!bool")' | tee /dev/stderr)
   [ "${actual}" = 'true' ]
+  actual=$(echo "$object" | yq '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
+  [ "${actual}" = '101' ]
 
   local driverObj
   driverObj=$(echo "$object" | yq '.spec.template.spec.containers[] | select(.name == "driver") | .securityContext')


### PR DESCRIPTION
Previously, we were setting in unsupported parameter on the PodSecurityContext. Now the PodSecurityContext defaults to empty and will not include unsupported parameters by default.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
