### PR TITLE
Add additional printer column fields

### DIFF
--- a/api/v1beta1/secrettransformation_types.go
+++ b/api/v1beta1/secrettransformation_types.go
@@ -22,6 +22,7 @@ type SecretTransformationStatus struct {
 
 // SecretTransformation is the Schema for the secrettransformations API
 // +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=`.status.conditions[?(@.type == "Healthy")].status`,description="health status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,description="resource age"
 type SecretTransformation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/vaultauth_types.go
+++ b/api/v1beta1/vaultauth_types.go
@@ -447,6 +447,7 @@ type VaultAuthStatus struct {
 
 // VaultAuth is the Schema for the vaultauths API
 // +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=`.status.conditions[?(@.type == "Healthy")].status`,description="health status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,description="resource age"
 type VaultAuth struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/vaultconnection_types.go
+++ b/api/v1beta1/vaultconnection_types.go
@@ -41,6 +41,7 @@ type VaultConnectionStatus struct {
 
 // VaultConnection is the Schema for the vaultconnections API
 // +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=`.status.conditions[?(@.type == "Healthy")].status`,description="health status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,description="resource age"
 type VaultConnection struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/vaultdynamicsecret_types.go
+++ b/api/v1beta1/vaultdynamicsecret_types.go
@@ -135,6 +135,7 @@ type VaultStaticCredsMetaData struct {
 // VaultDynamicSecret is the Schema for the vaultdynamicsecrets API
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=`.status.conditions[?(@.type == "SecretSynced")].status`,description="secret sync status"
 // +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=`.status.conditions[?(@.type == "Healthy")].status`,description="health status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,description="resource age"
 type VaultDynamicSecret struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/vaultpkisecret_types.go
+++ b/api/v1beta1/vaultpkisecret_types.go
@@ -149,6 +149,7 @@ type VaultPKISecretStatus struct {
 // VaultPKISecret is the Schema for the vaultpkisecrets API
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=`.status.conditions[?(@.type == "SecretSynced")].status`,description="secret sync status"
 // +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=`.status.conditions[?(@.type == "Healthy")].status`,description="health status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,description="resource age"
 type VaultPKISecret struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/vaultstaticsecret_types.go
+++ b/api/v1beta1/vaultstaticsecret_types.go
@@ -99,6 +99,7 @@ type VaultStaticSecretStatus struct {
 // VaultStaticSecret is the Schema for the vaultstaticsecrets API
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=`.status.conditions[?(@.type == "SecretSynced")].status`,description="secret sync status"
 // +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=`.status.conditions[?(@.type == "Healthy")].status`,description="health status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,description="resource age"
 type VaultStaticSecret struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/chart/crds/secrets.hashicorp.com_secrettransformations.yaml
+++ b/chart/crds/secrets.hashicorp.com_secrettransformations.yaml
@@ -22,6 +22,10 @@ spec:
       jsonPath: .status.conditions[?(@.type == "Healthy")].status
       name: Healthy
       type: string
+    - description: resource age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/chart/crds/secrets.hashicorp.com_vaultauths.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultauths.yaml
@@ -22,6 +22,10 @@ spec:
       jsonPath: .status.conditions[?(@.type == "Healthy")].status
       name: Healthy
       type: string
+    - description: resource age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/chart/crds/secrets.hashicorp.com_vaultconnections.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultconnections.yaml
@@ -22,6 +22,10 @@ spec:
       jsonPath: .status.conditions[?(@.type == "Healthy")].status
       name: Healthy
       type: string
+    - description: resource age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -26,6 +26,10 @@ spec:
       jsonPath: .status.conditions[?(@.type == "Healthy")].status
       name: Healthy
       type: string
+    - description: resource age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -26,6 +26,10 @@ spec:
       jsonPath: .status.conditions[?(@.type == "Healthy")].status
       name: Healthy
       type: string
+    - description: resource age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -26,6 +26,10 @@ spec:
       jsonPath: .status.conditions[?(@.type == "Healthy")].status
       name: Healthy
       type: string
+    - description: resource age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/secrets.hashicorp.com_secrettransformations.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_secrettransformations.yaml
@@ -22,6 +22,10 @@ spec:
       jsonPath: .status.conditions[?(@.type == "Healthy")].status
       name: Healthy
       type: string
+    - description: resource age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/secrets.hashicorp.com_vaultauths.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultauths.yaml
@@ -22,6 +22,10 @@ spec:
       jsonPath: .status.conditions[?(@.type == "Healthy")].status
       name: Healthy
       type: string
+    - description: resource age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/secrets.hashicorp.com_vaultconnections.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultconnections.yaml
@@ -22,6 +22,10 @@ spec:
       jsonPath: .status.conditions[?(@.type == "Healthy")].status
       name: Healthy
       type: string
+    - description: resource age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -26,6 +26,10 @@ spec:
       jsonPath: .status.conditions[?(@.type == "Healthy")].status
       name: Healthy
       type: string
+    - description: resource age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -26,6 +26,10 @@ spec:
       jsonPath: .status.conditions[?(@.type == "Healthy")].status
       name: Healthy
       type: string
+    - description: resource age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -26,6 +26,10 @@ spec:
       jsonPath: .status.conditions[?(@.type == "Healthy")].status
       name: Healthy
       type: string
+    - description: resource age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Add health check and secret sync status for (optional) to all CRDs having controller managed status.conditions.

E.g:
```
$ kubectl get --all-namespaces vaultstaticsecrets.secrets.hashicorp.com

NAMESPACE                  NAME                                 SYNCED   HEALTHY   AGE
vss-c7a2oqz4v62seeef-app   create-kv-v2-fixed-version-kv-v2-0   False    False     45h
vss-c7a2oqz4v62seeef-app   create-kv-v2-fixed-version-kv-v2-1   False    False     45h
vss-c7a2oqz4v62seeef-app   create-kv-v2-kv-v2-0                 False    False     45h
vss-c7a2oqz4v62seeef-app   create-kv-v2-kv-v2-1                 False    False     45h

```

Support types:
```
 api/v1beta1/secrettransformation
 api/v1beta1/vaultauth
 api/v1beta1/vaultconnection
 api/v1beta1/vaultdynamicsecret
 api/v1beta1/vaultpkisecret
 api/v1beta1/vaultstaticsecret
```

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
