### PR TITLE
Add support for X-Vault-Index header in Vault requests.

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -24,4 +24,10 @@ const (
 
 	AnnotationResync = "vso.hashicorp.com/resync"
 	HeaderUserAgent  = "User-Agent"
+
+	// HeaderVaultIndex is the Vault consistency header for conditional forwarding
+	// on Performance Standbys. When set on a request, the standby node either
+	// serves the request locally (if its WAL index >= the value) or immediately
+	// forwards to the active node — avoiding blocking waits.
+	HeaderVaultIndex = "X-Vault-Index"
 )

--- a/controllers/instant_updates.go
+++ b/controllers/instant_updates.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
@@ -54,6 +55,11 @@ type InstantUpdateConfig struct {
 	// EventObjectFactory builds the object sent on SourceCh. When nil a default
 	// factory that deep copies Object is used.
 	EventObjectFactory func(types.NamespacedName) client.Object
+	// PendingVaultIndex stores the vault_index from the latest matched event so
+	// the reconciler can attach it as X-Vault-Index on the subsequent Vault
+	// request for conditional forwarding (Performance Standbys only).
+	// Key: types.NamespacedName, Value: string.
+	PendingVaultIndex *sync.Map
 }
 
 // vaultEventMessage is used to extract the relevant fields from an event message sent from Vault.
