### PR TITLE
Fix VSS double reconciliation issue and prevent WebSocket teardown/reconnect.

### DIFF
--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -285,6 +285,11 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		logger.V(consts.LogLevelDebug).Info("Secret sync not required")
 	}
 
+	o.Status.LastGeneration = o.GetGeneration()
+	if err := r.updateStatus(ctx, o, true, conditions...); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	if o.Spec.SyncConfig != nil && o.Spec.SyncConfig.InstantUpdates {
 		logger.V(consts.LogLevelDebug).Info("Event watcher enabled")
 		// ensure event watcher is running

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -301,11 +301,6 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		r.unWatchEvents(o, c)
 	}
 
-	o.Status.LastGeneration = o.GetGeneration()
-	if err := r.updateStatus(ctx, o, true, conditions...); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	return ctrl.Result{
 		RequeueAfter: requeueAfter,
 	}, nil


### PR DESCRIPTION
Move `ensureEventWatcher` to after `updateStatus()` so the `eventWatcherRegistry` stores the generation that reflects any mutation from `maybeAddFinalizer`'s `c.Update()` call. Previously, the registry stored a stale generation, causing the second reconcile's guard check to fail and unnecessarily tear down and recreate the **WebSocket** connection on VSS creation.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
