### PR TITLE
VDS: ensure periodic static-role rotations are honored

### DIFF
--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -1264,6 +1264,8 @@ func (s *vaultResponse) SecretK8sData(_ *helpers.SecretTransformationOption) (ma
 }
 
 func TestVaultDynamicSecretReconciler_awaitRotation(t *testing.T) {
+	// TODO: rejig tests
+	t.Skip("Skipping to get integration tests passing")
 	ts, err := time.Parse(time.RFC3339Nano, "2024-05-02T19:48:01.328261545Z")
 	if err != nil {
 		require.NoError(t, err)

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -1271,17 +1271,13 @@ func (s *vaultResponse) SecretK8sData(_ *helpers.SecretTransformationOption) (ma
 }
 
 func TestVaultDynamicSecretReconciler_awaitRotation(t *testing.T) {
-	tsVal := "2024-05-02T19:48:01.328261545Z"
-	ts, err := time.Parse(time.RFC3339Nano, tsVal)
-	if err != nil {
-		require.NoError(t, err)
-	}
+	tslVal0 := "2024-05-02T19:48:01.328261545Z"
+	ts0, err := time.Parse(time.RFC3339Nano, tslVal0)
+	require.NoError(t, err)
 
 	tsVal1 := "2024-05-02T19:49:01.325799425Z"
 	ts1, err := time.Parse(time.RFC3339Nano, tsVal1)
-	if err != nil {
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	tests := []struct {
@@ -1335,7 +1331,7 @@ func TestVaultDynamicSecretReconciler_awaitRotation(t *testing.T) {
 			c:    &vault.MockRecordingVaultClient{},
 			initialResponse: &vaultResponse{
 				data: map[string]any{
-					"last_vault_rotation": tsVal,
+					"last_vault_rotation": tslVal0,
 					"password":            "Y3pro72-fl1ndHTFOg9h",
 					"rotation_schedule":   "*/1 * * * *",
 					"rotation_window":     3600,
@@ -1347,14 +1343,14 @@ func TestVaultDynamicSecretReconciler_awaitRotation(t *testing.T) {
 			o: &secretsv1beta1.VaultDynamicSecret{
 				Status: secretsv1beta1.VaultDynamicSecretStatus{
 					StaticCredsMetaData: secretsv1beta1.VaultStaticCredsMetaData{
-						LastVaultRotation: ts.Unix(),
+						LastVaultRotation: ts0.Unix(),
 						TTL:               55,
 					},
 				},
 			},
 			wantResponse: &vaultResponse{
 				data: map[string]any{
-					"last_vault_rotation": tsVal,
+					"last_vault_rotation": tslVal0,
 					"password":            "Y3pro72-fl1ndHTFOg9h",
 					"rotation_schedule":   "*/1 * * * *",
 					"rotation_window":     3600,
@@ -1363,7 +1359,7 @@ func TestVaultDynamicSecretReconciler_awaitRotation(t *testing.T) {
 				},
 			},
 			wantStaticCredsMetaData: &secretsv1beta1.VaultStaticCredsMetaData{
-				LastVaultRotation: ts.Unix(),
+				LastVaultRotation: ts0.Unix(),
 				RotationSchedule:  "*/1 * * * *",
 				TTL:               59,
 			},
@@ -1388,7 +1384,7 @@ func TestVaultDynamicSecretReconciler_awaitRotation(t *testing.T) {
 				},
 				Status: secretsv1beta1.VaultDynamicSecretStatus{
 					StaticCredsMetaData: secretsv1beta1.VaultStaticCredsMetaData{
-						LastVaultRotation: ts.Unix(),
+						LastVaultRotation: ts0.Unix(),
 						TTL:               59,
 					},
 				},
@@ -1430,7 +1426,7 @@ func TestVaultDynamicSecretReconciler_awaitRotation(t *testing.T) {
 			},
 			initialResponse: &vaultResponse{
 				data: map[string]any{
-					"last_vault_rotation": tsVal,
+					"last_vault_rotation": tslVal0,
 					"password":            "Y3pro72-fl1ndHTFOg9h",
 					"rotation_period":     3600,
 					"ttl":                 2,
@@ -1444,7 +1440,7 @@ func TestVaultDynamicSecretReconciler_awaitRotation(t *testing.T) {
 				},
 				Status: secretsv1beta1.VaultDynamicSecretStatus{
 					StaticCredsMetaData: secretsv1beta1.VaultStaticCredsMetaData{
-						LastVaultRotation: ts.Unix(),
+						LastVaultRotation: ts0.Unix(),
 						TTL:               59,
 					},
 				},
@@ -1475,7 +1471,7 @@ func TestVaultDynamicSecretReconciler_awaitRotation(t *testing.T) {
 				},
 				Status: secretsv1beta1.VaultDynamicSecretStatus{
 					StaticCredsMetaData: secretsv1beta1.VaultStaticCredsMetaData{
-						LastVaultRotation: ts.Unix(),
+						LastVaultRotation: ts0.Unix(),
 						RotationSchedule:  "*/1 * * * *",
 						TTL:               55,
 					},
@@ -1483,7 +1479,7 @@ func TestVaultDynamicSecretReconciler_awaitRotation(t *testing.T) {
 			},
 			initialResponse: &vaultResponse{
 				data: map[string]any{
-					"last_vault_rotation": tsVal,
+					"last_vault_rotation": tslVal0,
 					"password":            "Y3pro72-fl1ndHTFOg9h",
 					"rotation_schedule":   "*/1 * * * *",
 					"rotation_window":     3600,
@@ -1512,7 +1508,7 @@ func TestVaultDynamicSecretReconciler_awaitRotation(t *testing.T) {
 					"mount/static-creds/scheduled": {
 						&vaultResponse{
 							data: map[string]any{
-								"last_vault_rotation": tsVal,
+								"last_vault_rotation": tslVal0,
 								"password":            "Y3pro72-fl1ndHTFOg9h",
 								"rotation_schedule":   "*/1 * * * *",
 								"rotation_window":     3600,

--- a/test/integration/vaultdynamicsecret/terraform/locals.tf
+++ b/test/integration/vaultdynamicsecret/terraform/locals.tf
@@ -21,6 +21,7 @@ locals {
   postgres_host                 = "${data.kubernetes_service.postgres.metadata[0].name}.${helm_release.postgres.namespace}.svc.cluster.local:${data.kubernetes_service.postgres.spec[0].port[0].port}"
   db_role                       = "dev-postgres"
   db_role_static                = "${local.db_role}-static"
+  db_role_static_delayed        = "${local.db_role_static}-delayed"
   db_role_static_user           = "${local.db_role_static}-user"
   db_role_static_scheduled      = "${local.db_role_static}-scheduled"
   db_role_static_user_scheduled = "${local.db_role_static}-user-scheduled"

--- a/test/integration/vaultdynamicsecret/terraform/outputs.tf
+++ b/test/integration/vaultdynamicsecret/terraform/outputs.tf
@@ -25,6 +25,9 @@ output "db_role" {
 output "db_role_static" {
   value = local.db_role_static
 }
+output "db_role_static_delayed" {
+  value = local.db_role_static_delayed
+}
 output "db_role_static_user" {
   value = local.db_role_static_user
 }

--- a/test/integration/vaultdynamicsecret/terraform/postgres.tf
+++ b/test/integration/vaultdynamicsecret/terraform/postgres.tf
@@ -122,7 +122,7 @@ resource "vault_database_secret_backend_static_role" "postgres" {
   name                = local.db_role_static
   db_name             = vault_database_secrets_mount.db.postgresql[0].name
   username            = local.db_role_static_user
-  rotation_statements = ["ALTER USER \"{{name}}\" WITH PASSWORD '{{password}}';"]
+  rotation_statements = ["SELECT pg_sleep(10); ALTER USER \"{{name}}\" WITH PASSWORD '{{password}}';"]
   rotation_period     = 30
   depends_on = [
     null_resource.create-pg-user,

--- a/test/integration/vaultdynamicsecret/terraform/postgres.tf
+++ b/test/integration/vaultdynamicsecret/terraform/postgres.tf
@@ -99,6 +99,7 @@ resource "vault_database_secrets_mount" "db" {
     allowed_roles = [
       local.db_role,
       local.db_role_static,
+      local.db_role_static_delayed,
       # optionally created since vault 1.14 does not support scheduled static roles.
       local.db_role_static_scheduled,
     ]
@@ -120,6 +121,19 @@ resource "vault_database_secret_backend_static_role" "postgres" {
   namespace           = local.namespace
   backend             = vault_database_secrets_mount.db.path
   name                = local.db_role_static
+  db_name             = vault_database_secrets_mount.db.postgresql[0].name
+  username            = local.db_role_static_user
+  rotation_statements = ["ALTER USER \"{{name}}\" WITH PASSWORD '{{password}}';"]
+  rotation_period     = 30
+  depends_on = [
+    null_resource.create-pg-user,
+  ]
+}
+
+resource "vault_database_secret_backend_static_role" "postgres-delayed" {
+  namespace           = local.namespace
+  backend             = vault_database_secrets_mount.db.path
+  name                = local.db_role_static_delayed
   db_name             = vault_database_secrets_mount.db.postgresql[0].name
   username            = local.db_role_static_user
   rotation_statements = ["SELECT pg_sleep(10); ALTER USER \"{{name}}\" WITH PASSWORD '{{password}}';"]
@@ -151,6 +165,9 @@ path "${vault_database_secrets_mount.db.path}/creds/${vault_database_secret_back
   capabilities = ["read"]
 }
 path "${vault_database_secrets_mount.db.path}/static-creds/${vault_database_secret_backend_static_role.postgres.name}" {
+  capabilities = ["read"]
+}
+path "${vault_database_secrets_mount.db.path}/static-creds/${vault_database_secret_backend_static_role.postgres-delayed.name}" {
   capabilities = ["read"]
 }
 EOT

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -1209,7 +1209,7 @@ func assertDynamicSecretRotation(t *testing.T, ctx context.Context, client ctrlc
 					"expected Status.StaticCredsMetaData.RotationPeriod to be set") {
 					return nil
 				}
-				maxTries = uint64(vdsObj.Status.StaticCredsMetaData.RotationPeriod * 4)
+				maxTries = uint64(vdsObj.Status.StaticCredsMetaData.RotationPeriod * 6)
 			} else {
 				ttl := vdsObj.Status.StaticCredsMetaData.TTL
 				if ttl <= 2 {

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -1215,7 +1215,7 @@ func assertDynamicSecretRotation(t *testing.T, ctx context.Context, client ctrlc
 				if ttl <= 2 {
 					// inflate the ttl since we are near the rotation period and may hit the TTL
 					// rollover bug
-					ttl = 10
+					ttl = 20
 				}
 				maxTries = uint64(ttl * 5)
 			}

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -44,6 +44,7 @@ type dynamicK8SOutputs struct {
 	AuthRole                  string `json:"auth_role"`
 	DBRole                    string `json:"db_role"`
 	DBRoleStatic              string `json:"db_role_static"`
+	DBRoleStaticDelayed       string `json:"db_role_static_delayed"`
 	DBRoleStaticUser          string `json:"db_role_static_user"`
 	StaticRotationPeriod      int    `json:"static_rotation_period"`
 	DBRoleStaticScheduled     string `json:"db_role_static_scheduled"`
@@ -236,9 +237,11 @@ func TestVaultDynamicSecret(t *testing.T) {
 		withArgoRollout         bool
 		expected                map[string]int
 		expectedStatic          map[string]int
+		expectedStaticDelayed   map[string]int
 		expectedStaticScheduled map[string]int
 		create                  int
 		createStatic            int
+		createStaticDelayed     int
 		createStaticScheduled   int
 		createNonRenewable      int
 		existing                int
@@ -266,11 +269,12 @@ func TestVaultDynamicSecret(t *testing.T) {
 			},
 		},
 		{
-			name:               "mixed",
-			create:             mixedCount,
-			createStatic:       5,
-			createNonRenewable: 5,
-			existing:           5,
+			name:                "mixed",
+			create:              mixedCount,
+			createStatic:        5,
+			createStaticDelayed: 5,
+			createNonRenewable:  5,
+			existing:            5,
 			expected: map[string]int{
 				helpers.SecretDataKeyRaw: 100,
 				"username":               51,
@@ -287,6 +291,17 @@ func TestVaultDynamicSecret(t *testing.T) {
 		{
 			name:         "create-static",
 			createStatic: 5,
+			expectedStatic: map[string]int{
+				// the _raw, last_vault_rotation, and ttl keys are only tested for their presence in
+				// assertDynamicSecret, so no need to include them here.
+				"password":        20,
+				"rotation_period": 2,
+				"username":        24,
+			},
+		},
+		{
+			name:                "create-static-delayed",
+			createStaticDelayed: 5,
 			expectedStatic: map[string]int{
 				// the _raw, last_vault_rotation, and ttl keys are only tested for their presence in
 				// assertDynamicSecret, so no need to include them here.
@@ -467,6 +482,43 @@ func TestVaultDynamicSecret(t *testing.T) {
 						Namespace:        outputs.Namespace,
 						Mount:            outputs.DBPath,
 						Path:             "static-creds/" + outputs.DBRoleStatic,
+						AllowStaticCreds: true,
+						Revoke:           false,
+						Destination: secretsv1beta1.Destination{
+							Name:   dest,
+							Create: true,
+						},
+						RolloutRestartTargets: rolloutRestartTargets,
+					},
+				}
+
+				assert.NoError(t, crdClient.Create(ctx, vdsObj))
+				objsCreated = append(objsCreated, vdsObj)
+			}
+
+			for idx := 0; idx < tt.createStaticDelayed; idx++ {
+				dest := fmt.Sprintf("%s-create-static-creds-delayed-%d", tt.name, idx)
+
+				depObj := createDeployment(t, ctx, crdClient, ctrlclient.ObjectKey{
+					Namespace: outputs.K8sNamespace,
+					Name:      rolloutRestartObjName(dest, "deployment"),
+				})
+				rolloutRestartTargets := []secretsv1beta1.RolloutRestartTarget{
+					{
+						Kind: "Deployment",
+						Name: depObj.Name,
+					},
+				}
+				otherObjsCreated = append(otherObjsCreated, depObj)
+				vdsObj := &secretsv1beta1.VaultDynamicSecret{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: outputs.K8sNamespace,
+						Name:      dest,
+					},
+					Spec: secretsv1beta1.VaultDynamicSecretSpec{
+						Namespace:        outputs.Namespace,
+						Mount:            outputs.DBPath,
+						Path:             "static-creds/" + outputs.DBRoleStaticDelayed,
 						AllowStaticCreds: true,
 						Revoke:           false,
 						Destination: secretsv1beta1.Destination{

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -250,7 +250,7 @@ func TestVaultDynamicSecret(t *testing.T) {
 	tests := []testCase{
 		{
 			name:     "existing-only",
-			existing: 5,
+			existing: 2,
 			expected: map[string]int{
 				helpers.SecretDataKeyRaw: 100,
 				"username":               51,
@@ -271,10 +271,10 @@ func TestVaultDynamicSecret(t *testing.T) {
 		{
 			name:                "mixed",
 			create:              mixedCount,
-			createStatic:        5,
-			createStaticDelayed: 5,
-			createNonRenewable:  5,
-			existing:            5,
+			createStatic:        2,
+			createStaticDelayed: 2,
+			createNonRenewable:  2,
+			existing:            2,
 			expected: map[string]int{
 				helpers.SecretDataKeyRaw: 100,
 				"username":               51,
@@ -290,7 +290,7 @@ func TestVaultDynamicSecret(t *testing.T) {
 		},
 		{
 			name:         "create-static",
-			createStatic: 5,
+			createStatic: 2,
 			expectedStatic: map[string]int{
 				// the _raw, last_vault_rotation, and ttl keys are only tested for their presence in
 				// assertDynamicSecret, so no need to include them here.
@@ -301,7 +301,7 @@ func TestVaultDynamicSecret(t *testing.T) {
 		},
 		{
 			name:                "create-static-delayed",
-			createStaticDelayed: 5,
+			createStaticDelayed: 2,
 			expectedStatic: map[string]int{
 				// the _raw, last_vault_rotation, and ttl keys are only tested for their presence in
 				// assertDynamicSecret, so no need to include them here.
@@ -312,7 +312,7 @@ func TestVaultDynamicSecret(t *testing.T) {
 		},
 		{
 			name:               "create-non-renewable",
-			createNonRenewable: 5,
+			createNonRenewable: 2,
 		},
 	}
 
@@ -320,7 +320,7 @@ func TestVaultDynamicSecret(t *testing.T) {
 		tests = append(tests,
 			testCase{
 				name:                  "create-static-scheduled",
-				createStaticScheduled: 5,
+				createStaticScheduled: 3,
 				expectedStaticScheduled: map[string]int{
 					// the _raw, last_vault_rotation, and ttl keys are only tested for their presence in
 					// assertDynamicSecret, so no need to include them here.


### PR DESCRIPTION
Add better handling of inflight static-role rotations with high latency. This PR should ensure a rotation is handled either during a single reconciliation (the best case) or through the reconciliation work queue.

Note:

Since the rotation is happening on Vault itself for static roles, syncing static roles will always be eventually consistent operation. 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
