### PR TITLE
Fix Dynamic Secrets Integration tests.

### DIFF
--- a/test/integration/vaultdynamicsecret/terraform/locals.tf
+++ b/test/integration/vaultdynamicsecret/terraform/locals.tf
@@ -35,8 +35,7 @@ locals {
   dev_token_policies = concat(
     [
       vault_policy.revocation.name,
-      vault_policy.db.name,
-      vault_policy.db-events.name,
+      one(coalescelist(vault_policy.db-with-events[*].name, vault_policy.db[*].name)),
       vault_policy.k8s_secrets.name,
     ],
     vault_policy.db-scheduled[*].name,

--- a/test/integration/vaultdynamicsecret/terraform/locals.tf
+++ b/test/integration/vaultdynamicsecret/terraform/locals.tf
@@ -36,6 +36,7 @@ locals {
     [
       vault_policy.revocation.name,
       vault_policy.db.name,
+      vault_policy.db-events.name,
       vault_policy.k8s_secrets.name,
     ],
     vault_policy.db-scheduled[*].name,

--- a/test/integration/vaultdynamicsecret/terraform/postgres.tf
+++ b/test/integration/vaultdynamicsecret/terraform/postgres.tf
@@ -158,6 +158,7 @@ resource "vault_database_secret_backend_static_role" "postgres-scheduled" {
   ]
 }
 resource "vault_policy" "db" {
+  count     = var.use_events ? 0 : 1
   namespace = local.namespace
   name      = "${local.auth_policy}-db"
   policy    = <<EOT
@@ -173,10 +174,20 @@ path "${vault_database_secrets_mount.db.path}/static-creds/${vault_database_secr
 EOT
 }
 
-resource "vault_policy" "db-events" {
+resource "vault_policy" "db-with-events" {
+  count     = var.use_events ? 1 : 0
   namespace = local.namespace
-  name      = "${local.auth_policy}-db-events"
+  name      = "${local.auth_policy}-db"
   policy    = <<EOT
+path "${vault_database_secrets_mount.db.path}/creds/${vault_database_secret_backend_role.postgres.name}" {
+  capabilities = ["read"]
+}
+path "${vault_database_secrets_mount.db.path}/static-creds/${vault_database_secret_backend_static_role.postgres.name}" {
+  capabilities = ["read"]
+}
+path "${vault_database_secrets_mount.db.path}/static-creds/${vault_database_secret_backend_static_role.postgres-delayed.name}" {
+  capabilities = ["read"]
+}
 path "${vault_database_secrets_mount.db.path}/*" {
   capabilities = ["subscribe"]
   subscribe_event_types = ["database*"]

--- a/test/integration/vaultdynamicsecret/terraform/postgres.tf
+++ b/test/integration/vaultdynamicsecret/terraform/postgres.tf
@@ -173,6 +173,21 @@ path "${vault_database_secrets_mount.db.path}/static-creds/${vault_database_secr
 EOT
 }
 
+resource "vault_policy" "db-events" {
+  namespace = local.namespace
+  name      = "${local.auth_policy}-db-events"
+  policy    = <<EOT
+path "${vault_database_secrets_mount.db.path}/*" {
+  capabilities = ["subscribe"]
+  subscribe_event_types = ["database*"]
+}
+
+path "sys/events/subscribe/database*" {
+  capabilities = ["read"]
+}
+EOT
+}
+
 resource "vault_policy" "db-scheduled" {
   count     = var.with_static_role_scheduled ? 1 : 0
   namespace = local.namespace

--- a/test/integration/vaultdynamicsecret/terraform/variables.tf
+++ b/test/integration/vaultdynamicsecret/terraform/variables.tf
@@ -95,3 +95,8 @@ variable "with_xns" {
 variable "chart_postgres" {
   type = string
 }
+
+variable "use_events" {
+  type    = bool
+  default = false
+}

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -1493,6 +1493,7 @@ func TestVaultDynamicSecret_InstantUpdates(t *testing.T) {
 			"vault_token_period":         120,
 			"vault_db_default_lease_ttl": 30,
 			"with_static_role_scheduled": false,
+			"use_events":                 true,
 			"chart_postgres":             filepath.Join(chartsDir, "postgresql"),
 		},
 	}

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -1576,8 +1576,9 @@ func TestVaultDynamicSecret_InstantUpdates(t *testing.T) {
 	// Wait for initial sync: the K8s secret must exist with the raw data key.
 	assertDynamicSecret(t, nil, tfOptions.MaxRetries, tfOptions.TimeBetweenRetries, vdsObj,
 		map[string]int{
-			"password": 20,
-			"username": len(outputs.DBRoleStaticUser),
+			"password":        20,
+			"username":        len(outputs.DBRoleStaticUser),
+			"rotation_period": 2,
 		},
 		helpers.SecretDataKeyRaw,
 		"last_vault_rotation",

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -1530,10 +1530,11 @@ func TestVaultDynamicSecret_InstantUpdates(t *testing.T) {
 		created = append(created, o)
 	}
 
+	vaultAuthName := outputs.NamePrefix + "-default"
 	vaultAuth := &secretsv1beta1.VaultAuth{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      consts.NameDefault,
-			Namespace: operatorNS,
+			Name:      vaultAuthName,
+			Namespace: outputs.K8sNamespace,
 		},
 		Spec: secretsv1beta1.VaultAuthSpec{
 			Namespace: outputs.Namespace,
@@ -1560,6 +1561,7 @@ func TestVaultDynamicSecret_InstantUpdates(t *testing.T) {
 			Path:             "static-creds/" + outputs.DBRoleStatic,
 			AllowStaticCreds: true,
 			Revoke:           false,
+			VaultAuthRef:     vaultAuthName,
 			Destination: secretsv1beta1.Destination{
 				Name:   destName,
 				Create: true,


### PR DESCRIPTION
Fixes three issues in the `TestVaultDynamicSecret_InstantUpdates` enterprise integration test:

- `rotation_period` assertion: Enterprise Vault static-creds responses include a `rotation_period` field. Added it to the `assertDynamicSecret` expected map to match actual secret data.

- Parallel test conflict: Both `TestVaultDynamicSecret` and `TestVaultDynamicSecret_InstantUpdates` created a `VaultAuth` named default in the operator namespace, causing an already exists conflict when `testInParallel=true`. Changed `TestVaultDynamicSecret_InstantUpdates` to create its own `VaultAuth` in the app namespace and set `VaultAuthRef` on the VDS spec accordingly.

- Missing Vault event subscription policy: The test's Vault policy did not include permissions for the database event WebSocket endpoint `sys/events/subscribe/database*`, causing `SubscribeToEvents` to fail silently and the EventWatcherStarted Kubernetes event to never be emitted. Added a new `vault_policy.db-events` Terraform resource granting `subscribe` on the DB mount and read on `sys/events/subscribe/database*`, and included it in the token policies for the auth role.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
