### PR TITLE
Make caching client factory usable as library without need for k8s API access

### DIFF
--- a/vault/client.go
+++ b/vault/client.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/uuid"
 	"golang.org/x/crypto/blake2b"
-	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -28,11 +27,6 @@ import (
 )
 
 type NewClientFunc func(ctx context.Context, client ctrlclient.Client, obj ctrlclient.Object, opts *ClientOptions) (Client, error)
-
-// NewCacheKeyFunc is a function that computes a cache key for a given VaultAuth and VaultConnection.
-// This allows customization of cache key computation, for use by
-// other tools that use the VSO client as a library. (e.g., for building k8s components where the API server is not available).
-type NewCacheKeyFunc func(authObj *secretsv1beta1.VaultAuth, connObj *secretsv1beta1.VaultConnection, providerUID types.UID) (ClientCacheKey, error)
 
 type ClientOptions struct {
 	SkipRenewal               bool

--- a/vault/client_factory.go
+++ b/vault/client_factory.go
@@ -157,9 +157,6 @@ type cachingClientFactory struct {
 	clientGetValidator ClientGetValidator
 	// newClientFunc is a function that returns a new Client.
 	newClientFunc NewClientFunc
-	// newCacheKeyFunc is a function that computes a cache key from the
-	// provided VaultAuth and VaultConnection.
-	newCacheKeyFunc NewCacheKeyFunc
 }
 
 // Remove removes a Client from the cache. Returns true if the Client was removed.
@@ -645,7 +642,7 @@ func (m *cachingClientFactory) computeCacheKeyFromMeta(ctx context.Context, clie
 		return "", err
 	}
 
-	return m.newCacheKeyFunc(authObj, connObj, provider.GetUID())
+	return computeClientCacheKey(authObj, connObj, provider.GetUID())
 }
 
 // cacheClient to the global in-memory cache.
@@ -962,7 +959,6 @@ func NewCachingClientFactory(ctx context.Context, client ctrlclient.Client, cach
 		credentialProviderFactory: config.CredentialProviderFactory,
 		clientGetValidator:        config.ClientGetValidator,
 		newClientFunc:             config.NewClientFunc,
-		newCacheKeyFunc:           config.NewCacheKeyFunc,
 		logger: zap.New().WithName("clientCacheFactory").WithValues(
 			"persist", config.Persist,
 			"enforceEncryption", config.StorageConfig.EnforceEncryption,
@@ -1036,9 +1032,6 @@ type CachingClientFactoryConfig struct {
 	ClientGetValidator  ClientGetValidator
 	// NewClientFunc is a function that returns a new Client.
 	NewClientFunc NewClientFunc
-	// NewCacheKeyFunc is a function that computes a cache key from the
-	// provided VaultAuth and VaultConnection.
-	NewCacheKeyFunc NewCacheKeyFunc
 }
 
 // DefaultCachingClientFactoryConfig provides the default configuration for a CachingClientFactory instance.
@@ -1053,7 +1046,6 @@ func DefaultCachingClientFactoryConfig() *CachingClientFactoryConfig {
 		SetupEncryptionClientTimeout: defaultSetupEncryptionClientTimeout,
 		ClientCacheNumLocks:          100,
 		NewClientFunc:                NewClientWithLogin,
-		NewCacheKeyFunc:              computeClientCacheKey,
 	}
 }
 


### PR DESCRIPTION
WIP: do not review yet

An improvement over my [first](https://github.com/hashicorp/vault-secrets-operator/pull/1189) attempt to make VSO's caching client factory more usable for other use cases.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