@@ -61,8 +67,9 @@ type vaultEventMessage struct {
 	Data struct {
 		Event struct {
 			Metadata struct {
-				Path     string `json:"path"`
-				Modified string `json:"modified"`
+				Path       string `json:"path"`
+				Modified   string `json:"modified"`
+				VaultIndex string `json:"vault_index"`
 			} `json:"metadata"`
 		} `json:"event"`
 		Namespace string `json:"namespace"`
@@ -316,6 +323,17 @@ func (cfg *InstantUpdateConfig) matchSecretEvent(ctx context.Context, obj client
 		logger.V(consts.LogLevelDebug).Info("Event is not relevant for instant updates, skipping",
 			"namespace", namespace, "path", path, "spec namespace", specNamespace, "spec path", specPath)
 		return false, nil
+	}
+
+	// Store the vault_index so the reconciler can attach X-Vault-Index on the
+	// subsequent Vault request, ensuring the responding node has applied at least
+	// this WAL entry before serving data (conditional forwarding for Performance
+	// Standbys). TrimSpace guards against empty or whitespace-only values that
+	// would produce a meaningless header.
+	if cfg.PendingVaultIndex != nil {
+		if vaultIndex := strings.TrimSpace(message.Data.Event.Metadata.VaultIndex); vaultIndex != "" {
+			cfg.PendingVaultIndex.Store(client.ObjectKeyFromObject(obj), vaultIndex)
+		}
 	}
 
 	logger.V(consts.LogLevelDebug).Info("Event matches, requeueing",

--- a/controllers/instant_updates_test.go
+++ b/controllers/instant_updates_test.go
@@ -6,12 +6,15 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 	"github.com/hashicorp/vault-secrets-operator/consts"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -177,4 +180,233 @@ func Test_matchSecretEvent(t *testing.T) {
 			require.Equal(t, tt.wantMatch, matched)
 		})
 	}
+}
+
+// Test_matchSecretEvent_storesVaultIndex verifies that matchSecretEvent stores
+// the vault_index from the event payload into PendingVaultIndex when a match is
+// found, and does not store anything in all non-matching or empty-index cases.
+func Test_matchSecretEvent_storesVaultIndex(t *testing.T) {
+	t.Parallel()
+
+	vssKVV2 := &secretsv1beta1.VaultStaticSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "kvv2", Namespace: "default"},
+		Spec: secretsv1beta1.VaultStaticSecretSpec{
+			Namespace: "ns-a",
+			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+				Mount: "kv",
+				Path:  "app/config",
+				Type:  consts.KVSecretTypeV2,
+			},
+		},
+	}
+	vssKVV1 := &secretsv1beta1.VaultStaticSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "kvv1", Namespace: "default"},
+		Spec: secretsv1beta1.VaultStaticSecretSpec{
+			Namespace: "ns-a",
+			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+				Mount: "kv",
+				Path:  "app/config",
+				Type:  consts.KVSecretTypeV1,
+			},
+		},
+	}
+	vds := &secretsv1beta1.VaultDynamicSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "dyndb", Namespace: "default"},
+		Spec: secretsv1beta1.VaultDynamicSecretSpec{
+			Namespace: "ns-a",
+			Mount:     "db",
+			Path:      "creds/app",
+		},
+	}
+
+	const sampleIndex = "AAAAAAAAAZk="
+
+	eventJSON := func(path, ns, vaultIndex string) []byte {
+		if vaultIndex == "" {
+			return []byte(fmt.Sprintf(
+				`{"data":{"event":{"metadata":{"path":%q,"modified":"true"}},"namespace":"/%s"}}`,
+				path, ns,
+			))
+		}
+		return []byte(fmt.Sprintf(
+			`{"data":{"event":{"metadata":{"path":%q,"modified":"true","vault_index":%q}},"namespace":"/%s"}}`,
+			path, vaultIndex, ns,
+		))
+	}
+
+	tests := []struct {
+		name           string
+		obj            client.Object
+		eventJSON      []byte
+		wantMatch      bool
+		wantIndexKey   *types.NamespacedName // nil means "expect no entry stored"
+		wantIndexValue string
+	}{
+		// ── Matching cases that should store the index ──────────────────────────
+		{
+			name:           "vss-kvv2-match-stores-index",
+			obj:            vssKVV2,
+			eventJSON:      eventJSON("kv/data/app/config", "ns-a", sampleIndex),
+			wantMatch:      true,
+			wantIndexKey:   &types.NamespacedName{Namespace: "default", Name: "kvv2"},
+			wantIndexValue: sampleIndex,
+		},
+		{
+			name:           "vss-kvv1-match-stores-index",
+			obj:            vssKVV1,
+			eventJSON:      eventJSON("kv/app/config", "ns-a", sampleIndex),
+			wantMatch:      true,
+			wantIndexKey:   &types.NamespacedName{Namespace: "default", Name: "kvv1"},
+			wantIndexValue: sampleIndex,
+		},
+		{
+			name:           "vds-match-stores-index",
+			obj:            vds,
+			eventJSON:      eventJSON("db/creds/app", "ns-a", sampleIndex),
+			wantMatch:      true,
+			wantIndexKey:   &types.NamespacedName{Namespace: "default", Name: "dyndb"},
+			wantIndexValue: sampleIndex,
+		},
+		{
+			// Non-base64 / opaque value must be stored and forwarded as-is;
+			// no client-side validation since the token is opaque.
+			name:           "opaque-non-base64-value-stored-as-is",
+			obj:            vssKVV2,
+			eventJSON:      eventJSON("kv/data/app/config", "ns-a", "not-valid-base64!!!"),
+			wantMatch:      true,
+			wantIndexKey:   &types.NamespacedName{Namespace: "default", Name: "kvv2"},
+			wantIndexValue: "not-valid-base64!!!",
+		},
+		// ── Matching cases that must NOT store the index ─────────────────────────
+		{
+			name:         "match-vault-index-absent",
+			obj:          vssKVV2,
+			eventJSON:    eventJSON("kv/data/app/config", "ns-a", ""),
+			wantMatch:    true,
+			wantIndexKey: nil, // no entry expected
+		},
+		{
+			name:         "match-vault-index-empty-string",
+			obj:          vssKVV2,
+			eventJSON:    []byte(`{"data":{"event":{"metadata":{"path":"kv/data/app/config","modified":"true","vault_index":""}},"namespace":"/ns-a"}}`),
+			wantMatch:    true,
+			wantIndexKey: nil,
+		},
+		{
+			name:         "match-vault-index-whitespace-only",
+			obj:          vssKVV2,
+			eventJSON:    []byte(`{"data":{"event":{"metadata":{"path":"kv/data/app/config","modified":"true","vault_index":"   "}},"namespace":"/ns-a"}}`),
+			wantMatch:    true,
+			wantIndexKey: nil,
+		},
+		// ── Non-matching cases must never store the index ───────────────────────
+		{
+			name:         "path-mismatch-does-not-store",
+			obj:          vssKVV2,
+			eventJSON:    eventJSON("kv/data/other/secret", "ns-a", sampleIndex),
+			wantMatch:    false,
+			wantIndexKey: nil,
+		},
+		{
+			name:         "namespace-mismatch-does-not-store",
+			obj:          vssKVV2,
+			eventJSON:    eventJSON("kv/data/app/config", "other-ns", sampleIndex),
+			wantMatch:    false,
+			wantIndexKey: nil,
+		},
+		{
+			name:         "not-modified-does-not-store",
+			obj:          vssKVV2,
+			eventJSON:    []byte(`{"data":{"event":{"metadata":{"path":"kv/data/app/config","modified":"false","vault_index":"AAAAAAAAAZk="}},"namespace":"/ns-a"}}`),
+			wantMatch:    false,
+			wantIndexKey: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var m sync.Map
+			cfg := &InstantUpdateConfig{PendingVaultIndex: &m}
+
+			matched, err := cfg.matchSecretEvent(context.Background(), tt.obj, tt.eventJSON)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMatch, matched)
+
+			if tt.wantIndexKey != nil {
+				v, ok := m.Load(*tt.wantIndexKey)
+				require.True(t, ok, "expected vault_index to be stored for key %v", *tt.wantIndexKey)
+				assert.Equal(t, tt.wantIndexValue, v.(string))
+			} else {
+				// Ensure nothing was written into the map at all.
+				count := 0
+				m.Range(func(_, _ any) bool { count++; return true })
+				assert.Equal(t, 0, count, "expected no entry in PendingVaultIndex map")
+			}
+		})
+	}
+}
+
+// Test_matchSecretEvent_nilPendingVaultIndex verifies that a nil PendingVaultIndex
+// does not cause a panic when vault_index is present in the event payload.
+func Test_matchSecretEvent_nilPendingVaultIndex(t *testing.T) {
+	t.Parallel()
+
+	vss := &secretsv1beta1.VaultStaticSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: secretsv1beta1.VaultStaticSecretSpec{
+			Namespace: "ns-a",
+			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+				Mount: "kv",
+				Path:  "app/config",
+				Type:  consts.KVSecretTypeV2,
+			},
+		},
+	}
+
+	cfg := &InstantUpdateConfig{PendingVaultIndex: nil}
+	eventJSON := []byte(`{"data":{"event":{"metadata":{"path":"kv/data/app/config","modified":"true","vault_index":"AAAAAAAAAZk="}},"namespace":"/ns-a"}}`)
+
+	matched, err := cfg.matchSecretEvent(context.Background(), vss, eventJSON)
+	require.NoError(t, err)
+	assert.True(t, matched, "event should still match even with nil PendingVaultIndex")
+}
+
+// Test_matchSecretEvent_lastWriteWins verifies that when two rapid events fire for
+// the same object before a reconcile runs, only the second (most recent) vault_index
+// survives in the map.
+func Test_matchSecretEvent_lastWriteWins(t *testing.T) {
+	t.Parallel()
+
+	vss := &secretsv1beta1.VaultStaticSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+		Spec: secretsv1beta1.VaultStaticSecretSpec{
+			Namespace: "ns-a",
+			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+				Mount: "kv",
+				Path:  "app/config",
+				Type:  consts.KVSecretTypeV2,
+			},
+		},
+	}
+
+	var m sync.Map
+	cfg := &InstantUpdateConfig{PendingVaultIndex: &m}
+
+	firstEvent := []byte(`{"data":{"event":{"metadata":{"path":"kv/data/app/config","modified":"true","vault_index":"AAAAAAAAAA="}},"namespace":"/ns-a"}}`)
+	secondEvent := []byte(`{"data":{"event":{"metadata":{"path":"kv/data/app/config","modified":"true","vault_index":"BBBBBBBBBBB="}},"namespace":"/ns-a"}}`)
+
+	matched, err := cfg.matchSecretEvent(context.Background(), vss, firstEvent)
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	matched, err = cfg.matchSecretEvent(context.Background(), vss, secondEvent)
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	key := types.NamespacedName{Namespace: "default", Name: "s"}
+	v, ok := m.Load(key)
+	require.True(t, ok)
+	assert.Equal(t, "BBBBBBBBBBB=", v.(string), "second event's vault_index should overwrite the first")
 }

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -12,6 +12,7 @@ import (
 	"maps"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -74,6 +75,11 @@ type VaultDynamicSecretReconciler struct {
 	// OPERATOR_POD_UID environment variable, or the /var/run/podinfo/uid file; in that order.
 	runtimePodUID types.UID
 	SecretsClient client.Client
+	// pendingVaultIndex stores the vault_index from the most recent matched
+	// Vault event for each secret. Consumed once per reconcile via LoadAndDelete
+	// to attach X-Vault-Index on the subsequent Vault read/write request.
+	// Key: types.NamespacedName, Value: string.
+	pendingVaultIndex sync.Map
 }
 
 // +kubebuilder:rbac:groups=secrets.hashicorp.com,resources=vaultdynamicsecrets,verbs=get;list;watch;create;update;patch;delete
@@ -146,19 +152,23 @@ func (r *VaultDynamicSecretReconciler) Reconcile(ctx context.Context, req ctrl.R
 		logger.V(consts.LogLevelDebug).Info("Event watcher enabled")
 
 		err := EnsureEventWatcher(ctx, &InstantUpdateConfig{
-			Secret:          o,
-			Client:          vClient,
-			Registry:        r.eventWatcherRegistry,
-			BackOffRegistry: r.BackOffRegistry,
-			SourceCh:        r.SourceCh,
-			Recorder:        r.Recorder,
-			NewClientFunc:   r.newVDSClient,
+			Secret:            o,
+			Client:            vClient,
+			Registry:          r.eventWatcherRegistry,
+			BackOffRegistry:   r.BackOffRegistry,
+			SourceCh:          r.SourceCh,
+			Recorder:          r.Recorder,
+			NewClientFunc:     r.newVDSClient,
+			PendingVaultIndex: &r.pendingVaultIndex,
 		})
 		if err != nil {
 			r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonEventWatcherError, "Failed to watch events: %s", err)
 		}
 	} else {
 		UnwatchEvents(r.eventWatcherRegistry, o)
+		// Clear any pending index so it does not persist across reconciles when
+		// instant updates is disabled.
+		r.pendingVaultIndex.Delete(req.NamespacedName)
 	}
 
 	// we can ignore the error here, since it was handled above in the Get() call.
