### PR TITLE
ci: declare permissions on build.yaml and jira.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,9 @@ env:
   # used by scripts that fetch build tools from GH
   GH_GET_RETRIES: 5
 
+permissions:
+  contents: read
+
 jobs:
   get-product-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -6,6 +6,13 @@ on:
     types: [opened, closed, reopened]
   issue_comment: # Also triggers when commenting on a PR from the conversation view
     types: [created]
+
+# Reusable Jira sync only reads issue/PR metadata to mirror it to Jira.
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
 jobs:
   sync:
     uses: hashicorp/vault-workflows-common/.github/workflows/jira.yaml@main


### PR DESCRIPTION
Two workflows in this repo had no explicit `permissions:` block. This PR pins each to the minimum it actually needs:

- **build.yaml** — `contents: read`. The full build/test/docker pipeline only checks out source, runs make targets, uploads artifacts via `actions/upload-artifact` (run-scoped), and builds container images through `hashicorp/actions-docker-build@v2` (uses its own docker-registry secrets). The `make generate manifests` step verifies no drift, doesn't push.
- **jira.yaml** — `contents: read` + `issues: read` + `pull-requests: read`. Caller for the shared `hashicorp/vault-workflows-common/.github/workflows/jira.yaml@main` reusable workflow. The Jira mirror writes through `JIRA_SYNC_API_TOKEN` against the Jira API; the GitHub side only needs to read the event metadata.

YAML validated locally with `yaml.safe_load`.