### PR TITLE
chart: allow to set scrape relabelings and metrics relabelings

### DIFF
--- a/chart/templates/prometheus-servicemonitor.yaml
+++ b/chart/templates/prometheus-servicemonitor.yaml
@@ -35,4 +35,12 @@ spec:
           - prometheus
       tlsConfig:
         insecureSkipVerify: true
+      {{- with .Values.telemetry.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.telemetry.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{ end }}

--- a/test/unit/prometheus-servicemonitor.bats
+++ b/test/unit/prometheus-servicemonitor.bats
@@ -121,3 +121,35 @@ load _helpers
   [ "$(echo "$output" | yq -r '.spec.endpoints[0].port')" = "http" ]
   [ "$(echo "$output" | yq -r '.spec.endpoints[0].bearerTokenFile')" = "/foo/token" ]
 }
+
+@test "prometheus/ServiceMonitor-server: assertRelabellings default" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/prometheus-servicemonitor.yaml \
+      --set 'telemetry.serviceMonitor.enabled=true' \
+      . | tee /dev/stderr)
+
+  [ "$(echo "$output" | yq -r '.spec.endpoints | length')" = "1" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0] | has("relabelings")')" = "false" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0] | has("metricRelabelings")')" = "false" ]
+}
+
+@test "prometheus/ServiceMonitor-server: assertRelabellings update" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/prometheus-servicemonitor.yaml \
+      --set 'telemetry.serviceMonitor.enabled=true' \
+      --set 'telemetry.serviceMonitor.relabelings[0].sourceLabels[0]=__meta_kubernetes_endpoint_node_name' \
+      --set 'telemetry.serviceMonitor.relabelings[0].targetLabel=nodename' \
+      --set 'telemetry.serviceMonitor.metricRelabelings[0].sourceLabels[0]=__name__' \
+      --set 'telemetry.serviceMonitor.metricRelabelings[0].regex=controller_runtime_.*' \
+      --set 'telemetry.serviceMonitor.metricRelabelings[0].action=keep' \
+      . | tee /dev/stderr)
+
+  [ "$(echo "$output" | yq -r '.spec.endpoints | length')" = "1" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].relabelings[0].sourceLabels[0]')" = "__meta_kubernetes_endpoint_node_name" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].relabelings[0].targetLabel')" = "nodename" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].metricRelabelings[0].sourceLabels[0]')" = "__name__" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].metricRelabelings[0].regex')" = "controller_runtime_.*" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].metricRelabelings[0].action')" = "keep" ]
+}


### PR DESCRIPTION
Add ability to relabel metrics scraped via prometheus servicemonitor. For instance to rename metrics, to drop metrics, add labels, etc.

Closes #1258 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