@@ -339,7 +349,16 @@ func (r *VaultDynamicSecretReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// sync the secret
-	secretLease, staticCredsUpdated, err := r.syncSecret(ctx, vClient, o, transOption)
+	// Consume any vault_index stored by the event watcher goroutine when the
+	// event that triggered this reconcile was received. Attach it as
+	// X-Vault-Index so Performance Standbys forward to the active node when
+	// their local WAL index is behind, guaranteeing fresh data.
+	var vaultHeaders http.Header
+	if idx, ok := r.pendingVaultIndex.LoadAndDelete(req.NamespacedName); ok {
+		vaultHeaders = http.Header{consts.HeaderVaultIndex: []string{idx.(string)}}
+	}
+
+	secretLease, staticCredsUpdated, err := r.syncSecret(ctx, vClient, o, transOption, vaultHeaders)
 	if err != nil {
 		r.SyncRegistry.Add(req.NamespacedName)
 		if vault.IsForbiddenError(err) {
@@ -446,7 +465,7 @@ func (r *VaultDynamicSecretReconciler) isStaticCreds(meta *secretsv1beta1.VaultS
 }
 
 // doVault performs a Vault request based on the VaultDynamicSecret's spec.
-func (r *VaultDynamicSecretReconciler) doVault(ctx context.Context, c vault.ClientBase, o *secretsv1beta1.VaultDynamicSecret) (vault.Response, error) {
+func (r *VaultDynamicSecretReconciler) doVault(ctx context.Context, c vault.ClientBase, o *secretsv1beta1.VaultDynamicSecret, headers http.Header) (vault.Response, error) {
 	path := vault.JoinPath(o.Spec.Mount, o.Spec.Path)
 	var err error
 	var resp vault.Response
@@ -476,9 +495,9 @@ func (r *VaultDynamicSecretReconciler) doVault(ctx context.Context, c vault.Clie
 	logger = logger.WithValues("path", path, "method", method)
 	switch method {
 	case http.MethodPut, http.MethodPost:
-		resp, err = c.Write(ctx, vault.NewWriteRequest(path, params, nil))
+		resp, err = c.Write(ctx, vault.NewWriteRequest(path, params, headers))
 	case http.MethodGet:
-		resp, err = c.Read(ctx, vault.NewReadRequest(path, nil, nil))
+		resp, err = c.Read(ctx, vault.NewReadRequest(path, nil, headers))
 	default:
 		return nil, fmt.Errorf("unsupported HTTP method %q for sync", method)
 	}
@@ -496,11 +515,11 @@ func (r *VaultDynamicSecretReconciler) doVault(ctx context.Context, c vault.Clie
 }
 
 func (r *VaultDynamicSecretReconciler) syncSecret(ctx context.Context, c vault.ClientBase,
-	o *secretsv1beta1.VaultDynamicSecret, opt *helpers.SecretTransformationOption,
+	o *secretsv1beta1.VaultDynamicSecret, opt *helpers.SecretTransformationOption, headers http.Header,
 ) (*secretsv1beta1.VaultSecretLease, bool, error) {
 	logger := log.FromContext(ctx).WithName("syncSecret")
 
-	resp, err := r.doVault(ctx, c, o)
+	resp, err := r.doVault(ctx, c, o, headers)
 	if err != nil {
 		return nil, false, err
 	}
@@ -610,7 +629,9 @@ func (r *VaultDynamicSecretReconciler) awaitVaultSecretRotation(ctx context.Cont
 		backoff.WithMaxInterval(time.Second*2))
 	if err := backoff.Retry(
 		func() error {
-			resp, err = r.doVault(ctx, c, o)
+			// No consistency header on retry — this is a poll within the same
+			// reconcile cycle for static-creds rotation, not a new event trigger.
+			resp, err = r.doVault(ctx, c, o, nil)
 			if err != nil {
 				return err
 			}
@@ -777,6 +798,8 @@ func (r *VaultDynamicSecretReconciler) handleDeletion(ctx context.Context, o *se
 	r.SyncRegistry.Delete(objKey)
 	r.BackOffRegistry.Delete(objKey)
 	r.referenceCache.Remove(SecretTransformation, objKey)
+	// Clean up any pending vault_index entry so it does not leak after deletion.
+	r.pendingVaultIndex.Delete(objKey)
 	UnwatchEvents(r.eventWatcherRegistry, o)
 	if controllerutil.ContainsFinalizer(o, vaultDynamicSecretFinalizer) {
 		logger.Info("Removing finalizer")

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -170,9 +170,10 @@ func TestVaultDynamicSecretReconciler_syncSecret(t *testing.T) {
 		runtimePodUID types.UID
 	}
 	type args struct {
-		ctx     context.Context
-		vClient *vault.MockRecordingVaultClient
-		o       *secretsv1beta1.VaultDynamicSecret
+		ctx          context.Context
+		vClient      *vault.MockRecordingVaultClient
+		o            *secretsv1beta1.VaultDynamicSecret
+		vaultHeaders http.Header
 	}
 	tests := []struct {
 		name           string
@@ -552,18 +553,150 @@ func TestVaultDynamicSecretReconciler_syncSecret(t *testing.T) {
 					"unsupported HTTP method %q for sync", http.MethodOptions), i...)
 			},
 		},
+		// ── X-Vault-Index header propagation ───
+		{
+			// GET request with X-Vault-Index header — verifies the header is
+			// forwarded to the underlying Vault read request.
+			name: "with-vault-index-header-get",
+			fields: fields{
+				Client:        fake.NewClientBuilder().Build(),
+				runtimePodUID: "",
+			},
+			args: args{
+				ctx:     nil,
+				vClient: &vault.MockRecordingVaultClient{},
+				o: &secretsv1beta1.VaultDynamicSecret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "default",
+					},
+					Spec: secretsv1beta1.VaultDynamicSecretSpec{
+						Mount:  "baz",
+						Path:   "foo",
+						Params: nil,
+						Destination: secretsv1beta1.Destination{
+							Name:   "baz",
+							Create: true,
+						},
+					},
+					Status: secretsv1beta1.VaultDynamicSecretStatus{},
+				},
+				vaultHeaders: http.Header{"X-Vault-Index": []string{"AAAAAAAAAZk="}},
+			},
+			want: &secretsv1beta1.VaultSecretLease{
+				LeaseDuration: 0,
+				Renewable:     false,
+			},
+			expectRequests: []*vault.MockRequest{
+				{
+					Method:  http.MethodGet,
+					Path:    "baz/foo",
+					Params:  nil,
+					Headers: http.Header{"X-Vault-Index": []string{"AAAAAAAAAZk="}},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			// PUT request with params and X-Vault-Index header — verifies the
+			// header is forwarded to the underlying Vault write request.
+			name: "with-vault-index-header-put",
+			fields: fields{
+				Client:        fake.NewClientBuilder().Build(),
+				runtimePodUID: "",
+			},
+			args: args{
+				ctx:     nil,
+				vClient: &vault.MockRecordingVaultClient{},
+				o: &secretsv1beta1.VaultDynamicSecret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "default",
+					},
+					Spec: secretsv1beta1.VaultDynamicSecretSpec{
+						Mount: "baz",
+						Path:  "foo",
+						Params: map[string]string{
+							"qux": "bar",
+						},
+						Destination: secretsv1beta1.Destination{
+							Name:   "baz",
+							Create: true,
+						},
+					},
+					Status: secretsv1beta1.VaultDynamicSecretStatus{},
+				},
+				vaultHeaders: http.Header{"X-Vault-Index": []string{"AAAAAAAAAZk="}},
+			},
+			want: &secretsv1beta1.VaultSecretLease{
+				LeaseDuration: 0,
+				Renewable:     false,
+			},
+			expectRequests: []*vault.MockRequest{
+				{
+					Method:  http.MethodPut,
+					Path:    "baz/foo",
+					Params:  map[string]any{"qux": "bar"},
+					Headers: http.Header{"X-Vault-Index": []string{"AAAAAAAAAZk="}},
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			// nil headers must not alter the recorded request — no regression for
+			// the normal (non-event-triggered) reconcile path.
+			name: "nil-headers-get-no-regression",
+			fields: fields{
+				Client:        fake.NewClientBuilder().Build(),
+				runtimePodUID: "",
+			},
+			args: args{
+				ctx:          nil,
+				vClient:      &vault.MockRecordingVaultClient{},
+				vaultHeaders: nil,
+				o: &secretsv1beta1.VaultDynamicSecret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "default",
+					},
+					Spec: secretsv1beta1.VaultDynamicSecretSpec{
+						Mount:  "baz",
+						Path:   "foo",
+						Params: nil,
+						Destination: secretsv1beta1.Destination{
+							Name:   "baz",
+							Create: true,
+						},
+					},
+					Status: secretsv1beta1.VaultDynamicSecretStatus{},
+				},
+			},
+			want: &secretsv1beta1.VaultSecretLease{
+				LeaseDuration: 0,
+				Renewable:     false,
+			},
+			expectRequests: []*vault.MockRequest{
+				{
+					Method:  http.MethodGet,
+					Path:    "baz/foo",
+					Params:  nil,
+					Headers: nil,
+				},
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &VaultDynamicSecretReconciler{
 				Client: tt.fields.Client,
 			}
-			got, _, err := r.syncSecret(tt.args.ctx, tt.args.vClient, tt.args.o, nil)
-			if !tt.wantErr(t, err, fmt.Sprintf("syncSecret(%v, %v, %v, %v)", tt.args.ctx, tt.args.vClient, tt.args.o, nil)) {
+			got, _, err := r.syncSecret(tt.args.ctx, tt.args.vClient, tt.args.o, nil, tt.args.vaultHeaders)
+			if !tt.wantErr(t, err, fmt.Sprintf("syncSecret(%v, %v, %v, %v, %v)", tt.args.ctx, tt.args.vClient, tt.args.o, nil, tt.args.vaultHeaders)) {
 				return
 			}
-			assert.Equalf(t, tt.want, got, "syncSecret(%v, %v, %v, %v)", tt.args.ctx, tt.args.vClient, tt.args.o, nil)
-			assert.Equalf(t, tt.expectRequests, tt.args.vClient.Requests, "syncSecret(%v, %v, %v, %v)", tt.args.ctx, tt.args.vClient, tt.args.o, nil)
+			assert.Equalf(t, tt.want, got, "syncSecret(%v, %v, %v, %v, %v)", tt.args.ctx, tt.args.vClient, tt.args.o, nil, tt.args.vaultHeaders)
+			assert.Equalf(t, tt.expectRequests, tt.args.vClient.Requests, "syncSecret(%v, %v, %v, %v, %v)", tt.args.ctx, tt.args.vClient, tt.args.o, nil, tt.args.vaultHeaders)
 		})
 	}
 }

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/http"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -51,6 +53,11 @@ type VaultStaticSecretReconciler struct {
 	// This channel should be closed when the controller is stopped.
 	SourceCh             chan event.GenericEvent
 	eventWatcherRegistry *eventWatcherRegistry
+	// pendingVaultIndex stores the vault_index from the most recent matched
+	// Vault event for each secret. Consumed once per reconcile via LoadAndDelete
+	// to attach X-Vault-Index on the subsequent Vault read request.
+	// Key: types.NamespacedName, Value: string.
+	pendingVaultIndex sync.Map
 }
 
 // +kubebuilder:rbac:groups=secrets.hashicorp.com,resources=vaultstaticsecrets,verbs=get;list;watch;create;update;patch;delete
@@ -139,7 +146,16 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}, nil
 	}
 
-	kvReq, err := newKVRequest(o.Spec)
+	// Consume any vault_index stored by the event watcher goroutine when the
+	// event that triggered this reconcile was received. Attach it as
+	// X-Vault-Index so Performance Standbys forward to the active node when
+	// their local WAL index is behind, guaranteeing fresh data.
+	var kvHeaders http.Header
+	if idx, ok := r.pendingVaultIndex.LoadAndDelete(req.NamespacedName); ok {
+		kvHeaders = http.Header{consts.HeaderVaultIndex: []string{idx.(string)}}
+	}
+
+	kvReq, err := newKVRequest(o.Spec, kvHeaders)
 	if err != nil {
 		horizon := computeHorizonWithJitter(requeueDurationOnError)
 		r.Recorder.Event(o, corev1.EventTypeWarning, consts.ReasonVaultStaticSecret, err.Error())
@@ -283,19 +299,23 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		// starts listening to events that are relevant to the secret so that updates can be triggered
 		// on a near-instant basis
 		err := EnsureEventWatcher(ctx, &InstantUpdateConfig{
-			Secret:          o,
-			Client:          c,
-			Registry:        r.eventWatcherRegistry,
-			BackOffRegistry: r.BackOffRegistry,
-			SourceCh:        r.SourceCh,
-			Recorder:        r.Recorder,
-			NewClientFunc:   r.newVSSClient,
+			Secret:            o,
+			Client:            c,
+			Registry:          r.eventWatcherRegistry,
+			BackOffRegistry:   r.BackOffRegistry,
+			SourceCh:          r.SourceCh,
+			Recorder:          r.Recorder,
+			NewClientFunc:     r.newVSSClient,
+			PendingVaultIndex: &r.pendingVaultIndex,
 		})
 		if err != nil {
 			r.Recorder.Eventf(o, corev1.EventTypeWarning, consts.ReasonEventWatcherError, "Failed to watch events: %s", err)
 		}
 	} else {
 		UnwatchEvents(r.eventWatcherRegistry, o)
+		// Clear any pending index so it does not persist across reconciles when
+		// instant updates is disabled.
+		r.pendingVaultIndex.Delete(req.NamespacedName)
 	}
 
 	o.Status.LastGeneration = o.GetGeneration()
@@ -330,6 +350,8 @@ func (r *VaultStaticSecretReconciler) handleDeletion(ctx context.Context, o clie
 	objKey := client.ObjectKeyFromObject(o)
 	r.referenceCache.Remove(SecretTransformation, objKey)
 	r.BackOffRegistry.Delete(objKey)
+	// Clean up any pending vault_index entry so it does not leak after deletion.
+	r.pendingVaultIndex.Delete(objKey)
 	UnwatchEvents(r.eventWatcherRegistry, o)
 	if controllerutil.ContainsFinalizer(o, vaultStaticSecretFinalizer) {
 		logger.Info("Removing finalizer")
@@ -390,13 +412,13 @@ func (r *VaultStaticSecretReconciler) SetupWithManager(mgr ctrl.Manager, opts co
 		Complete(r)
 }
 
-func newKVRequest(s secretsv1beta1.VaultStaticSecretSpec) (vault.ReadRequest, error) {
+func newKVRequest(s secretsv1beta1.VaultStaticSecretSpec, headers http.Header) (vault.ReadRequest, error) {
 	var kvReq vault.ReadRequest
 	switch s.Type {
 	case consts.KVSecretTypeV1:
-		kvReq = vault.NewKVReadRequestV1(s.Mount, s.Path, nil)
+		kvReq = vault.NewKVReadRequestV1(s.Mount, s.Path, headers)
 	case consts.KVSecretTypeV2:
-		kvReq = vault.NewKVReadRequestV2(s.Mount, s.Path, s.Version, nil)
+		kvReq = vault.NewKVReadRequestV2(s.Mount, s.Path, s.Version, headers)
 	default:
 		return nil, fmt.Errorf("unsupported secret type %q", s.Type)
 	}

--- a/controllers/vaultstaticsecret_controller_test.go
+++ b/controllers/vaultstaticsecret_controller_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package controllers
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
+	"github.com/hashicorp/vault-secrets-operator/consts"
+)
+
+func Test_newKVRequest(t *testing.T) {
+	t.Parallel()
+
+	const (
+		mount   = "secret"
+		path    = "app/config"
+		version = 3
+	)
+
+	vaultIndexHeader := http.Header{consts.HeaderVaultIndex: []string{"AAAAAAAAAZk="}}
+
+	tests := []struct {
+		name        string
+		spec        secretsv1beta1.VaultStaticSecretSpec
+		headers     http.Header
+		wantPath    string
+		wantHeaders http.Header
+		wantErr     bool
+	}{
+		// ── KV v1 ────────────────────────────────────────────────────────────────
+		{
+			name: "kvv1-nil-headers",
+			spec: secretsv1beta1.VaultStaticSecretSpec{
+				VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+					Mount: mount,
+					Path:  path,
+					Type:  consts.KVSecretTypeV1,
+				},
+			},
+			headers:     nil,
+			wantPath:    "secret/app/config",
+			wantHeaders: nil,
+		},
+		{
+			name: "kvv1-with-vault-index-header",
+			spec: secretsv1beta1.VaultStaticSecretSpec{
+				VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+					Mount: mount,
+					Path:  path,
+					Type:  consts.KVSecretTypeV1,
+				},
+			},
+			headers:     vaultIndexHeader,
+			wantPath:    "secret/app/config",
+			wantHeaders: vaultIndexHeader,
+		},
+		// ── KV v2 ────────────────────────────────────────────────────────────────
+		{
+			name: "kvv2-nil-headers",
+			spec: secretsv1beta1.VaultStaticSecretSpec{
+				VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+					Mount:   mount,
+					Path:    path,
+					Type:    consts.KVSecretTypeV2,
+					Version: 0,
+				},
+			},
+			headers:     nil,
+			wantPath:    "secret/data/app/config",
+			wantHeaders: nil,
+		},
+		{
+			name: "kvv2-with-vault-index-header",
+			spec: secretsv1beta1.VaultStaticSecretSpec{
+				VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+					Mount:   mount,
+					Path:    path,
+					Type:    consts.KVSecretTypeV2,
+					Version: 0,
+				},
+			},
+			headers:     vaultIndexHeader,
+			wantPath:    "secret/data/app/config",
+			wantHeaders: vaultIndexHeader,
+		},
+		{
+			// Version is passed through to the query parameter; headers are
+			// independent of it and must still be propagated.
+			name: "kvv2-with-version-and-vault-index-header",
+			spec: secretsv1beta1.VaultStaticSecretSpec{
+				VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+					Mount:   mount,
+					Path:    path,
+					Type:    consts.KVSecretTypeV2,
+					Version: version,
+				},
+			},
+			headers:     vaultIndexHeader,
+			wantPath:    "secret/data/app/config",
+			wantHeaders: vaultIndexHeader,
+		},
+		// ── Error cases ──────────────────────────────────────────────────────────
+		{
+			name: "unsupported-type-returns-error",
+			spec: secretsv1beta1.VaultStaticSecretSpec{
+				VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+					Mount: mount,
+					Path:  path,
+					Type:  "kv-v3",
+				},
+			},
+			headers: nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := newKVRequest(tt.spec, tt.headers)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, req)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, req)
+
+			assert.Equal(t, tt.wantPath, req.Path(), "unexpected request path")
+			assert.Equal(t, tt.wantHeaders, req.Headers(), "unexpected request headers")
+
+			// For KV v2 with a version, verify the version query parameter is present.
+			if tt.spec.Type == consts.KVSecretTypeV2 && tt.spec.Version > 0 {
+				vals := req.Values()
+				require.NotNil(t, vals)
+				assert.Equal(t, []string{"3"}, vals["version"])
+			}
+		})
+	}
+}

--- a/vault/client.go
+++ b/vault/client.go
@@ -858,9 +858,10 @@ func (c *defaultClient) incrementOperationCounter(operation string, err error) {
 }
 
 type MockRequest struct {
-	Method string
-	Path   string
-	Params map[string]any
+	Method  string
+	Path    string
+	Params  map[string]any
+	Headers http.Header
 }
 
 var _ ClientBase = (*MockRecordingVaultClient)(nil)
@@ -880,10 +881,10 @@ func (m *MockRecordingVaultClient) Taint() {}
 
 func (m *MockRecordingVaultClient) Read(_ context.Context, s ReadRequest) (Response, error) {
 	m.Requests = append(m.Requests, &MockRequest{
-		Method: http.MethodGet,
-
-		Path:   s.Path(),
-		Params: nil,
+		Method:  http.MethodGet,
+		Path:    s.Path(),
+		Params:  nil,
+		Headers: s.Headers(),
 	})
 
 	resps, ok := m.ReadResponses[s.Path()]
@@ -905,9 +906,10 @@ func (m *MockRecordingVaultClient) Read(_ context.Context, s ReadRequest) (Respo
 
 func (m *MockRecordingVaultClient) Write(_ context.Context, s WriteRequest) (Response, error) {
 	m.Requests = append(m.Requests, &MockRequest{
-		Method: http.MethodPut,
-		Path:   s.Path(),
-		Params: s.Data(),
+		Method:  http.MethodPut,
+		Path:    s.Path(),
+		Params:  s.Data(),
+		Headers: s.Headers(),
 	})
 
 	resps, ok := m.WriteResponses[s.Path()]


### PR DESCRIPTION
When a Vault WebSocket event triggers an instant-update reconcile, extract the `vault_index` from the event metadata and attach it as `X-Vault-Index` on the subsequent read request. This ensures VSO always reads the latest version of the secret, even when connected to a Performance Standby that may not have replicated the write yet.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
