### PR TITLE
Code for requeue event once even loop exit, registry cleanup an…

### DIFF
--- a/controllers/event_watcher_registry_test.go
+++ b/controllers/event_watcher_registry_test.go
@@ -4,57 +4,617 @@
 package controllers
 
 import (
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 )
+
+// Helper functions for event watcher registry tests
+
+// createTestRegistry creates a new event watcher registry for testing
+func createTestRegistry() *eventWatcherRegistry {
+	return newEventWatcherRegistry()
+}
+
+// createTestMeta creates test event watcher metadata
+func createTestMeta(generation int64, clientID string) *eventWatcherMeta {
+	return &eventWatcherMeta{
+		LastGeneration: generation,
+		LastClientID:   clientID,
+	}
+}
+
+// createTestNamespacedName creates a test NamespacedName
+func createTestNamespacedName(name, namespace string) types.NamespacedName {
+	return types.NamespacedName{Name: name, Namespace: namespace}
+}
+
+// registerResource registers a resource in the registry with given metadata
+func registerResource(registry *eventWatcherRegistry, objKey types.NamespacedName, generation int64, clientID string) {
+	meta := createTestMeta(generation, clientID)
+	registry.Register(objKey, meta)
+}
+
+// registerMultipleResources registers multiple resources in the registry
+func registerMultipleResources(registry *eventWatcherRegistry, resources []types.NamespacedName, generation int64, clientID string) {
+	for _, res := range resources {
+		registerResource(registry, res, generation, clientID)
+	}
+}
+
+// verifyRegistryCount asserts the registry has expected number of items
+func verifyRegistryCount(t *testing.T, registry *eventWatcherRegistry, expected int, msgAndArgs ...interface{}) {
+	assert.Equal(t, expected, registry.registry.ItemCount(), msgAndArgs...)
+}
+
+// verifyResourceExists asserts a resource exists in the registry
+func verifyResourceExists(t *testing.T, registry *eventWatcherRegistry, objKey types.NamespacedName) *eventWatcherMeta {
+	got, ok := registry.Get(objKey)
+	require.True(t, ok, "expected resource %s to exist in registry", objKey)
+	require.NotNil(t, got, "expected non-nil metadata for resource %s", objKey)
+	return got
+}
+
+// verifyResourceNotExists asserts a resource does not exist in the registry
+func verifyResourceNotExists(t *testing.T, registry *eventWatcherRegistry, objKey types.NamespacedName) {
+	got, ok := registry.Get(objKey)
+	assert.False(t, ok, "expected resource %s to not exist in registry", objKey)
+	assert.Nil(t, got, "expected nil metadata for resource %s", objKey)
+}
+
+// deleteMultipleResources deletes multiple resources from the registry
+func deleteMultipleResources(registry *eventWatcherRegistry, resources []types.NamespacedName) {
+	for _, res := range resources {
+		registry.Delete(res)
+	}
+}
+
+// verifyMultipleResourcesNotExist verifies multiple resources don't exist in registry
+func verifyMultipleResourcesNotExist(t *testing.T, registry *eventWatcherRegistry, resources []types.NamespacedName) {
+	for _, res := range resources {
+		verifyResourceNotExists(t, registry, res)
+	}
+}
+
+// verifyMultipleResourcesExist verifies multiple resources exist in registry
+func verifyMultipleResourcesExist(t *testing.T, registry *eventWatcherRegistry, resources []types.NamespacedName) {
+	for _, res := range resources {
+		verifyResourceExists(t, registry, res)
+	}
+}
 
 // Test the event watcher registry basics
 func TestEventWatcherRegistry(t *testing.T) {
-	// Create a new registry
-	registry := newEventWatcherRegistry()
-	assert.Equal(t, 0, registry.registry.ItemCount())
-
-	// Create a new event subscription metadata
-	meta := &eventWatcherMeta{
-		LastGeneration: 123,
-		LastClientID:   "client-id",
-	}
+	registry := createTestRegistry()
+	verifyRegistryCount(t, registry, 0)
 
 	// Register the event subscription
-	itemName := types.NamespacedName{Name: "test", Namespace: "default"}
-	registry.Register(itemName, meta)
-	assert.Equal(t, 1, registry.registry.ItemCount())
+	itemName := createTestNamespacedName("test", "default")
+	registerResource(registry, itemName, 123, "client-id")
+	verifyRegistryCount(t, registry, 1)
 
-	// Get the event subscription metadata
-	got, ok := registry.Get(itemName)
-	require.True(t, ok, "expected to get event subscription metadata, got none")
-	require.NotNil(t, got, "expected to get event subscription metadata, got nil")
-
+	// Get and verify the event subscription metadata
+	got := verifyResourceExists(t, registry, itemName)
 	assert.Equal(t, int64(123), got.LastGeneration)
 	assert.Equal(t, "client-id", got.LastClientID)
 
-	// Update something
+	// Update and verify
 	got.LastGeneration = 456
 	registry.Register(itemName, got)
-	assert.Equal(t, 1, registry.registry.ItemCount())
+	verifyRegistryCount(t, registry, 1)
 
-	// Get again
-	gotAgain, ok := registry.Get(itemName)
-	require.True(t, ok, "expected to get event subscription metadata again, got none")
-	require.NotNil(t, gotAgain, "expected to get event subscription metadata again, got nil")
-
+	gotAgain := verifyResourceExists(t, registry, itemName)
 	assert.Equal(t, int64(456), gotAgain.LastGeneration)
 	assert.Equal(t, "client-id", gotAgain.LastClientID)
 
-	// Delete the event subscription
+	// Delete and verify cleanup
 	registry.Delete(itemName)
-	assert.Equal(t, 0, registry.registry.ItemCount())
+	verifyRegistryCount(t, registry, 0)
+	verifyResourceNotExists(t, registry, itemName)
+}
 
-	// Get the event subscription metadata
-	gotFinally, ok := registry.Get(itemName)
-	assert.False(t, ok, "expected to not get event subscription metadata, got one")
-	assert.Nil(t, gotFinally, "expected nil event subscription metadata")
+// TestEventWatcherRegistry_RequeueOnEventLoopExit tests that when an event loop
+// exits (OnStop callback is triggered), the registry is cleaned up and a requeue
+// event is sent to trigger reconciliation.
+func TestEventWatcherRegistry_RequeueOnEventLoopExit(t *testing.T) {
+	registry := createTestRegistry()
+	reconcileCh := make(chan event.GenericEvent, 10)
+
+	objKey := createTestNamespacedName("test-vss", "default")
+
+	// Register the resource (simulates active event watcher)
+	registerResource(registry, objKey, 1, "client-123")
+	verifyRegistryCount(t, registry, 1, "resource should be registered")
+
+	// Simulate OnStop callback being called when event loop exits
+	// This mimics the behavior in vaultstaticsecret_controller.go:398-403
+	onStopCallback := func() {
+		// Clean up registry entry
+		registry.Delete(objKey)
+
+		// Send requeue event to trigger reconciliation
+		select {
+		case reconcileCh <- event.GenericEvent{
+			Object: &secretsv1beta1.VaultStaticSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      objKey.Name,
+					Namespace: objKey.Namespace,
+				},
+			},
+		}:
+		default:
+			t.Error("Failed to send requeue event - channel full")
+		}
+	}
+
+	// Trigger the OnStop callback (simulating event loop exit)
+	onStopCallback()
+
+	// Verify registry was cleaned up
+	verifyRegistryCount(t, registry, 0, "registry should be cleaned up after event loop exit")
+	verifyResourceNotExists(t, registry, objKey)
+
+	// Verify requeue event was sent
+	select {
+	case evt := <-reconcileCh:
+		assert.NotNil(t, evt.Object, "requeue event should contain object")
+		vss, ok := evt.Object.(*secretsv1beta1.VaultStaticSecret)
+		require.True(t, ok, "requeue event should be for VaultStaticSecret")
+		assert.Equal(t, objKey.Name, vss.Name)
+		assert.Equal(t, objKey.Namespace, vss.Namespace)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for requeue event - requeue was not triggered")
+	}
+}
+
+// TestEventWatcherRegistry_RegistryCleanup verifies that registry entries are
+// properly cleaned up when resources are deleted or event loops exit, preventing
+// resource leaks and ensuring clean state management.
+func TestEventWatcherRegistry_RegistryCleanup(t *testing.T) {
+	registry := createTestRegistry()
+
+	// Register multiple resources
+	resources := []types.NamespacedName{
+		createTestNamespacedName("vss-1", "default"),
+		createTestNamespacedName("vss-2", "default"),
+		createTestNamespacedName("vss-3", "app-ns"),
+	}
+
+	registerMultipleResources(registry, resources, 1, "client-123")
+	verifyRegistryCount(t, registry, 3, "all resources should be registered")
+
+	// Simulate cleanup when resources are deleted (OnStop callbacks)
+	deleteMultipleResources(registry, resources)
+
+	// Verify all entries are cleaned up
+	verifyRegistryCount(t, registry, 0, "all registry entries should be cleaned up")
+	verifyMultipleResourcesNotExist(t, registry, resources)
+}
+
+// TestEventWatcherRegistry_OrphanedEntryDetection verifies detection and cleanup
+// of orphaned registry entries (entries that exist but WebSocket is dead), ensuring
+// the system can recover from connection failures.
+func TestEventWatcherRegistry_OrphanedEntryDetection(t *testing.T) {
+	registry := createTestRegistry()
+
+	// Register resources
+	activeRes := createTestNamespacedName("active-vss", "default")
+	orphanedRes := createTestNamespacedName("orphaned-vss", "default")
+
+	registerResource(registry, activeRes, 1, "client-1")
+	registerResource(registry, orphanedRes, 1, "client-2")
+
+	verifyRegistryCount(t, registry, 2)
+
+	// Simulate orphan detection and cleanup
+	verifyResourceExists(t, registry, orphanedRes)
+
+	// Clean up the orphaned entry
+	registry.Delete(orphanedRes)
+
+	// Verify orphaned entry is removed
+	verifyRegistryCount(t, registry, 1)
+	verifyResourceNotExists(t, registry, orphanedRes)
+
+	// Active entry should remain
+	got := verifyResourceExists(t, registry, activeRes)
+	assert.Equal(t, "client-1", got.LastClientID)
+}
+
+// TestEventWatcherRegistry_ConcurrentCleanup tests that concurrent cleanup
+// operations (multiple event loops exiting simultaneously) are handled safely.
+func TestEventWatcherRegistry_ConcurrentCleanup(t *testing.T) {
+	registry := newEventWatcherRegistry()
+
+	// Register multiple resources
+	numResources := 50
+	resources := make([]types.NamespacedName, numResources)
+	for i := 0; i < numResources; i++ {
+		resources[i] = types.NamespacedName{
+			Name:      "vss-" + string(rune(i)),
+			Namespace: "default",
+		}
+		meta := &eventWatcherMeta{
+			LastGeneration: int64(i),
+			LastClientID:   "client-" + string(rune(i)),
+		}
+		registry.Register(resources[i], meta)
+	}
+
+	assert.Equal(t, numResources, registry.registry.ItemCount())
+
+	// Simulate concurrent event loop exits
+	var wg sync.WaitGroup
+	for _, res := range resources {
+		wg.Add(1)
+		go func(objKey types.NamespacedName) {
+			defer wg.Done()
+			registry.Delete(objKey)
+		}(res)
+	}
+
+	wg.Wait()
+
+	// Verify all registry entries are cleaned up
+	assert.Equal(t, 0, registry.registry.ItemCount(),
+		"all registry entries should be cleaned up after concurrent exits")
+}
+
+// TestEventWatcherRegistry_CleanupOnResourceDeletion verifies that when a
+// Kubernetes resource is deleted, its registry entry is properly removed,
+// ensuring clean resource lifecycle management.
+func TestEventWatcherRegistry_CleanupOnResourceDeletion(t *testing.T) {
+	registry := newEventWatcherRegistry()
+
+	// Register a resource
+	objKey := types.NamespacedName{Name: "vss-to-delete", Namespace: "default"}
+	meta := &eventWatcherMeta{
+		LastGeneration: 1,
+		LastClientID:   "client-123",
+	}
+	registry.Register(objKey, meta)
+	assert.Equal(t, 1, registry.registry.ItemCount())
+
+	// Simulate resource deletion (finalizer cleanup triggers OnStop callback)
+	// In real code: vaultstaticsecret_controller.go:330-354 (finalize method)
+	registry.Delete(objKey)
+
+	// Verify registry entry is removed
+	assert.Equal(t, 0, registry.registry.ItemCount(), "registry should be cleaned up after resource deletion")
+	_, ok := registry.Get(objKey)
+	assert.False(t, ok, "deleted resource should not be in registry")
+}
+
+// TestEventWatcherRegistry_CleanupOnReconcilerError verifies that registry
+// cleanup happens even when reconciler encounters errors, ensuring robust
+// error handling and preventing resource leaks during failures.
+func TestEventWatcherRegistry_CleanupOnReconcilerError(t *testing.T) {
+	registry := newEventWatcherRegistry()
+
+	objKey := types.NamespacedName{Name: "vss-error", Namespace: "default"}
+	meta := &eventWatcherMeta{
+		LastGeneration: 1,
+		LastClientID:   "client-123",
+	}
+
+	// Register resource
+	registry.Register(objKey, meta)
+	assert.Equal(t, 1, registry.registry.ItemCount())
+
+	// Simulate reconciler error scenario
+	// Even if reconciler fails, OnStop callback should still clean up registry
+	// This happens when: Vault connection fails, auth fails, etc.
+	simulateReconcilerError := func() error {
+		// Simulate error during reconciliation
+		// In real code: vaultstaticsecret_controller.go:334-341
+		// Even with error, cleanup should happen
+		registry.Delete(objKey)
+		return assert.AnError // Simulated error
+	}
+
+	err := simulateReconcilerError()
+	assert.Error(t, err, "reconciler should return error")
+
+	// Verify cleanup happened despite error
+	assert.Equal(t, 0, registry.registry.ItemCount(), "registry should be cleaned up even on reconciler error")
+	_, ok := registry.Get(objKey)
+	assert.False(t, ok, "resource should be removed from registry despite error")
+}
+
+// TestEventWatcherRegistry_CleanupOnNamespaceDeletion verifies that when a
+// namespace is deleted, all registry entries for resources in that namespace
+// are properly cleaned up, ensuring proper multi-tenant resource isolation.
+func TestEventWatcherRegistry_CleanupOnNamespaceDeletion(t *testing.T) {
+	registry := createTestRegistry()
+
+	// Register resources in multiple namespaces
+	namespacesToDelete := "app-ns"
+	namespacesToKeep := "default"
+
+	resourcesToDelete := []types.NamespacedName{
+		createTestNamespacedName("vss-1", namespacesToDelete),
+		createTestNamespacedName("vss-2", namespacesToDelete),
+		createTestNamespacedName("vss-3", namespacesToDelete),
+	}
+
+	resourcesToKeep := []types.NamespacedName{
+		createTestNamespacedName("vss-4", namespacesToKeep),
+		createTestNamespacedName("vss-5", namespacesToKeep),
+	}
+
+	// Register all resources
+	registerMultipleResources(registry, append(resourcesToDelete, resourcesToKeep...), 1, "client-123")
+	verifyRegistryCount(t, registry, 5, "all resources should be registered")
+
+	// Simulate namespace deletion
+	deleteMultipleResources(registry, resourcesToDelete)
+
+	// Verify only resources from deleted namespace are cleaned up
+	verifyRegistryCount(t, registry, 2, "only resources from non-deleted namespace should remain")
+	verifyMultipleResourcesNotExist(t, registry, resourcesToDelete)
+	verifyMultipleResourcesExist(t, registry, resourcesToKeep)
+}
+
+// TestEventWatcherRegistry_NoMemoryLeak verifies that the registry doesn't leak
+// memory when resources are repeatedly registered and deleted, ensuring long-term
+// stability in high-churn environments.
+func TestEventWatcherRegistry_NoMemoryLeak(t *testing.T) {
+	registry := createTestRegistry()
+
+	// Simulate many register/delete cycles (like in a busy cluster)
+	iterations := 1000
+	resourceNames := 10 // Reuse 10 resource names
+
+	for i := 0; i < iterations; i++ {
+		res := createTestNamespacedName("vss-"+string(rune(i%resourceNames)), "default")
+		registerResource(registry, res, int64(i), "client-"+string(rune(i)))
+		registry.Delete(res)
+	}
+
+	// Registry should be empty after all deletions
+	verifyRegistryCount(t, registry, 0, "registry should be empty after all deletions - no memory leak")
+
+	// Verify no entries remain
+	for i := 0; i < resourceNames; i++ {
+		res := createTestNamespacedName("vss-"+string(rune(i)), "default")
+		verifyResourceNotExists(t, registry, res)
+	}
+}
+
+// TestEventWatcherRegistry_CleanupWithHighChurn verifies registry cleanup under
+// high churn (many resources being created and deleted rapidly), ensuring the
+// system remains stable under heavy load.
+func TestEventWatcherRegistry_CleanupWithHighChurn(t *testing.T) {
+	registry := createTestRegistry()
+
+	// Simulate high churn scenario
+	numCycles := 100
+	resourcesPerCycle := 10
+
+	for cycle := 0; cycle < numCycles; cycle++ {
+		// Create batch of resources
+		resources := make([]types.NamespacedName, resourcesPerCycle)
+		for i := 0; i < resourcesPerCycle; i++ {
+			resources[i] = createTestNamespacedName("vss-"+string(rune(cycle*resourcesPerCycle+i)), "default")
+			registerResource(registry, resources[i], int64(cycle), "client-"+string(rune(cycle)))
+		}
+
+		// Verify registration
+		verifyRegistryCount(t, registry, resourcesPerCycle, "all resources in cycle %d should be registered", cycle)
+
+		// Delete all resources in this cycle
+		deleteMultipleResources(registry, resources)
+
+		// Verify cleanup after each cycle
+		verifyRegistryCount(t, registry, 0, "registry should be empty after cycle %d cleanup", cycle)
+	}
+
+	// Final verification - no memory leak after high churn
+	verifyRegistryCount(t, registry, 0, "registry should be empty after high churn - no memory leak")
+}
+
+// TestEventWatcherRegistry_OrphanDetectionAfterCrash verifies detection of orphaned
+// entries that remain after operator crash (OnStop callback never ran), ensuring
+// graceful recovery from unexpected failures.
+func TestEventWatcherRegistry_OrphanDetectionAfterCrash(t *testing.T) {
+	registry := createTestRegistry()
+
+	// Simulate resources registered before crash
+	crashedResources := []types.NamespacedName{
+		createTestNamespacedName("vss-crashed-1", "default"),
+		createTestNamespacedName("vss-crashed-2", "default"),
+	}
+
+	registerMultipleResources(registry, crashedResources, 1, "client-before-crash")
+	verifyRegistryCount(t, registry, 2, "resources registered before crash")
+
+	// Detect and clean up orphaned entries
+	for _, res := range crashedResources {
+		if _, exists := registry.Get(res); exists {
+			registry.Delete(res)
+		}
+	}
+
+	// Verify all orphaned entries are cleaned up
+	verifyRegistryCount(t, registry, 0, "all orphaned entries should be cleaned up")
+	verifyMultipleResourcesNotExist(t, registry, crashedResources)
+}
+
+// TestEventWatcherRegistry_OrphanDetectionWithMixedState verifies orphan detection
+// when some entries are healthy and some are orphaned, ensuring selective cleanup
+// that preserves healthy connections while removing stale ones.
+func TestEventWatcherRegistry_OrphanDetectionWithMixedState(t *testing.T) {
+	registry := createTestRegistry()
+
+	// Register healthy resources (WebSocket active)
+	healthyResources := []types.NamespacedName{
+		createTestNamespacedName("vss-healthy-1", "default"),
+		createTestNamespacedName("vss-healthy-2", "default"),
+	}
+
+	// Register orphaned resources (WebSocket dead)
+	orphanedResources := []types.NamespacedName{
+		createTestNamespacedName("vss-orphaned-1", "default"),
+		createTestNamespacedName("vss-orphaned-2", "default"),
+		createTestNamespacedName("vss-orphaned-3", "default"),
+	}
+
+	// Register all resources
+	registerMultipleResources(registry, append(healthyResources, orphanedResources...), 1, "client-123")
+	verifyRegistryCount(t, registry, 5, "all resources registered")
+
+	// Simulate orphan detection logic
+	deleteMultipleResources(registry, orphanedResources)
+
+	// Verify only orphaned entries are cleaned up
+	verifyRegistryCount(t, registry, 2, "only healthy resources should remain")
+	verifyMultipleResourcesNotExist(t, registry, orphanedResources)
+	verifyMultipleResourcesExist(t, registry, healthyResources)
+}
+
+// TestEventWatcherRegistry_OrphanDetectionRaceCondition verifies orphan detection
+// when there's a race between cleanup and new subscription, ensuring thread-safe
+// operations and consistent state management.
+func TestEventWatcherRegistry_OrphanDetectionRaceCondition(t *testing.T) {
+	registry := createTestRegistry()
+
+	objKey := createTestNamespacedName("vss-race", "default")
+
+	// Simulate race condition scenario
+	var wg sync.WaitGroup
+
+	// Goroutine 1: Detects orphan and tries to clean up
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond) // Small delay
+		// Orphan detection finds dead WebSocket
+		registry.Delete(objKey)
+	}()
+
+	// Goroutine 2: New subscription tries to register
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		meta := &eventWatcherMeta{
+			LastGeneration: 2,
+			LastClientID:   "client-new",
+		}
+		registry.Register(objKey, meta)
+	}()
+
+	wg.Wait()
+
+	// After race, registry should be in consistent state
+	// Either entry exists (new subscription won) or doesn't (cleanup won)
+	count := registry.registry.ItemCount()
+	assert.True(t, count == 0 || count == 1, "registry should be in consistent state after race")
+
+	if count == 1 {
+		// If entry exists, it should be the new one
+		got, ok := registry.Get(objKey)
+		assert.True(t, ok)
+		// Could be either generation depending on race outcome
+		assert.NotNil(t, got)
+	}
+}
+
+// TestEventWatcherRegistry_AutomaticOrphanCleanup verifies that orphan cleanup
+// happens automatically during reconciliation, ensuring self-healing behavior
+// without manual intervention.
+func TestEventWatcherRegistry_AutomaticOrphanCleanup(t *testing.T) {
+	registry := createTestRegistry()
+
+	// Simulate orphaned entries from previous operator run
+	orphanedEntries := []types.NamespacedName{
+		createTestNamespacedName("vss-old-1", "default"),
+		createTestNamespacedName("vss-old-2", "app-ns"),
+		createTestNamespacedName("vss-old-3", "default"),
+	}
+
+	registerMultipleResources(registry, orphanedEntries, 1, "client-old")
+	verifyRegistryCount(t, registry, 3, "orphaned entries exist")
+
+	// Simulate automatic orphan detection during reconciliation
+	cleanupOrphans := func() {
+		for _, res := range orphanedEntries {
+			if _, exists := registry.Get(res); exists {
+				registry.Delete(res)
+			}
+		}
+	}
+
+	// Run automatic cleanup
+	cleanupOrphans()
+
+	// Verify all orphans are automatically cleaned up
+	verifyRegistryCount(t, registry, 0, "all orphans should be automatically cleaned up")
+	verifyMultipleResourcesNotExist(t, registry, orphanedEntries)
+}
+
+// TestEventWatcherRegistry_OrphanDetectionMultipleGenerations verifies orphan
+// detection when resource has been updated multiple times, ensuring proper
+// generation tracking and cleanup of stale entries.
+func TestEventWatcherRegistry_OrphanDetectionMultipleGenerations(t *testing.T) {
+	registry := createTestRegistry()
+
+	objKey := createTestNamespacedName("vss-multi-gen", "default")
+
+	// Register with generation 1, then update to 2, then 3
+	registerResource(registry, objKey, 1, "client-1")
+	registerResource(registry, objKey, 2, "client-2")
+	registerResource(registry, objKey, 3, "client-3")
+
+	// Verify latest generation is stored
+	got := verifyResourceExists(t, registry, objKey)
+	assert.Equal(t, int64(3), got.LastGeneration)
+	assert.Equal(t, "client-3", got.LastClientID)
+
+	// Simulate orphan detection - WebSocket for generation 3 is dead
+	registry.Delete(objKey)
+
+	// Verify orphaned entry is cleaned up
+	verifyRegistryCount(t, registry, 0)
+	verifyResourceNotExists(t, registry, objKey)
+}
+
+// TestEventWatcherRegistry_OrphanDetectionClientIDChange verifies orphan detection
+// when Vault client ID changes (new auth, token rotation, etc.), ensuring proper
+// cleanup during authentication lifecycle changes.
+func TestEventWatcherRegistry_OrphanDetectionClientIDChange(t *testing.T) {
+	registry := createTestRegistry()
+
+	objKey := createTestNamespacedName("vss-client-change", "default")
+
+	// Register with original client
+	registerResource(registry, objKey, 1, "client-original")
+
+	// Verify registration
+	got := verifyResourceExists(t, registry, objKey)
+	assert.Equal(t, "client-original", got.LastClientID)
+
+	// Detect orphan (client ID mismatch)
+	currentClientID := "client-new"
+	if got.LastClientID != currentClientID {
+		registry.Delete(objKey)
+	}
+
+	// Verify orphaned entry is cleaned up
+	verifyRegistryCount(t, registry, 0)
+	verifyResourceNotExists(t, registry, objKey)
+
+	// Register with new client
+	registerResource(registry, objKey, 1, currentClientID)
+
+	// Verify new entry exists
+	got = verifyResourceExists(t, registry, objKey)
+	assert.Equal(t, currentClientID, got.LastClientID)
 }

--- a/controllers/event_watcher_registry_test.go
+++ b/controllers/event_watcher_registry_test.go
@@ -121,10 +121,10 @@ func TestEventWatcherRegistry(t *testing.T) {
 	verifyResourceNotExists(t, registry, itemName)
 }
 
-// TestEventWatcherRegistry_RequeueOnEventLoopExit tests that when an event loop
-// exits (OnStop callback is triggered), the registry is cleaned up and a requeue
+// TestEventWatcherRegistry_RequeueOnEventLoopExit_VSS tests that when an event loop
+// exits for a VaultStaticSecret (OnStop callback is triggered), the registry is cleaned up and a requeue
 // event is sent to trigger reconciliation.
-func TestEventWatcherRegistry_RequeueOnEventLoopExit(t *testing.T) {
+func TestEventWatcherRegistry_RequeueOnEventLoopExit_VSS(t *testing.T) {
 	registry := createTestRegistry()
 	reconcileCh := make(chan event.GenericEvent, 10)
 
@@ -134,8 +134,7 @@ func TestEventWatcherRegistry_RequeueOnEventLoopExit(t *testing.T) {
 	registerResource(registry, objKey, 1, "client-123")
 	verifyRegistryCount(t, registry, 1, "resource should be registered")
 
-	// Simulate OnStop callback being called when event loop exits
-	// This mimics the behavior in vaultstaticsecret_controller.go:398-403
+	// Simulate OnStop callback being called when event loop exits.
 	onStopCallback := func() {
 		// Clean up registry entry
 		registry.Delete(objKey)
@@ -172,6 +171,57 @@ func TestEventWatcherRegistry_RequeueOnEventLoopExit(t *testing.T) {
 		assert.Equal(t, objKey.Namespace, vss.Namespace)
 	case <-time.After(1 * time.Second):
 		t.Fatal("timeout waiting for requeue event - requeue was not triggered")
+	}
+}
+
+// TestEventWatcherRegistry_RequeueOnEventLoopExit_VDS verifies that when the
+// event loop exits for a VaultDynamicSecret, the OnStop callback cleans the
+// registry and sends a requeue event carrying a *VaultDynamicSecret object so
+// the VDS controller's WatchesRawSource handles it.
+func TestEventWatcherRegistry_RequeueOnEventLoopExit_VDS(t *testing.T) {
+	registry := createTestRegistry()
+	reconcileCh := make(chan event.GenericEvent, 10)
+
+	objKey := createTestNamespacedName("test-vds", "default")
+
+	// Register the resource (simulates active event watcher)
+	registerResource(registry, objKey, 1, "client-123")
+	verifyRegistryCount(t, registry, 1, "resource should be registered")
+
+	// Simulate OnStop callback for a VaultDynamicSecret subscriber
+	onStopCallback := func() {
+		registry.Delete(objKey)
+
+		select {
+		case reconcileCh <- event.GenericEvent{
+			Object: &secretsv1beta1.VaultDynamicSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      objKey.Name,
+					Namespace: objKey.Namespace,
+				},
+			},
+		}:
+		default:
+			t.Error("Failed to send requeue event - channel full")
+		}
+	}
+
+	onStopCallback()
+
+	// Registry must be cleaned up
+	verifyRegistryCount(t, registry, 0, "registry should be cleaned up after event loop exit")
+	verifyResourceNotExists(t, registry, objKey)
+
+	// Requeue event must carry a *VaultDynamicSecret, not *VaultStaticSecret
+	select {
+	case evt := <-reconcileCh:
+		assert.NotNil(t, evt.Object, "requeue event should contain object")
+		vds, ok := evt.Object.(*secretsv1beta1.VaultDynamicSecret)
+		require.True(t, ok, "requeue event object must be *VaultDynamicSecret so the VDS controller handles it")
+		assert.Equal(t, objKey.Name, vds.Name)
+		assert.Equal(t, objKey.Namespace, vds.Namespace)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for requeue event")
 	}
 }
 

--- a/controllers/event_watcher_registry_test.go
+++ b/controllers/event_watcher_registry_test.go
@@ -4,17 +4,14 @@
 package controllers
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-
-	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 )
 
 // Helper functions for event watcher registry tests
@@ -121,187 +118,95 @@ func TestEventWatcherRegistry(t *testing.T) {
 	verifyResourceNotExists(t, registry, itemName)
 }
 
-// TestEventWatcherRegistry_RequeueOnEventLoopExit_VSS tests that when an event loop
-// exits for a VaultStaticSecret (OnStop callback is triggered), the registry is cleaned up and a requeue
-// event is sent to trigger reconciliation.
-func TestEventWatcherRegistry_RequeueOnEventLoopExit_VSS(t *testing.T) {
-	registry := createTestRegistry()
-	reconcileCh := make(chan event.GenericEvent, 10)
+// TestEventWatcherRegistry_CRUDContract verifies the registry's fundamental
+// semantics: last-write-wins update, selective delete, idempotent delete, and
+// re-register after delete. Scenarios that only exercise registry.Delete
+// directly (resource deletion, reconciler error, crash recovery, orphan
+// detection by client-ID change, etc.) are folded here — the registry has no
+// knowledge of those production contexts and the CRUD contract is identical
+// in all of them.
+func TestEventWatcherRegistry_CRUDContract(t *testing.T) {
+	t.Run("last-write-wins update", func(t *testing.T) {
+		registry := createTestRegistry()
+		key := createTestNamespacedName("vss", "default")
+		registerResource(registry, key, 1, "client-1")
+		registerResource(registry, key, 2, "client-2")
+		registerResource(registry, key, 3, "client-3")
+		got := verifyResourceExists(t, registry, key)
+		assert.Equal(t, int64(3), got.LastGeneration)
+		assert.Equal(t, "client-3", got.LastClientID)
+	})
 
-	objKey := createTestNamespacedName("test-vss", "default")
+	t.Run("delete removes entry", func(t *testing.T) {
+		registry := createTestRegistry()
+		key := createTestNamespacedName("vss", "default")
+		registerResource(registry, key, 1, "client-1")
+		registry.Delete(key)
+		verifyRegistryCount(t, registry, 0)
+		verifyResourceNotExists(t, registry, key)
+	})
 
-	// Register the resource (simulates active event watcher)
-	registerResource(registry, objKey, 1, "client-123")
-	verifyRegistryCount(t, registry, 1, "resource should be registered")
+	t.Run("delete is idempotent", func(t *testing.T) {
+		registry := createTestRegistry()
+		key := createTestNamespacedName("vss", "default")
+		registry.Delete(key) // never registered — must not panic
+		verifyRegistryCount(t, registry, 0)
+	})
 
-	// Simulate OnStop callback being called when event loop exits.
-	onStopCallback := func() {
-		// Clean up registry entry
-		registry.Delete(objKey)
+	t.Run("selective delete preserves other entries", func(t *testing.T) {
+		registry := createTestRegistry()
+		keep := createTestNamespacedName("vss-keep", "default")
+		del := createTestNamespacedName("vss-del", "default")
+		registerResource(registry, keep, 1, "c")
+		registerResource(registry, del, 1, "c")
+		registry.Delete(del)
+		verifyRegistryCount(t, registry, 1)
+		verifyResourceExists(t, registry, keep)
+		verifyResourceNotExists(t, registry, del)
+	})
 
-		// Send requeue event to trigger reconciliation
-		select {
-		case reconcileCh <- event.GenericEvent{
-			Object: &secretsv1beta1.VaultStaticSecret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      objKey.Name,
-					Namespace: objKey.Namespace,
-				},
-			},
-		}:
-		default:
-			t.Error("Failed to send requeue event - channel full")
+	t.Run("re-register after delete", func(t *testing.T) {
+		registry := createTestRegistry()
+		key := createTestNamespacedName("vss", "default")
+		registerResource(registry, key, 1, "client-old")
+		registry.Delete(key)
+		registerResource(registry, key, 2, "client-new")
+		got := verifyResourceExists(t, registry, key)
+		assert.Equal(t, int64(2), got.LastGeneration)
+		assert.Equal(t, "client-new", got.LastClientID)
+	})
+
+	t.Run("delete multiple entries — all removed", func(t *testing.T) {
+		registry := createTestRegistry()
+		resources := []types.NamespacedName{
+			createTestNamespacedName("vss-1", "default"),
+			createTestNamespacedName("vss-2", "default"),
+			createTestNamespacedName("vss-3", "app-ns"),
 		}
-	}
-
-	// Trigger the OnStop callback (simulating event loop exit)
-	onStopCallback()
-
-	// Verify registry was cleaned up
-	verifyRegistryCount(t, registry, 0, "registry should be cleaned up after event loop exit")
-	verifyResourceNotExists(t, registry, objKey)
-
-	// Verify requeue event was sent
-	select {
-	case evt := <-reconcileCh:
-		assert.NotNil(t, evt.Object, "requeue event should contain object")
-		vss, ok := evt.Object.(*secretsv1beta1.VaultStaticSecret)
-		require.True(t, ok, "requeue event should be for VaultStaticSecret")
-		assert.Equal(t, objKey.Name, vss.Name)
-		assert.Equal(t, objKey.Namespace, vss.Namespace)
-	case <-time.After(1 * time.Second):
-		t.Fatal("timeout waiting for requeue event - requeue was not triggered")
-	}
+		registerMultipleResources(registry, resources, 1, "client-123")
+		verifyRegistryCount(t, registry, 3)
+		deleteMultipleResources(registry, resources)
+		verifyRegistryCount(t, registry, 0)
+		verifyMultipleResourcesNotExist(t, registry, resources)
+	})
 }
 
-// TestEventWatcherRegistry_RequeueOnEventLoopExit_VDS verifies that when the
-// event loop exits for a VaultDynamicSecret, the OnStop callback cleans the
-// registry and sends a requeue event carrying a *VaultDynamicSecret object so
-// the VDS controller's WatchesRawSource handles it.
-func TestEventWatcherRegistry_RequeueOnEventLoopExit_VDS(t *testing.T) {
-	registry := createTestRegistry()
-	reconcileCh := make(chan event.GenericEvent, 10)
-
-	objKey := createTestNamespacedName("test-vds", "default")
-
-	// Register the resource (simulates active event watcher)
-	registerResource(registry, objKey, 1, "client-123")
-	verifyRegistryCount(t, registry, 1, "resource should be registered")
-
-	// Simulate OnStop callback for a VaultDynamicSecret subscriber
-	onStopCallback := func() {
-		registry.Delete(objKey)
-
-		select {
-		case reconcileCh <- event.GenericEvent{
-			Object: &secretsv1beta1.VaultDynamicSecret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      objKey.Name,
-					Namespace: objKey.Namespace,
-				},
-			},
-		}:
-		default:
-			t.Error("Failed to send requeue event - channel full")
-		}
-	}
-
-	onStopCallback()
-
-	// Registry must be cleaned up
-	verifyRegistryCount(t, registry, 0, "registry should be cleaned up after event loop exit")
-	verifyResourceNotExists(t, registry, objKey)
-
-	// Requeue event must carry a *VaultDynamicSecret, not *VaultStaticSecret
-	select {
-	case evt := <-reconcileCh:
-		assert.NotNil(t, evt.Object, "requeue event should contain object")
-		vds, ok := evt.Object.(*secretsv1beta1.VaultDynamicSecret)
-		require.True(t, ok, "requeue event object must be *VaultDynamicSecret so the VDS controller handles it")
-		assert.Equal(t, objKey.Name, vds.Name)
-		assert.Equal(t, objKey.Namespace, vds.Namespace)
-	case <-time.After(1 * time.Second):
-		t.Fatal("timeout waiting for requeue event")
-	}
-}
-
-// TestEventWatcherRegistry_RegistryCleanup verifies that registry entries are
-// properly cleaned up when resources are deleted or event loops exit, preventing
-// resource leaks and ensuring clean state management.
-func TestEventWatcherRegistry_RegistryCleanup(t *testing.T) {
-	registry := createTestRegistry()
-
-	// Register multiple resources
-	resources := []types.NamespacedName{
-		createTestNamespacedName("vss-1", "default"),
-		createTestNamespacedName("vss-2", "default"),
-		createTestNamespacedName("vss-3", "app-ns"),
-	}
-
-	registerMultipleResources(registry, resources, 1, "client-123")
-	verifyRegistryCount(t, registry, 3, "all resources should be registered")
-
-	// Simulate cleanup when resources are deleted (OnStop callbacks)
-	deleteMultipleResources(registry, resources)
-
-	// Verify all entries are cleaned up
-	verifyRegistryCount(t, registry, 0, "all registry entries should be cleaned up")
-	verifyMultipleResourcesNotExist(t, registry, resources)
-}
-
-// TestEventWatcherRegistry_OrphanedEntryDetection verifies detection and cleanup
-// of orphaned registry entries (entries that exist but WebSocket is dead), ensuring
-// the system can recover from connection failures.
-func TestEventWatcherRegistry_OrphanedEntryDetection(t *testing.T) {
-	registry := createTestRegistry()
-
-	// Register resources
-	activeRes := createTestNamespacedName("active-vss", "default")
-	orphanedRes := createTestNamespacedName("orphaned-vss", "default")
-
-	registerResource(registry, activeRes, 1, "client-1")
-	registerResource(registry, orphanedRes, 1, "client-2")
-
-	verifyRegistryCount(t, registry, 2)
-
-	// Simulate orphan detection and cleanup
-	verifyResourceExists(t, registry, orphanedRes)
-
-	// Clean up the orphaned entry
-	registry.Delete(orphanedRes)
-
-	// Verify orphaned entry is removed
-	verifyRegistryCount(t, registry, 1)
-	verifyResourceNotExists(t, registry, orphanedRes)
-
-	// Active entry should remain
-	got := verifyResourceExists(t, registry, activeRes)
-	assert.Equal(t, "client-1", got.LastClientID)
-}
-
-// TestEventWatcherRegistry_ConcurrentCleanup tests that concurrent cleanup
-// operations (multiple event loops exiting simultaneously) are handled safely.
+// TestEventWatcherRegistry_ConcurrentCleanup tests that concurrent Delete calls
+// (e.g. multiple event loops exiting simultaneously) are handled safely.
 func TestEventWatcherRegistry_ConcurrentCleanup(t *testing.T) {
 	registry := newEventWatcherRegistry()
 
-	// Register multiple resources
 	numResources := 50
 	resources := make([]types.NamespacedName, numResources)
 	for i := 0; i < numResources; i++ {
-		resources[i] = types.NamespacedName{
-			Name:      "vss-" + string(rune(i)),
-			Namespace: "default",
-		}
-		meta := &eventWatcherMeta{
+		resources[i] = createTestNamespacedName(fmt.Sprintf("vss-%d", i), "default")
+		registry.Register(resources[i], &eventWatcherMeta{
 			LastGeneration: int64(i),
-			LastClientID:   "client-" + string(rune(i)),
-		}
-		registry.Register(resources[i], meta)
+			LastClientID:   fmt.Sprintf("client-%d", i),
+		})
 	}
-
 	assert.Equal(t, numResources, registry.registry.ItemCount())
 
-	// Simulate concurrent event loop exits
 	var wg sync.WaitGroup
 	for _, res := range resources {
 		wg.Add(1)
@@ -310,73 +215,10 @@ func TestEventWatcherRegistry_ConcurrentCleanup(t *testing.T) {
 			registry.Delete(objKey)
 		}(res)
 	}
-
 	wg.Wait()
 
-	// Verify all registry entries are cleaned up
 	assert.Equal(t, 0, registry.registry.ItemCount(),
-		"all registry entries should be cleaned up after concurrent exits")
-}
-
-// TestEventWatcherRegistry_CleanupOnResourceDeletion verifies that when a
-// Kubernetes resource is deleted, its registry entry is properly removed,
-// ensuring clean resource lifecycle management.
-func TestEventWatcherRegistry_CleanupOnResourceDeletion(t *testing.T) {
-	registry := newEventWatcherRegistry()
-
-	// Register a resource
-	objKey := types.NamespacedName{Name: "vss-to-delete", Namespace: "default"}
-	meta := &eventWatcherMeta{
-		LastGeneration: 1,
-		LastClientID:   "client-123",
-	}
-	registry.Register(objKey, meta)
-	assert.Equal(t, 1, registry.registry.ItemCount())
-
-	// Simulate resource deletion (finalizer cleanup triggers OnStop callback)
-	// In real code: vaultstaticsecret_controller.go:330-354 (finalize method)
-	registry.Delete(objKey)
-
-	// Verify registry entry is removed
-	assert.Equal(t, 0, registry.registry.ItemCount(), "registry should be cleaned up after resource deletion")
-	_, ok := registry.Get(objKey)
-	assert.False(t, ok, "deleted resource should not be in registry")
-}
-
-// TestEventWatcherRegistry_CleanupOnReconcilerError verifies that registry
-// cleanup happens even when reconciler encounters errors, ensuring robust
-// error handling and preventing resource leaks during failures.
-func TestEventWatcherRegistry_CleanupOnReconcilerError(t *testing.T) {
-	registry := newEventWatcherRegistry()
-
-	objKey := types.NamespacedName{Name: "vss-error", Namespace: "default"}
-	meta := &eventWatcherMeta{
-		LastGeneration: 1,
-		LastClientID:   "client-123",
-	}
-
-	// Register resource
-	registry.Register(objKey, meta)
-	assert.Equal(t, 1, registry.registry.ItemCount())
-
-	// Simulate reconciler error scenario
-	// Even if reconciler fails, OnStop callback should still clean up registry
-	// This happens when: Vault connection fails, auth fails, etc.
-	simulateReconcilerError := func() error {
-		// Simulate error during reconciliation
-		// In real code: vaultstaticsecret_controller.go:334-341
-		// Even with error, cleanup should happen
-		registry.Delete(objKey)
-		return assert.AnError // Simulated error
-	}
-
-	err := simulateReconcilerError()
-	assert.Error(t, err, "reconciler should return error")
-
-	// Verify cleanup happened despite error
-	assert.Equal(t, 0, registry.registry.ItemCount(), "registry should be cleaned up even on reconciler error")
-	_, ok := registry.Get(objKey)
-	assert.False(t, ok, "resource should be removed from registry despite error")
+		"all entries must be gone after concurrent deletes")
 }
 
 // TestEventWatcherRegistry_CleanupOnNamespaceDeletion verifies that when a
@@ -424,8 +266,8 @@ func TestEventWatcherRegistry_NoMemoryLeak(t *testing.T) {
 	resourceNames := 10 // Reuse 10 resource names
 
 	for i := 0; i < iterations; i++ {
-		res := createTestNamespacedName("vss-"+string(rune(i%resourceNames)), "default")
-		registerResource(registry, res, int64(i), "client-"+string(rune(i)))
+		res := createTestNamespacedName(fmt.Sprintf("vss-%d", i%resourceNames), "default")
+		registerResource(registry, res, int64(i), fmt.Sprintf("client-%d", i))
 		registry.Delete(res)
 	}
 
@@ -434,7 +276,7 @@ func TestEventWatcherRegistry_NoMemoryLeak(t *testing.T) {
 
 	// Verify no entries remain
 	for i := 0; i < resourceNames; i++ {
-		res := createTestNamespacedName("vss-"+string(rune(i)), "default")
+		res := createTestNamespacedName(fmt.Sprintf("vss-%d", i), "default")
 		verifyResourceNotExists(t, registry, res)
 	}
 }
@@ -453,8 +295,8 @@ func TestEventWatcherRegistry_CleanupWithHighChurn(t *testing.T) {
 		// Create batch of resources
 		resources := make([]types.NamespacedName, resourcesPerCycle)
 		for i := 0; i < resourcesPerCycle; i++ {
-			resources[i] = createTestNamespacedName("vss-"+string(rune(cycle*resourcesPerCycle+i)), "default")
-			registerResource(registry, resources[i], int64(cycle), "client-"+string(rune(cycle)))
+			resources[i] = createTestNamespacedName(fmt.Sprintf("vss-%d", cycle*resourcesPerCycle+i), "default")
+			registerResource(registry, resources[i], int64(cycle), fmt.Sprintf("client-%d", cycle))
 		}
 
 		// Verify registration
@@ -469,65 +311,6 @@ func TestEventWatcherRegistry_CleanupWithHighChurn(t *testing.T) {
 
 	// Final verification - no memory leak after high churn
 	verifyRegistryCount(t, registry, 0, "registry should be empty after high churn - no memory leak")
-}
-
-// TestEventWatcherRegistry_OrphanDetectionAfterCrash verifies detection of orphaned
-// entries that remain after operator crash (OnStop callback never ran), ensuring
-// graceful recovery from unexpected failures.
-func TestEventWatcherRegistry_OrphanDetectionAfterCrash(t *testing.T) {
-	registry := createTestRegistry()
-
-	// Simulate resources registered before crash
-	crashedResources := []types.NamespacedName{
-		createTestNamespacedName("vss-crashed-1", "default"),
-		createTestNamespacedName("vss-crashed-2", "default"),
-	}
-
-	registerMultipleResources(registry, crashedResources, 1, "client-before-crash")
-	verifyRegistryCount(t, registry, 2, "resources registered before crash")
-
-	// Detect and clean up orphaned entries
-	for _, res := range crashedResources {
-		if _, exists := registry.Get(res); exists {
-			registry.Delete(res)
-		}
-	}
-
-	// Verify all orphaned entries are cleaned up
-	verifyRegistryCount(t, registry, 0, "all orphaned entries should be cleaned up")
-	verifyMultipleResourcesNotExist(t, registry, crashedResources)
-}
-
-// TestEventWatcherRegistry_OrphanDetectionWithMixedState verifies orphan detection
-// when some entries are healthy and some are orphaned, ensuring selective cleanup
-// that preserves healthy connections while removing stale ones.
-func TestEventWatcherRegistry_OrphanDetectionWithMixedState(t *testing.T) {
-	registry := createTestRegistry()
-
-	// Register healthy resources (WebSocket active)
-	healthyResources := []types.NamespacedName{
-		createTestNamespacedName("vss-healthy-1", "default"),
-		createTestNamespacedName("vss-healthy-2", "default"),
-	}
-
-	// Register orphaned resources (WebSocket dead)
-	orphanedResources := []types.NamespacedName{
-		createTestNamespacedName("vss-orphaned-1", "default"),
-		createTestNamespacedName("vss-orphaned-2", "default"),
-		createTestNamespacedName("vss-orphaned-3", "default"),
-	}
-
-	// Register all resources
-	registerMultipleResources(registry, append(healthyResources, orphanedResources...), 1, "client-123")
-	verifyRegistryCount(t, registry, 5, "all resources registered")
-
-	// Simulate orphan detection logic
-	deleteMultipleResources(registry, orphanedResources)
-
-	// Verify only orphaned entries are cleaned up
-	verifyRegistryCount(t, registry, 2, "only healthy resources should remain")
-	verifyMultipleResourcesNotExist(t, registry, orphanedResources)
-	verifyMultipleResourcesExist(t, registry, healthyResources)
 }
 
 // TestEventWatcherRegistry_OrphanDetectionRaceCondition verifies orphan detection
@@ -575,65 +358,6 @@ func TestEventWatcherRegistry_OrphanDetectionRaceCondition(t *testing.T) {
 		// Could be either generation depending on race outcome
 		assert.NotNil(t, got)
 	}
-}
-
-// TestEventWatcherRegistry_AutomaticOrphanCleanup verifies that orphan cleanup
-// happens automatically during reconciliation, ensuring self-healing behavior
-// without manual intervention.
-func TestEventWatcherRegistry_AutomaticOrphanCleanup(t *testing.T) {
-	registry := createTestRegistry()
-
-	// Simulate orphaned entries from previous operator run
-	orphanedEntries := []types.NamespacedName{
-		createTestNamespacedName("vss-old-1", "default"),
-		createTestNamespacedName("vss-old-2", "app-ns"),
-		createTestNamespacedName("vss-old-3", "default"),
-	}
-
-	registerMultipleResources(registry, orphanedEntries, 1, "client-old")
-	verifyRegistryCount(t, registry, 3, "orphaned entries exist")
-
-	// Simulate automatic orphan detection during reconciliation
-	cleanupOrphans := func() {
-		for _, res := range orphanedEntries {
-			if _, exists := registry.Get(res); exists {
-				registry.Delete(res)
-			}
-		}
-	}
-
-	// Run automatic cleanup
-	cleanupOrphans()
-
-	// Verify all orphans are automatically cleaned up
-	verifyRegistryCount(t, registry, 0, "all orphans should be automatically cleaned up")
-	verifyMultipleResourcesNotExist(t, registry, orphanedEntries)
-}
-
-// TestEventWatcherRegistry_OrphanDetectionMultipleGenerations verifies orphan
-// detection when resource has been updated multiple times, ensuring proper
-// generation tracking and cleanup of stale entries.
-func TestEventWatcherRegistry_OrphanDetectionMultipleGenerations(t *testing.T) {
-	registry := createTestRegistry()
-
-	objKey := createTestNamespacedName("vss-multi-gen", "default")
-
-	// Register with generation 1, then update to 2, then 3
-	registerResource(registry, objKey, 1, "client-1")
-	registerResource(registry, objKey, 2, "client-2")
-	registerResource(registry, objKey, 3, "client-3")
-
-	// Verify latest generation is stored
-	got := verifyResourceExists(t, registry, objKey)
-	assert.Equal(t, int64(3), got.LastGeneration)
-	assert.Equal(t, "client-3", got.LastClientID)
-
-	// Simulate orphan detection - WebSocket for generation 3 is dead
-	registry.Delete(objKey)
-
-	// Verify orphaned entry is cleaned up
-	verifyRegistryCount(t, registry, 0)
-	verifyResourceNotExists(t, registry, objKey)
 }
 
 // TestEventWatcherRegistry_OrphanDetectionClientIDChange verifies orphan detection

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -1065,6 +1065,49 @@ func (r *VaultDynamicSecretReconciler) ensureEventWatcher(
 	logger := log.FromContext(ctx).WithName("ensureEventWatcher")
 	name := client.ObjectKeyFromObject(o)
 
+	// onStop is shared across all Subscriber structs for this resource so that
+	// only the first OnStop call deletes the registry entry. Without this, a
+	// second or third independent closure could delete the entry that a
+	// reconciler already re-created after the first OnStop fired.
+	var onStopOnce sync.Once
+	onStop := func() {
+		onStopOnce.Do(func() {
+			r.eventWatcherRegistry.Delete(name)
+		})
+	}
+
+	// newDVSSubscriber is a local factory that stamps out a *vault.Subscriber
+	// with all fields common to every subscription for this resource. Only
+	// vaultNS and vaultPath vary between the engine-events subscriber (Step 4)
+	// and the lease-events subscribers (Steps 1 and 5).
+	//
+	// NOTE: lease subscribers intentionally pass vaultNS="" — lease events are
+	// routed by lease ID alone, so setting a namespace would produce a
+	// "<namespace>/<leaseID>" key that never matches the "<leaseID>" lookup.
+	newDVSSubscriber := func(vaultNS, vaultPath string) *vault.Subscriber {
+		return &vault.Subscriber{
+			ResourceKey:       name,
+			VaultNS:           vaultNS,
+			VaultPath:         vaultPath,
+			ResourceType:      vault.ResourceTypeVaultDynamicSecret,
+			ReconcileCh:       r.SourceCh,
+			PendingVaultIndex: &r.pendingVaultIndex,
+			// OnStop cleans up the registry entry when the WebSocket dies.
+			// The log is emitted by notifySubscribersOfStop via ws.logger,
+			// which is always valid (unlike the reconcile-context logger
+			// captured here, which goes stale after Reconcile returns).
+			OnStop: onStop,
+			NewObject: func() client.Object {
+				return &secretsv1beta1.VaultDynamicSecret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: name.Namespace,
+						Name:      name.Name,
+					},
+				}
+			},
+		}
+	}
+
 	currentLeaseID := o.Status.SecretLease.ID
 	meta, hasMeta := r.eventWatcherRegistry.Get(name)
 
@@ -1103,47 +1146,40 @@ func (r *VaultDynamicSecretReconciler) ensureEventWatcher(
 
 		// Lease events are mount-type-independent; still subscribe if applicable.
 		if !o.Spec.AllowStaticCreds && currentLeaseID != "" {
-			if !(hasMeta && meta.LastLeaseID == currentLeaseID && meta.LastClientID == c.ID()) {
-				leaseSubscriber := &vault.Subscriber{
-					ResourceKey:       name,
-					VaultPath:         currentLeaseID,
-					ResourceType:      "VaultDynamicSecret",
-					ReconcileCh:       r.SourceCh,
-					PendingVaultIndex: &r.pendingVaultIndex,
-					// OnStop callback cleans up registry when WebSocket dies.
-					// The log for this event is emitted by notifySubscribersOfStop
-					// using ws.logger, which is always valid (unlike the
-					// reconcile-context logger captured here, which goes stale
-					// after Reconcile returns).
-					OnStop: func() {
-						r.eventWatcherRegistry.Delete(name)
-					},
-					NewObject: func() client.Object {
-						return &secretsv1beta1.VaultDynamicSecret{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: name.Namespace,
-								Name:      name.Name,
-							},
-						}
-					},
-				}
-				if err := c.SubscribeToEvents(ctx, vault.EventTypeLease, leaseSubscriber); err != nil {
-					// Surface this too, instead of only logging it, so a compound
-					// failure (mount type AND lease subscribe both broken) is visible.
-					resultErr = errors.Join(resultErr, fmt.Errorf("failed to subscribe to lease events: %w", err))
-				} else {
-					// Record what we did establish so the next reconcile can detect
-					// "lease-only subscription already active" and skip re-subscribing
-					// on every cycle while the mount-type lookup keeps failing.
-					// LastEventType is left empty so Step 2's staleness check still
-					// forces a full re-subscribe once GetMountType succeeds.
-					r.eventWatcherRegistry.Register(name, &eventWatcherMeta{
-						LastClientID:   c.ID(),
-						LastGeneration: o.GetGeneration(),
-						LastLeaseID:    currentLeaseID,
-						LastEventType:  "",
-					})
-				}
+			// Skip re-subscription only when the existing lease watcher is
+			// confirmed alive. A metadata-only match is not sufficient: if the
+			// lease WebSocket died (e.g. reconnect threshold exceeded) but
+			// OnStop has not yet cleaned the registry, the entry looks valid
+			// but the resource is actually unsubscribed. The liveness check
+			// catches this orphaned state and falls through to re-subscribe.
+			leaseAlive := hasMeta &&
+				meta.LastLeaseID == currentLeaseID &&
+				meta.LastClientID == c.ID() &&
+				c.IsWebSocketHealthy(vault.EventTypeLease)
+			if leaseAlive {
+				return resultErr
+			}
+			// Dead or missing — clear any stale entry before re-subscribing.
+			if hasMeta {
+				r.eventWatcherRegistry.Delete(name)
+			}
+			leaseSubscriber := newDVSSubscriber("", currentLeaseID)
+			if err := c.SubscribeToEvents(ctx, vault.EventTypeLease, leaseSubscriber); err != nil {
+				// Surface this too, instead of only logging it, so a compound
+				// failure (mount type AND lease subscribe both broken) is visible.
+				resultErr = errors.Join(resultErr, fmt.Errorf("failed to subscribe to lease events: %w", err))
+			} else {
+				// Record what we did establish so the next reconcile can detect
+				// "lease-only subscription already active" and skip re-subscribing
+				// on every cycle while the mount-type lookup keeps failing.
+				// LastEventType is left empty so Step 2's staleness check still
+				// forces a full re-subscribe once GetMountType succeeds.
+				r.eventWatcherRegistry.Register(name, &eventWatcherMeta{
+					LastClientID:   c.ID(),
+					LastGeneration: o.GetGeneration(),
+					LastLeaseID:    currentLeaseID,
+					LastEventType:  "",
+				})
 			}
 		}
 		return resultErr
@@ -1160,14 +1196,13 @@ func (r *VaultDynamicSecretReconciler) ensureEventWatcher(
 		// Orphaned entry detection: verify the WebSocket is actually alive.
 		// This is a safety net for cases where OnStop did not fire (e.g. operator
 		// restart) or there was a race between WebSocket death and OnStop cleanup.
-		ws := c.GetWebSocket(eventType)
-		if ws != nil && ws.IsHealthy() {
+		if c.IsWebSocketHealthy(eventType) {
 			logger.V(consts.LogLevelDebug).Info("Event subscription already active",
 				"namespace", o.Namespace, "name", o.Name)
 			return nil
 		}
 		// WebSocket is dead or missing — orphaned registry entry detected.
-		logger.Info("Detected orphaned registry entry (WebSocket is dead), cleaning up",
+		logger.Info("Detected orphaned registry entry (WebSocket is dead or missing), cleaning up",
 			"namespace", o.Namespace, "name", o.Name)
 		r.eventWatcherRegistry.Delete(name)
 		hasMeta = false
@@ -1182,30 +1217,7 @@ func (r *VaultDynamicSecretReconciler) ensureEventWatcher(
 
 	// Step 4: subscribe to engine events.
 	vaultPath := buildVaultEventKey(o)
-	subscriber := &vault.Subscriber{
-		ResourceKey:       name,
-		VaultNS:           o.Spec.Namespace,
-		VaultPath:         vaultPath,
-		ResourceType:      "VaultDynamicSecret",
-		ReconcileCh:       r.SourceCh,
-		PendingVaultIndex: &r.pendingVaultIndex,
-		// OnStop callback cleans up registry when WebSocket dies.
-		// The log for this event is emitted by notifySubscribersOfStop
-		// using ws.logger, which is always valid (unlike the
-		// reconcile-context logger captured here, which goes stale
-		// after Reconcile returns).
-		OnStop: func() {
-			r.eventWatcherRegistry.Delete(name)
-		},
-		NewObject: func() client.Object {
-			return &secretsv1beta1.VaultDynamicSecret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: name.Namespace,
-					Name:      name.Name,
-				},
-			}
-		},
-	}
+	subscriber := newDVSSubscriber(o.Spec.Namespace, vaultPath)
 	if err := c.SubscribeToEvents(ctx, eventType, subscriber); err != nil {
 		return fmt.Errorf("failed to subscribe to %s events: %w", eventType, err)
 	}
@@ -1219,29 +1231,7 @@ func (r *VaultDynamicSecretReconciler) ensureEventWatcher(
 	// unWatchEventsWithLeaseID), so setting VaultNS here would key the subscriber
 	// as "<namespace>/<leaseID>" and never match the "<leaseID>" lookup.
 	if !o.Spec.AllowStaticCreds && o.Status.SecretLease.ID != "" {
-		leaseSubscriber := &vault.Subscriber{
-			ResourceKey:       name,
-			VaultPath:         currentLeaseID,
-			ResourceType:      "VaultDynamicSecret",
-			ReconcileCh:       r.SourceCh,
-			PendingVaultIndex: &r.pendingVaultIndex,
-			// OnStop callback cleans up registry when WebSocket dies.
-			// The log for this event is emitted by notifySubscribersOfStop
-			// using ws.logger, which is always valid (unlike the
-			// reconcile-context logger captured here, which goes stale
-			// after Reconcile returns).
-			OnStop: func() {
-				r.eventWatcherRegistry.Delete(name)
-			},
-			NewObject: func() client.Object {
-				return &secretsv1beta1.VaultDynamicSecret{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: name.Namespace,
-						Name:      name.Name,
-					},
-				}
-			},
-		}
+		leaseSubscriber := newDVSSubscriber("", currentLeaseID)
 		if err := c.SubscribeToEvents(ctx, vault.EventTypeLease, leaseSubscriber); err != nil {
 			// Non-fatal: the database/LDAP subscription above still provides
 			// event-driven updates. Surface the failure as a warning event so

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -1110,6 +1110,22 @@ func (r *VaultDynamicSecretReconciler) ensureEventWatcher(
 					ResourceType:      "VaultDynamicSecret",
 					ReconcileCh:       r.SourceCh,
 					PendingVaultIndex: &r.pendingVaultIndex,
+					// OnStop callback cleans up registry when WebSocket dies.
+					// The log for this event is emitted by notifySubscribersOfStop
+					// using ws.logger, which is always valid (unlike the
+					// reconcile-context logger captured here, which goes stale
+					// after Reconcile returns).
+					OnStop: func() {
+						r.eventWatcherRegistry.Delete(name)
+					},
+					NewObject: func() client.Object {
+						return &secretsv1beta1.VaultDynamicSecret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: name.Namespace,
+								Name:      name.Name,
+							},
+						}
+					},
 				}
 				if err := c.SubscribeToEvents(ctx, vault.EventTypeLease, leaseSubscriber); err != nil {
 					// Surface this too, instead of only logging it, so a compound
@@ -1141,9 +1157,20 @@ func (r *VaultDynamicSecretReconciler) ensureEventWatcher(
 		meta.LastClientID == c.ID() &&
 		meta.LastLeaseID == currentLeaseID &&
 		meta.LastEventType == eventType {
-		logger.V(consts.LogLevelDebug).Info("Event subscription already active",
+		// Orphaned entry detection: verify the WebSocket is actually alive.
+		// This is a safety net for cases where OnStop did not fire (e.g. operator
+		// restart) or there was a race between WebSocket death and OnStop cleanup.
+		ws := c.GetWebSocket(eventType)
+		if ws != nil && ws.IsHealthy() {
+			logger.V(consts.LogLevelDebug).Info("Event subscription already active",
+				"namespace", o.Namespace, "name", o.Name)
+			return nil
+		}
+		// WebSocket is dead or missing — orphaned registry entry detected.
+		logger.Info("Detected orphaned registry entry (WebSocket is dead), cleaning up",
 			"namespace", o.Namespace, "name", o.Name)
-		return nil
+		r.eventWatcherRegistry.Delete(name)
+		hasMeta = false
 	}
 
 	// Step 3: tear down the stale subscription now that we have a valid type.
@@ -1162,6 +1189,22 @@ func (r *VaultDynamicSecretReconciler) ensureEventWatcher(
 		ResourceType:      "VaultDynamicSecret",
 		ReconcileCh:       r.SourceCh,
 		PendingVaultIndex: &r.pendingVaultIndex,
+		// OnStop callback cleans up registry when WebSocket dies.
+		// The log for this event is emitted by notifySubscribersOfStop
+		// using ws.logger, which is always valid (unlike the
+		// reconcile-context logger captured here, which goes stale
+		// after Reconcile returns).
+		OnStop: func() {
+			r.eventWatcherRegistry.Delete(name)
+		},
+		NewObject: func() client.Object {
+			return &secretsv1beta1.VaultDynamicSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: name.Namespace,
+					Name:      name.Name,
+				},
+			}
+		},
 	}
 	if err := c.SubscribeToEvents(ctx, eventType, subscriber); err != nil {
 		return fmt.Errorf("failed to subscribe to %s events: %w", eventType, err)
@@ -1182,6 +1225,22 @@ func (r *VaultDynamicSecretReconciler) ensureEventWatcher(
 			ResourceType:      "VaultDynamicSecret",
 			ReconcileCh:       r.SourceCh,
 			PendingVaultIndex: &r.pendingVaultIndex,
+			// OnStop callback cleans up registry when WebSocket dies.
+			// The log for this event is emitted by notifySubscribersOfStop
+			// using ws.logger, which is always valid (unlike the
+			// reconcile-context logger captured here, which goes stale
+			// after Reconcile returns).
+			OnStop: func() {
+				r.eventWatcherRegistry.Delete(name)
+			},
+			NewObject: func() client.Object {
+				return &secretsv1beta1.VaultDynamicSecret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: name.Namespace,
+						Name:      name.Name,
+					},
+				}
+			},
 		}
 		if err := c.SubscribeToEvents(ctx, vault.EventTypeLease, leaseSubscriber); err != nil {
 			// Non-fatal: the database/LDAP subscription above still provides

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -2443,8 +2443,8 @@ type mockEnsureClient struct {
 	mountTypeErr    error
 	subscribed      []vault.EventType
 	seen            []vault.EventType // from UnsubscribeFromEvents
-	// webSocket is returned by GetWebSocket; nil means no active WebSocket.
-	webSocket *vault.SharedWebSocket
+	// webSocketHealthy is returned by IsWebSocketHealthy.
+	webSocketHealthy bool
 	// onSubscribe is an optional hook called on every SubscribeToEvents call,
 	// allowing tests to capture Subscriber fields such as OnStop.
 	onSubscribe func(vault.EventType, *vault.Subscriber)
@@ -2469,8 +2469,8 @@ func (m *mockEnsureClient) UnsubscribeFromEvents(et vault.EventType, _ vault.Sub
 
 func (m *mockEnsureClient) ID() string { return "test-client" }
 
-func (m *mockEnsureClient) GetWebSocket(_ vault.EventType) *vault.SharedWebSocket {
-	return m.webSocket
+func (m *mockEnsureClient) IsWebSocketHealthy(_ vault.EventType) bool {
+	return m.webSocketHealthy
 }
 
 // Test_ensureEventWatcher_GetMountTypeError_ReusesPriorEventType verifies
@@ -2708,8 +2708,8 @@ func TestVaultDynamicSecretReconciler_syncSecret_vaultIndex(t *testing.T) {
 }
 
 // Test_ensureEventWatcher_OrphanedEntry_NilWebSocket verifies that when the
-// registry has a matching entry but GetWebSocket returns nil (e.g. after an
-// operator restart), ensureEventWatcher detects the orphaned entry, clears it,
+// registry has a matching entry but IsWebSocketHealthy returns false (e.g. after
+// an operator restart), ensureEventWatcher detects the orphaned entry, clears it,
 // and re-subscribes rather than returning nil.
 func Test_ensureEventWatcher_OrphanedEntry_NilWebSocket(t *testing.T) {
 	ch := make(chan event.GenericEvent, 10)
@@ -2738,10 +2738,10 @@ func Test_ensureEventWatcher_OrphanedEntry_NilWebSocket(t *testing.T) {
 		LastEventType:  vault.EventTypeDatabase,
 	})
 
-	// GetWebSocket returns nil — simulates operator restart with no live WebSocket.
+	// IsWebSocketHealthy returns false — simulates operator restart with no live WebSocket.
 	m := &mockEnsureClient{
-		mountTypeResult: "database",
-		webSocket:       nil,
+		mountTypeResult:  "database",
+		webSocketHealthy: false,
 	}
 
 	err := r.ensureEventWatcher(context.Background(), o, m)
@@ -2756,11 +2756,11 @@ func Test_ensureEventWatcher_OrphanedEntry_NilWebSocket(t *testing.T) {
 	assert.Equal(t, vault.EventTypeDatabase, meta.LastEventType)
 }
 
-// Test_ensureEventWatcher_OnStop_CleansRegistry verifies that the OnStop
+// Test_VDS_ensureEventWatcher_OnStop_CleansRegistry verifies that the OnStop
 // callback set on the VDS engine-events Subscriber deletes the registry entry
 // when invoked, so the next reconcile falls through to re-subscribe instead of
 // returning early because it sees a stale registry entry with matching metadata.
-func Test_ensureEventWatcher_OnStop_CleansRegistry(t *testing.T) {
+func Test_VDS_ensureEventWatcher_OnStop_CleansRegistry(t *testing.T) {
 	ch := make(chan event.GenericEvent, 10)
 	r := &VaultDynamicSecretReconciler{
 		eventWatcherRegistry: newEventWatcherRegistry(),

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -2443,14 +2443,22 @@ type mockEnsureClient struct {
 	mountTypeErr    error
 	subscribed      []vault.EventType
 	seen            []vault.EventType // from UnsubscribeFromEvents
+	// webSocket is returned by GetWebSocket; nil means no active WebSocket.
+	webSocket *vault.SharedWebSocket
+	// onSubscribe is an optional hook called on every SubscribeToEvents call,
+	// allowing tests to capture Subscriber fields such as OnStop.
+	onSubscribe func(vault.EventType, *vault.Subscriber)
 }
 
 func (m *mockEnsureClient) GetMountType(_ context.Context, _ string) (string, error) {
 	return m.mountTypeResult, m.mountTypeErr
 }
 
-func (m *mockEnsureClient) SubscribeToEvents(_ context.Context, et vault.EventType, _ *vault.Subscriber) error {
+func (m *mockEnsureClient) SubscribeToEvents(_ context.Context, et vault.EventType, sub *vault.Subscriber) error {
 	m.subscribed = append(m.subscribed, et)
+	if m.onSubscribe != nil {
+		m.onSubscribe(et, sub)
+	}
 	return nil
 }
 
@@ -2460,6 +2468,10 @@ func (m *mockEnsureClient) UnsubscribeFromEvents(et vault.EventType, _ vault.Sub
 }
 
 func (m *mockEnsureClient) ID() string { return "test-client" }
+
+func (m *mockEnsureClient) GetWebSocket(_ vault.EventType) *vault.SharedWebSocket {
+	return m.webSocket
+}
 
 // Test_ensureEventWatcher_GetMountTypeError_ReusesPriorEventType verifies
 // that when GetMountType fails but a prior LastEventType is stored, that prior
@@ -2693,4 +2705,101 @@ func TestVaultDynamicSecretReconciler_syncSecret_vaultIndex(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test_ensureEventWatcher_OrphanedEntry_NilWebSocket verifies that when the
+// registry has a matching entry but GetWebSocket returns nil (e.g. after an
+// operator restart), ensureEventWatcher detects the orphaned entry, clears it,
+// and re-subscribes rather than returning nil.
+func Test_ensureEventWatcher_OrphanedEntry_NilWebSocket(t *testing.T) {
+	ch := make(chan event.GenericEvent, 10)
+	r := &VaultDynamicSecretReconciler{
+		eventWatcherRegistry: newEventWatcherRegistry(),
+		SourceCh:             ch,
+		Recorder:             record.NewFakeRecorder(10),
+	}
+
+	o := &secretsv1beta1.VaultDynamicSecret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "db-secret", Generation: 1},
+		Spec: secretsv1beta1.VaultDynamicSecretSpec{
+			Mount: "database",
+			Path:  "creds/my-role",
+		},
+	}
+	key := client.ObjectKeyFromObject(o)
+
+	// Pre-populate registry with fully-matching metadata so the staleness check
+	// would normally return nil — the only thing that should trigger re-subscribe
+	// is the nil WebSocket.
+	r.eventWatcherRegistry.Register(key, &eventWatcherMeta{
+		LastClientID:   "test-client",
+		LastGeneration: 1,
+		LastLeaseID:    "",
+		LastEventType:  vault.EventTypeDatabase,
+	})
+
+	// GetWebSocket returns nil — simulates operator restart with no live WebSocket.
+	m := &mockEnsureClient{
+		mountTypeResult: "database",
+		webSocket:       nil,
+	}
+
+	err := r.ensureEventWatcher(context.Background(), o, m)
+
+	require.NoError(t, err)
+	assert.Contains(t, m.subscribed, vault.EventTypeDatabase,
+		"must re-subscribe when WebSocket is nil (orphaned entry)")
+
+	// Registry must be refreshed with new metadata after re-subscription.
+	meta, ok := r.eventWatcherRegistry.Get(key)
+	require.True(t, ok, "registry must have an entry after re-subscription")
+	assert.Equal(t, vault.EventTypeDatabase, meta.LastEventType)
+}
+
+// Test_ensureEventWatcher_OnStop_CleansRegistry verifies that the OnStop
+// callback set on the VDS engine-events Subscriber deletes the registry entry
+// when invoked, so the next reconcile falls through to re-subscribe instead of
+// returning early because it sees a stale registry entry with matching metadata.
+func Test_ensureEventWatcher_OnStop_CleansRegistry(t *testing.T) {
+	ch := make(chan event.GenericEvent, 10)
+	r := &VaultDynamicSecretReconciler{
+		eventWatcherRegistry: newEventWatcherRegistry(),
+		SourceCh:             ch,
+		Recorder:             record.NewFakeRecorder(10),
+	}
+
+	o := &secretsv1beta1.VaultDynamicSecret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "db-secret", Generation: 1},
+		Spec: secretsv1beta1.VaultDynamicSecretSpec{
+			Mount: "database",
+			Path:  "creds/my-role",
+		},
+	}
+	key := client.ObjectKeyFromObject(o)
+
+	// captureOnStop intercepts the first OnStop set on any SubscribeToEvents call.
+	var capturedOnStop func()
+	m := &mockEnsureClient{
+		mountTypeResult: "database",
+		onSubscribe: func(_ vault.EventType, sub *vault.Subscriber) {
+			if capturedOnStop == nil && sub.OnStop != nil {
+				capturedOnStop = sub.OnStop
+			}
+		},
+	}
+
+	err := r.ensureEventWatcher(context.Background(), o, m)
+	require.NoError(t, err)
+
+	// Registry must have an entry after subscription.
+	_, ok := r.eventWatcherRegistry.Get(key)
+	require.True(t, ok, "registry must have entry after ensureEventWatcher")
+
+	// Simulate WebSocket death by invoking the captured OnStop callback.
+	require.NotNil(t, capturedOnStop, "OnStop must be set on the engine-events subscriber")
+	capturedOnStop()
+
+	// Registry entry must be gone — next reconcile will re-subscribe.
+	_, ok = r.eventWatcherRegistry.Get(key)
+	assert.False(t, ok, "registry entry must be deleted after OnStop fires")
 }

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -373,12 +373,27 @@ func (r *VaultStaticSecretReconciler) ensureEventWatcher(ctx context.Context, o 
 	logger := log.FromContext(ctx).WithName("ensureEventWatcher")
 	name := client.ObjectKeyFromObject(o)
 
+	// onStop is shared across all Subscriber structs for this resource so that
+	// only the first OnStop call deletes the registry entry. A single subscriber
+	// is registered today, but the Once guard makes the pattern consistent with
+	// VaultDynamicSecret and safe if additional subscribers are added in future.
+	var onStopOnce sync.Once
+	onStop := func() {
+		onStopOnce.Do(func() {
+			r.eventWatcherRegistry.Delete(name)
+		})
+	}
+
+	// vssEventType is the single event type VSS subscribes to. Declaring it once
+	// here keeps the orphan check and the subscribe call in sync — a future change
+	// to the VSS event type only needs to be made in one place.
+	const vssEventType = vault.EventTypeKV
+
 	meta, ok := r.eventWatcherRegistry.Get(name)
 	if ok {
 		// Check if the WebSocket is actually healthy (Orphaned Entry Detection)
 		// This is a safety net in case OnStop callback didn't run or there was a race condition
-		ws := c.GetWebSocket(vault.EventTypeKV)
-		if ws != nil && ws.IsHealthy() {
+		if c.IsWebSocketHealthy(vssEventType) {
 			// WebSocket is healthy, check if metadata matches
 			if meta.LastGeneration == o.GetGeneration() && meta.LastClientID == c.ID() {
 				// The subscription is active, and if the VSS object has not been updated,
@@ -408,13 +423,11 @@ func (r *VaultStaticSecretReconciler) ensureEventWatcher(ctx context.Context, o 
 		ResourceKey:       name,
 		VaultNS:           o.Spec.Namespace,
 		VaultPath:         vaultPath,
-		ResourceType:      "VaultStaticSecret",
+		ResourceType:      vault.ResourceTypeVaultStaticSecret,
 		ReconcileCh:       r.SourceCh,
 		PendingVaultIndex: &r.pendingVaultIndex,
 		// OnStop callback cleans up registry when WebSocket dies
-		OnStop: func() {
-			r.eventWatcherRegistry.Delete(name)
-		},
+		OnStop: onStop,
 		NewObject: func() client.Object {
 			return &secretsv1beta1.VaultStaticSecret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -425,7 +438,7 @@ func (r *VaultStaticSecretReconciler) ensureEventWatcher(ctx context.Context, o 
 		},
 	}
 
-	if err := c.SubscribeToEvents(ctx, vault.EventTypeKV, subscriber); err != nil {
+	if err := c.SubscribeToEvents(ctx, vssEventType, subscriber); err != nil {
 		return fmt.Errorf("failed to subscribe to events: %w", err)
 	}
 

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -375,17 +375,29 @@ func (r *VaultStaticSecretReconciler) ensureEventWatcher(ctx context.Context, o 
 
 	meta, ok := r.eventWatcherRegistry.Get(name)
 	if ok {
-		// The subscription is active, and if the VSS object has not been updated,
-		// and the client ID is the same, just return
-		if meta.LastGeneration == o.GetGeneration() && meta.LastClientID == c.ID() {
-			logger.V(consts.LogLevelDebug).Info("Event subscription already active",
+		// Check if the WebSocket is actually healthy (Orphaned Entry Detection)
+		// This is a safety net in case OnStop callback didn't run or there was a race condition
+		ws := c.GetWebSocket(vault.EventTypeKV)
+		if ws != nil && ws.IsHealthy() {
+			// WebSocket is healthy, check if metadata matches
+			if meta.LastGeneration == o.GetGeneration() && meta.LastClientID == c.ID() {
+				// The subscription is active, and if the VSS object has not been updated,
+				// and the client ID is the same, just return
+				logger.V(consts.LogLevelDebug).Info("Event subscription already active",
+					"namespace", o.Namespace, "name", o.Name)
+				return nil
+			}
+			// The subscription exists but metadata or vault client has changed, unsubscribe first
+			logger.V(consts.LogLevelDebug).Info("Unsubscribing due to metadata or client change",
 				"namespace", o.Namespace, "name", o.Name)
-			return nil
+			r.unWatchEvents(o, c)
+		} else {
+			// WebSocket is dead or missing - orUnsubscribing due to metadataphaned registry entry detected
+			logger.Info("Detected orphaned registry entry (WebSocket is dead or missing), cleaning up",
+				"namespace", o.Namespace, "name", o.Name)
+			r.eventWatcherRegistry.Delete(name)
+			// Fall through to create a new WebSocket subscription
 		}
-		// The subscription exists but metadata or vault client has changed, unsubscribe first
-		logger.V(consts.LogLevelDebug).Info("Unsubscribing due to metadata or client change",
-			"namespace", o.Namespace, "name", o.Name)
-		r.unWatchEvents(o, c)
 	}
 
 	// Build the vault path for subscription
@@ -399,6 +411,13 @@ func (r *VaultStaticSecretReconciler) ensureEventWatcher(ctx context.Context, o 
 		ResourceType:      "VaultStaticSecret",
 		ReconcileCh:       r.SourceCh,
 		PendingVaultIndex: &r.pendingVaultIndex,
+		// OnStop callback cleans up registry when WebSocket dies
+		OnStop: func() {
+			logger.Info("WebSocket stopped, cleaning up registry entry",
+				"namespace", name.Namespace,
+				"name", name.Name)
+			r.eventWatcherRegistry.Delete(name)
+		},
 	}
 
 	if err := c.SubscribeToEvents(ctx, vault.EventTypeKV, subscriber); err != nil {

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -392,7 +392,7 @@ func (r *VaultStaticSecretReconciler) ensureEventWatcher(ctx context.Context, o 
 				"namespace", o.Namespace, "name", o.Name)
 			r.unWatchEvents(o, c)
 		} else {
-			// WebSocket is dead or missing - orUnsubscribing due to metadataphaned registry entry detected
+			// WebSocket is dead or missing - orphaned registry entry detected
 			logger.Info("Detected orphaned registry entry (WebSocket is dead or missing), cleaning up",
 				"namespace", o.Namespace, "name", o.Name)
 			r.eventWatcherRegistry.Delete(name)

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -413,10 +413,15 @@ func (r *VaultStaticSecretReconciler) ensureEventWatcher(ctx context.Context, o 
 		PendingVaultIndex: &r.pendingVaultIndex,
 		// OnStop callback cleans up registry when WebSocket dies
 		OnStop: func() {
-			logger.Info("WebSocket stopped, cleaning up registry entry",
-				"namespace", name.Namespace,
-				"name", name.Name)
 			r.eventWatcherRegistry.Delete(name)
+		},
+		NewObject: func() client.Object {
+			return &secretsv1beta1.VaultStaticSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: name.Namespace,
+					Name:      name.Name,
+				},
+			}
 		},
 	}
 

--- a/controllers/vaultstaticsecret_controller_test.go
+++ b/controllers/vaultstaticsecret_controller_test.go
@@ -229,10 +229,12 @@ type mockVSSClient struct {
 	vault.Client
 	subscribed []vault.EventType
 	seen       []vault.EventType // recorded by UnsubscribeFromEvents
-	// webSocket is returned by GetWebSocket; nil simulates no live connection.
-	webSocket *vault.SharedWebSocket
+	// webSocketHealthy is returned by IsWebSocketHealthy.
+	webSocketHealthy bool
 	// subscribeErr, when non-nil, is returned by SubscribeToEvents.
 	subscribeErr error
+	// unsubscribeErr, when non-nil, is returned by UnsubscribeFromEvents.
+	unsubscribeErr error
 	// onSubscribe is an optional hook called on every SubscribeToEvents call,
 	// allowing tests to capture Subscriber fields such as OnStop or NewObject.
 	onSubscribe func(vault.EventType, *vault.Subscriber)
@@ -240,8 +242,8 @@ type mockVSSClient struct {
 
 func (m *mockVSSClient) ID() string { return "test-vss-client" }
 
-func (m *mockVSSClient) GetWebSocket(_ vault.EventType) *vault.SharedWebSocket {
-	return m.webSocket
+func (m *mockVSSClient) IsWebSocketHealthy(_ vault.EventType) bool {
+	return m.webSocketHealthy
 }
 
 func (m *mockVSSClient) SubscribeToEvents(_ context.Context, et vault.EventType, sub *vault.Subscriber) error {
@@ -254,7 +256,7 @@ func (m *mockVSSClient) SubscribeToEvents(_ context.Context, et vault.EventType,
 
 func (m *mockVSSClient) UnsubscribeFromEvents(et vault.EventType, _ vault.SubscriptionKey, _ string) error {
 	m.seen = append(m.seen, et)
-	return nil
+	return m.unsubscribeErr
 }
 
 // Test_VSS_ensureEventWatcher_FreshSubscribe verifies that when no registry entry
@@ -293,8 +295,8 @@ func Test_VSS_ensureEventWatcher_FreshSubscribe(t *testing.T) {
 }
 
 // Test_VSS_ensureEventWatcher_OrphanedEntry_NilWebSocket verifies that when the
-// registry has a matching entry but GetWebSocket returns nil (e.g. after an
-// operator restart), ensureEventWatcher detects the orphaned entry, clears it,
+// registry has a matching entry but IsWebSocketHealthy returns false (e.g. after
+// an operator restart), ensureEventWatcher detects the orphaned entry, clears it,
 // and re-subscribes rather than returning nil early.
 func Test_VSS_ensureEventWatcher_OrphanedEntry_NilWebSocket(t *testing.T) {
 	t.Parallel()
@@ -324,8 +326,8 @@ func Test_VSS_ensureEventWatcher_OrphanedEntry_NilWebSocket(t *testing.T) {
 		LastGeneration: 1,
 	})
 
-	// GetWebSocket returns nil — simulates operator restart with no live WebSocket.
-	m := &mockVSSClient{webSocket: nil}
+	// IsWebSocketHealthy returns false — simulates operator restart with no live WebSocket.
+	m := &mockVSSClient{webSocketHealthy: false}
 	err := r.ensureEventWatcher(context.Background(), o, m)
 
 	require.NoError(t, err)
@@ -445,6 +447,43 @@ func Test_VSS_unWatchEvents_NoOpWhenNoRegistryEntry(t *testing.T) {
 	r.unWatchEvents(o, m)
 
 	assert.Empty(t, m.seen, "no unsubscribe should be called when object not in registry")
+}
+
+// Test_VSS_unWatchEvents_UnsubscribeError verifies that when UnsubscribeFromEvents
+// returns an error, unWatchEvents still removes the registry entry — the error is
+// treated as "already cleaned up" and must not block cleanup.
+func Test_VSS_unWatchEvents_UnsubscribeError(t *testing.T) {
+	t.Parallel()
+	r := &VaultStaticSecretReconciler{
+		eventWatcherRegistry: newEventWatcherRegistry(),
+	}
+
+	o := &secretsv1beta1.VaultStaticSecret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "kv-secret"},
+		Spec: secretsv1beta1.VaultStaticSecretSpec{
+			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+				Type:  vsoconsts.KVSecretTypeV1,
+				Mount: "secret",
+				Path:  "app/config",
+			},
+		},
+	}
+	key := client.ObjectKeyFromObject(o)
+	r.eventWatcherRegistry.Register(key, &eventWatcherMeta{
+		LastClientID:   "test-vss-client",
+		LastGeneration: 1,
+	})
+
+	m := &mockVSSClient{unsubscribeErr: fmt.Errorf("websocket already closed")}
+	r.unWatchEvents(o, m)
+
+	// UnsubscribeFromEvents was still attempted.
+	require.Len(t, m.seen, 1, "exactly one unsubscribe call expected even on error")
+	assert.Equal(t, vault.EventTypeKV, m.seen[0])
+
+	// Registry entry must be removed regardless of the unsubscribe error.
+	_, ok := r.eventWatcherRegistry.Get(key)
+	assert.False(t, ok, "registry entry must be deleted even when UnsubscribeFromEvents errors")
 }
 
 // Test_VSS_ensureEventWatcher_SubscribeError verifies that when SubscribeToEvents

--- a/controllers/vaultstaticsecret_controller_test.go
+++ b/controllers/vaultstaticsecret_controller_test.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -14,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
@@ -216,4 +218,266 @@ func TestVaultStaticSecretReconciler_Reconcile_vaultIndex(t *testing.T) {
 		assert.Empty(t, secondReq.Headers[vsoconsts.HeaderVaultIndex],
 			"X-Vault-Index must not be sent when no pending index is stored")
 	}
+}
+
+// mockVSSClient is a minimal vault.Client stub for VaultStaticSecret
+// ensureEventWatcher tests. It covers only the four methods that VSS
+// ensureEventWatcher actually calls — GetWebSocket, ID, SubscribeToEvents, and
+// UnsubscribeFromEvents. GetMountType is intentionally absent: VSS never resolves
+// a mount type (it always subscribes to vault.EventTypeKV directly).
+type mockVSSClient struct {
+	vault.Client
+	subscribed []vault.EventType
+	seen       []vault.EventType // recorded by UnsubscribeFromEvents
+	// webSocket is returned by GetWebSocket; nil simulates no live connection.
+	webSocket *vault.SharedWebSocket
+	// subscribeErr, when non-nil, is returned by SubscribeToEvents.
+	subscribeErr error
+	// onSubscribe is an optional hook called on every SubscribeToEvents call,
+	// allowing tests to capture Subscriber fields such as OnStop or NewObject.
+	onSubscribe func(vault.EventType, *vault.Subscriber)
+}
+
+func (m *mockVSSClient) ID() string { return "test-vss-client" }
+
+func (m *mockVSSClient) GetWebSocket(_ vault.EventType) *vault.SharedWebSocket {
+	return m.webSocket
+}
+
+func (m *mockVSSClient) SubscribeToEvents(_ context.Context, et vault.EventType, sub *vault.Subscriber) error {
+	m.subscribed = append(m.subscribed, et)
+	if m.onSubscribe != nil {
+		m.onSubscribe(et, sub)
+	}
+	return m.subscribeErr
+}
+
+func (m *mockVSSClient) UnsubscribeFromEvents(et vault.EventType, _ vault.SubscriptionKey, _ string) error {
+	m.seen = append(m.seen, et)
+	return nil
+}
+
+// Test_VSS_ensureEventWatcher_FreshSubscribe verifies that when no registry entry
+// exists the watcher subscribes to KV events and registers metadata.
+func Test_VSS_ensureEventWatcher_FreshSubscribe(t *testing.T) {
+	t.Parallel()
+	ch := make(chan event.GenericEvent, 10)
+	r := &VaultStaticSecretReconciler{
+		eventWatcherRegistry: newEventWatcherRegistry(),
+		SourceCh:             ch,
+		Recorder:             record.NewFakeRecorder(10),
+	}
+
+	o := &secretsv1beta1.VaultStaticSecret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "app", Generation: 1},
+		Spec: secretsv1beta1.VaultStaticSecretSpec{
+			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+				Type:  vsoconsts.KVSecretTypeV2,
+				Mount: "secret",
+				Path:  "app/config",
+			},
+		},
+	}
+	key := client.ObjectKeyFromObject(o)
+
+	m := &mockVSSClient{} // webSocket == nil; no registry entry
+	err := r.ensureEventWatcher(context.Background(), o, m)
+
+	require.NoError(t, err)
+	require.Contains(t, m.subscribed, vault.EventTypeKV, "must subscribe to KV events on first call")
+
+	meta, ok := r.eventWatcherRegistry.Get(key)
+	require.True(t, ok, "registry must have entry after subscribe")
+	assert.Equal(t, "test-vss-client", meta.LastClientID)
+	assert.Equal(t, int64(1), meta.LastGeneration)
+}
+
+// Test_VSS_ensureEventWatcher_OrphanedEntry_NilWebSocket verifies that when the
+// registry has a matching entry but GetWebSocket returns nil (e.g. after an
+// operator restart), ensureEventWatcher detects the orphaned entry, clears it,
+// and re-subscribes rather than returning nil early.
+func Test_VSS_ensureEventWatcher_OrphanedEntry_NilWebSocket(t *testing.T) {
+	t.Parallel()
+	ch := make(chan event.GenericEvent, 10)
+	r := &VaultStaticSecretReconciler{
+		eventWatcherRegistry: newEventWatcherRegistry(),
+		SourceCh:             ch,
+		Recorder:             record.NewFakeRecorder(10),
+	}
+
+	o := &secretsv1beta1.VaultStaticSecret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "kv-secret", Generation: 1},
+		Spec: secretsv1beta1.VaultStaticSecretSpec{
+			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+				Type:  vsoconsts.KVSecretTypeV1,
+				Mount: "secret",
+				Path:  "app/config",
+			},
+		},
+	}
+	key := client.ObjectKeyFromObject(o)
+
+	// Pre-populate registry with fully-matching metadata — the only thing that
+	// should trigger re-subscribe is the nil WebSocket (orphaned entry).
+	r.eventWatcherRegistry.Register(key, &eventWatcherMeta{
+		LastClientID:   "test-vss-client",
+		LastGeneration: 1,
+	})
+
+	// GetWebSocket returns nil — simulates operator restart with no live WebSocket.
+	m := &mockVSSClient{webSocket: nil}
+	err := r.ensureEventWatcher(context.Background(), o, m)
+
+	require.NoError(t, err)
+	assert.Contains(t, m.subscribed, vault.EventTypeKV,
+		"must re-subscribe when WebSocket is nil (orphaned entry)")
+
+	// Registry must be refreshed after re-subscription.
+	meta, ok := r.eventWatcherRegistry.Get(key)
+	require.True(t, ok, "registry must have entry after re-subscription")
+	assert.Equal(t, "test-vss-client", meta.LastClientID)
+}
+
+// Test_VSS_ensureEventWatcher_OnStop_CleansRegistry verifies that the OnStop
+// callback set on the VSS Subscriber deletes the registry entry when invoked,
+// so the next reconcile falls through to re-subscribe instead of returning early
+// because it sees a stale registry entry with matching metadata.
+func Test_VSS_ensureEventWatcher_OnStop_CleansRegistry(t *testing.T) {
+	t.Parallel()
+	ch := make(chan event.GenericEvent, 10)
+	r := &VaultStaticSecretReconciler{
+		eventWatcherRegistry: newEventWatcherRegistry(),
+		SourceCh:             ch,
+		Recorder:             record.NewFakeRecorder(10),
+	}
+
+	o := &secretsv1beta1.VaultStaticSecret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "kv-secret", Generation: 1},
+		Spec: secretsv1beta1.VaultStaticSecretSpec{
+			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+				Type:  vsoconsts.KVSecretTypeV2,
+				Mount: "secret",
+				Path:  "app/config",
+			},
+		},
+	}
+	key := client.ObjectKeyFromObject(o)
+
+	var capturedOnStop func()
+	m := &mockVSSClient{
+		onSubscribe: func(_ vault.EventType, sub *vault.Subscriber) {
+			if capturedOnStop == nil && sub.OnStop != nil {
+				capturedOnStop = sub.OnStop
+			}
+		},
+	}
+
+	err := r.ensureEventWatcher(context.Background(), o, m)
+	require.NoError(t, err)
+
+	_, ok := r.eventWatcherRegistry.Get(key)
+	require.True(t, ok, "registry must have entry after ensureEventWatcher")
+
+	// Simulate WebSocket death by invoking the captured OnStop callback.
+	require.NotNil(t, capturedOnStop, "OnStop must be set on the KV subscriber")
+	capturedOnStop()
+
+	// Registry entry must be gone — next reconcile will re-subscribe.
+	_, ok = r.eventWatcherRegistry.Get(key)
+	assert.False(t, ok, "registry entry must be deleted after OnStop fires")
+}
+
+// Test_VSS_unWatchEvents_UnsubscribesAndClearsRegistry verifies that
+// unWatchEvents calls UnsubscribeFromEvents for KV and removes the registry entry.
+func Test_VSS_unWatchEvents_UnsubscribesAndClearsRegistry(t *testing.T) {
+	t.Parallel()
+	r := &VaultStaticSecretReconciler{
+		eventWatcherRegistry: newEventWatcherRegistry(),
+	}
+
+	o := &secretsv1beta1.VaultStaticSecret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "kv-secret"},
+		Spec: secretsv1beta1.VaultStaticSecretSpec{
+			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+				Type:  vsoconsts.KVSecretTypeV1,
+				Mount: "secret",
+				Path:  "app/config",
+			},
+		},
+	}
+	key := client.ObjectKeyFromObject(o)
+	r.eventWatcherRegistry.Register(key, &eventWatcherMeta{
+		LastClientID:   "test-vss-client",
+		LastGeneration: 1,
+	})
+
+	m := &mockVSSClient{}
+	r.unWatchEvents(o, m)
+
+	require.Len(t, m.seen, 1, "exactly one unsubscribe call expected (KV only)")
+	assert.Equal(t, vault.EventTypeKV, m.seen[0])
+
+	_, ok := r.eventWatcherRegistry.Get(key)
+	assert.False(t, ok, "registry entry must be deleted after unWatchEvents")
+}
+
+// Test_VSS_unWatchEvents_NoOpWhenNoRegistryEntry verifies that unWatchEvents
+// does nothing (no panic, no unsubscribe) when the object is not in the registry.
+func Test_VSS_unWatchEvents_NoOpWhenNoRegistryEntry(t *testing.T) {
+	t.Parallel()
+	r := &VaultStaticSecretReconciler{
+		eventWatcherRegistry: newEventWatcherRegistry(),
+	}
+
+	o := &secretsv1beta1.VaultStaticSecret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "unknown"},
+		Spec: secretsv1beta1.VaultStaticSecretSpec{
+			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+				Type:  vsoconsts.KVSecretTypeV1,
+				Mount: "secret",
+				Path:  "app/config",
+			},
+		},
+	}
+
+	m := &mockVSSClient{}
+	// Must not panic and must not call UnsubscribeFromEvents.
+	r.unWatchEvents(o, m)
+
+	assert.Empty(t, m.seen, "no unsubscribe should be called when object not in registry")
+}
+
+// Test_VSS_ensureEventWatcher_SubscribeError verifies that when SubscribeToEvents
+// returns an error, ensureEventWatcher propagates it and does NOT register a
+// registry entry (so the next reconcile retries from scratch).
+func Test_VSS_ensureEventWatcher_SubscribeError(t *testing.T) {
+	t.Parallel()
+	ch := make(chan event.GenericEvent, 10)
+	r := &VaultStaticSecretReconciler{
+		eventWatcherRegistry: newEventWatcherRegistry(),
+		SourceCh:             ch,
+		Recorder:             record.NewFakeRecorder(10),
+	}
+
+	o := &secretsv1beta1.VaultStaticSecret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "app", Generation: 1},
+		Spec: secretsv1beta1.VaultStaticSecretSpec{
+			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+				Type:  vsoconsts.KVSecretTypeV1,
+				Mount: "secret",
+				Path:  "app/config",
+			},
+		},
+	}
+	key := client.ObjectKeyFromObject(o)
+
+	m := &mockVSSClient{subscribeErr: fmt.Errorf("websocket dial: connection refused")}
+	err := r.ensureEventWatcher(context.Background(), o, m)
+
+	require.Error(t, err, "must propagate SubscribeToEvents error to caller")
+	assert.Contains(t, err.Error(), "connection refused")
+
+	// Registry must stay empty — no successful subscription was made.
+	_, ok := r.eventWatcherRegistry.Get(key)
+	assert.False(t, ok, "registry must not have an entry when subscribe failed")
 }

--- a/test/integration/vaultstaticsecret_integration_test.go
+++ b/test/integration/vaultstaticsecret_integration_test.go
@@ -175,7 +175,7 @@ func waitForEventWatcherStarted(t *testing.T, ctx context.Context, crdClient ctr
 }
 
 // waitForNewOperatorPod waits for a new operator pod to be ready after the old one is deleted
-func waitForNewOperatorPod(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, operatorNS string, oldPodUID string, maxRetries uint64) error {
+func waitForNewOperatorPod(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, operatorNS, oldPodUID string, maxRetries uint64) error {
 	return backoff.Retry(func() error {
 		newPodList := &corev1.PodList{}
 		if err := crdClient.List(ctx, newPodList, ctrlclient.InNamespace(operatorNS),

--- a/test/integration/vaultstaticsecret_integration_test.go
+++ b/test/integration/vaultstaticsecret_integration_test.go
@@ -48,6 +48,194 @@ type vssK8SOutputs struct {
 	AdminK8sNamespace string `json:"admin_k8s_namespace"`
 }
 
+// Helper functions for common test operations
+
+// setupVSSTestInfrastructure sets up Terraform infrastructure for VSS tests
+func setupVSSTestInfrastructure(t *testing.T, useEvents bool) (string, *terraform.Options, vssK8SOutputs) {
+	tempDir, err := os.MkdirTemp(os.TempDir(), t.Name())
+	require.NoError(t, err)
+
+	tfDir := copyTerraformDir(t, path.Join(testRoot, "vaultstaticsecret/terraform"), tempDir)
+	copyModulesDirT(t, tfDir)
+
+	k8sConfigContext := os.Getenv("K8S_CLUSTER_CONTEXT")
+	if k8sConfigContext == "" {
+		k8sConfigContext = "kind-" + clusterName
+	}
+
+	tfOptions := &terraform.Options{
+		TerraformDir: tfDir,
+		Vars: map[string]interface{}{
+			"k8s_config_context": k8sConfigContext,
+			"vault_enterprise":   true,
+			"use_events":         useEvents,
+		},
+	}
+
+	tfOptions = setCommonTFOptions(t, tfOptions)
+
+	skipCleanup := os.Getenv("SKIP_CLEANUP") != ""
+	t.Cleanup(func() {
+		if skipCleanup {
+			t.Logf("Skipping cleanup (SKIP_CLEANUP=1), tfdir=%s", tfDir)
+			return
+		}
+
+		if !testInParallel {
+			exportKindLogsT(t)
+		}
+
+		terraform.Destroy(t, tfOptions)
+		assert.NoError(t, os.RemoveAll(tempDir))
+	})
+
+	terraform.InitAndApply(t, tfOptions)
+
+	b, err := json.Marshal(terraform.OutputAll(t, tfOptions))
+	require.NoError(t, err)
+
+	var outputs vssK8SOutputs
+	require.NoError(t, json.Unmarshal(b, &outputs))
+
+	return tfDir, tfOptions, outputs
+}
+
+// createVaultConnection creates a VaultConnection resource
+func createVaultConnection(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, name, namespace string, skipCleanup bool) *secretsv1beta1.VaultConnection {
+	vaultConn := &secretsv1beta1.VaultConnection{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: secretsv1beta1.VaultConnectionSpec{
+			Address: testVaultAddress,
+		},
+	}
+	require.NoError(t, crdClient.Create(ctx, vaultConn))
+
+	t.Cleanup(func() {
+		if !skipCleanup {
+			assert.NoError(t, crdClient.Delete(ctx, vaultConn))
+		}
+	})
+
+	return vaultConn
+}
+
+// createVaultAuth creates a VaultAuth resource with kubernetes auth
+func createVaultAuth(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, name string, vaultConn *secretsv1beta1.VaultConnection, outputs vssK8SOutputs, skipCleanup bool) *secretsv1beta1.VaultAuth {
+	vaultAuth := &secretsv1beta1.VaultAuth{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: vaultConn.Namespace,
+		},
+		Spec: secretsv1beta1.VaultAuthSpec{
+			VaultConnectionRef: ctrlclient.ObjectKeyFromObject(vaultConn).String(),
+			Namespace:          outputs.AppVaultNamespace,
+			Method:             "kubernetes",
+			Mount:              outputs.AuthMount,
+			Kubernetes: &secretsv1beta1.VaultAuthConfigKubernetes{
+				Role:           outputs.AuthRole,
+				ServiceAccount: "default",
+				TokenAudiences: []string{"vault"},
+			},
+			AllowedNamespaces: []string{outputs.AppK8sNamespace},
+		},
+	}
+	require.NoError(t, crdClient.Create(ctx, vaultAuth))
+
+	t.Cleanup(func() {
+		if !skipCleanup {
+			assert.NoError(t, crdClient.Delete(ctx, vaultAuth))
+		}
+	})
+
+	return vaultAuth
+}
+
+// waitForEventWatcherStarted waits for the EventWatcherStarted event for a VaultStaticSecret
+func waitForEventWatcherStarted(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, vssObj *secretsv1beta1.VaultStaticSecret, maxRetries uint64) error {
+	return backoff.Retry(func() error {
+		objEvents := corev1.EventList{}
+		err := crdClient.List(ctx, &objEvents,
+			ctrlclient.InNamespace(vssObj.Namespace),
+			ctrlclient.MatchingFields{
+				"involvedObject.name": vssObj.Name,
+				"reason":              consts.ReasonEventWatcherStarted,
+			},
+		)
+		if err != nil {
+			return err
+		}
+		if len(objEvents.Items) == 0 {
+			return fmt.Errorf("no EventWatcherStarted event for %s", vssObj.Name)
+		}
+		return nil
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), maxRetries))
+}
+
+// waitForNewOperatorPod waits for a new operator pod to be ready after the old one is deleted
+func waitForNewOperatorPod(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, operatorNS string, oldPodUID string, maxRetries uint64) error {
+	return backoff.Retry(func() error {
+		newPodList := &corev1.PodList{}
+		if err := crdClient.List(ctx, newPodList, ctrlclient.InNamespace(operatorNS),
+			ctrlclient.MatchingLabels{"control-plane": "controller-manager"}); err != nil {
+			return err
+		}
+
+		if len(newPodList.Items) == 0 {
+			return fmt.Errorf("no operator pods found")
+		}
+
+		newPod := newPodList.Items[0]
+		if string(newPod.UID) == oldPodUID {
+			return fmt.Errorf("still seeing old pod")
+		}
+
+		if newPod.Status.Phase != corev1.PodRunning {
+			return fmt.Errorf("new pod not running yet: %s", newPod.Status.Phase)
+		}
+
+		// Check if pod is ready
+		for _, cond := range newPod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("new pod not ready yet")
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second*2), maxRetries))
+}
+
+// deleteOperatorPod deletes the operator pod and returns its UID
+func deleteOperatorPod(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, operatorNS string) string {
+	podList := &corev1.PodList{}
+	require.NoError(t, crdClient.List(ctx, podList, ctrlclient.InNamespace(operatorNS),
+		ctrlclient.MatchingLabels{"control-plane": "controller-manager"}))
+	require.NotEmpty(t, podList.Items, "no operator pods found")
+
+	operatorPod := podList.Items[0]
+	oldPodUID := string(operatorPod.UID)
+	require.NoError(t, crdClient.Delete(ctx, &operatorPod))
+
+	return oldPodUID
+}
+
+// verifyVSSIsSynced verifies that a VaultStaticSecret has synced status
+func verifyVSSIsSynced(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, vssObj *secretsv1beta1.VaultStaticSecret) {
+	var currentVSS secretsv1beta1.VaultStaticSecret
+	require.NoError(t, crdClient.Get(ctx, ctrlclient.ObjectKeyFromObject(vssObj), &currentVSS))
+
+	var synced bool
+	for _, cond := range currentVSS.Status.Conditions {
+		if cond.Type == consts.TypeSecretSynced && cond.Status == v1.ConditionTrue {
+			synced = true
+			break
+		}
+	}
+	require.True(t, synced, "VaultStaticSecret should be synced")
+}
+
 func TestVaultStaticSecret(t *testing.T) {
 	if testInParallel {
 		t.Parallel()
@@ -622,56 +810,19 @@ func TestVaultStaticSecretEventWatcherShortTTLNoEOF(t *testing.T) {
 		t.Skip("Skipping because this test requires Vault Enterprise >= 1.16.3")
 	}
 
-	tempDir, err := os.MkdirTemp(os.TempDir(), t.Name())
-	require.NoError(t, err)
-
-	tfDir := copyTerraformDir(t, path.Join(testRoot, "vaultstaticsecret/terraform"), tempDir)
-	copyModulesDirT(t, tfDir)
-
-	k8sConfigContext := os.Getenv("K8S_CLUSTER_CONTEXT")
-	if k8sConfigContext == "" {
-		k8sConfigContext = "kind-" + clusterName
-	}
-
-	tfOptions := setCommonTFOptions(t, &terraform.Options{
-		TerraformDir: tfDir,
-		Vars: map[string]interface{}{
-			"k8s_config_context": k8sConfigContext,
-			"vault_enterprise":   true,
-			"use_events":         true,
-		},
-	})
+	// Setup infrastructure
+	_, _, outputs := setupVSSTestInfrastructure(t, true)
 
 	ctx := context.Background()
 	crdClient := getCRDClient(t)
-
 	skipCleanup := os.Getenv("SKIP_CLEANUP") != ""
-	t.Cleanup(func() {
-		if skipCleanup {
-			t.Logf("Skipping cleanup, tfdir=%s", tfDir)
-			return
-		}
-		if !testInParallel {
-			exportKindLogsT(t)
-		}
-		terraform.Destroy(t, tfOptions)
-		assert.NoError(t, os.RemoveAll(tempDir))
-	})
-
-	terraform.InitAndApply(t, tfOptions)
-
-	b, err := json.Marshal(terraform.OutputAll(t, tfOptions))
-	require.NoError(t, err)
-
-	var outputs vssK8SOutputs
-	require.NoError(t, json.Unmarshal(b, &outputs))
 
 	authClient := getVaultClient(t, outputs.AppVaultNamespace)
 
 	// Reproduce the reported short-lived Kubernetes auth token scenario by
 	// setting both the auth mount and auth role TTLs to 1 minute.
 	tunePath := fmt.Sprintf("sys/auth/%s/tune", outputs.AuthMount)
-	_, err = authClient.Logical().Write(tunePath, map[string]interface{}{
+	_, err := authClient.Logical().Write(tunePath, map[string]interface{}{
 		"default_lease_ttl": "1m",
 		"max_lease_ttl":     "1m",
 	})
@@ -773,25 +924,8 @@ func TestVaultStaticSecretEventWatcherShortTTLNoEOF(t *testing.T) {
 		vssObj.ObjectMeta.Namespace, expectedData)
 	require.NoError(t, err)
 
-	// Ensure the event watcher is active before validating behavior across
-	// token renewal boundaries.
-	require.NoError(t, backoff.Retry(func() error {
-		objEvents := corev1.EventList{}
-		err := crdClient.List(ctx, &objEvents,
-			ctrlclient.InNamespace(vssObj.Namespace),
-			ctrlclient.MatchingFields{
-				"involvedObject.name": vssObj.Name,
-				"reason":              consts.ReasonEventWatcherStarted,
-			},
-		)
-		if err != nil {
-			return err
-		}
-		if len(objEvents.Items) == 0 {
-			return fmt.Errorf("no EventWatcherStarted event for %s", vssObj.Name)
-		}
-		return nil
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 60)))
+	// Ensure the event watcher is active before validating behavior
+	require.NoError(t, waitForEventWatcherStarted(t, ctx, crdClient, vssObj, 60))
 
 	// Wait through 3 TTL cycles (~1 minute each) and mutate Vault data each
 	// cycle to verify websocket event streaming continues to drive sync updates.
@@ -1048,4 +1182,657 @@ func awaitNoRolloutRestartsVSS(t *testing.T, ctx context.Context, client ctrlcli
 		},
 		backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second*1), 30),
 	))
+}
+
+// TestVaultStaticSecret_RequeueAfterEventLoopExit tests that when an event loop
+// exits (WebSocket connection dies), the resource is requeued and reconciled again.
+// This verifies the fix for: "No Requeue Event After Event Loop Exit"
+func TestVaultStaticSecret_RequeueAfterEventLoopExit(t *testing.T) {
+	// Test initialization
+	if testInParallel {
+		t.Parallel()
+	}
+
+	require.NotEmpty(t, clusterName, "KIND_CLUSTER_NAME is not set")
+
+	operatorNS := os.Getenv("OPERATOR_NAMESPACE")
+	require.NotEmpty(t, operatorNS, "OPERATOR_NAMESPACE is not set")
+
+	// Setup Terraform directory
+	tempDir, err := os.MkdirTemp(os.TempDir(), t.Name())
+	require.Nil(t, err)
+
+	tfDir := copyTerraformDir(t, path.Join(testRoot, "vaultstaticsecret/terraform"), tempDir)
+	copyModulesDirT(t, tfDir)
+
+	// Configure Terraform options
+	k8sConfigContext := os.Getenv("K8S_CLUSTER_CONTEXT")
+	if k8sConfigContext == "" {
+		k8sConfigContext = "kind-" + clusterName
+	}
+
+	tfOptions := &terraform.Options{
+		TerraformDir: tfDir,
+		Vars: map[string]interface{}{
+			"k8s_config_context": k8sConfigContext,
+		},
+	}
+
+	// Enable events for this test (requires Vault Enterprise >= 1.16.3)
+	rootVaultClient := getVaultClient(t, "")
+	atLeast_v1_16_3 := vaultVersionGreaterThanOrEqual(t, rootVaultClient, "1.16.3")
+	if entTests && atLeast_v1_16_3 {
+		tfOptions.Vars["vault_enterprise"] = true
+		tfOptions.Vars["use_events"] = true
+	} else {
+		t.Skip("Skipping test - requires Vault Enterprise >= 1.16.3 for event loop testing")
+	}
+
+	tfOptions = setCommonTFOptions(t, tfOptions)
+
+	ctx := context.Background()
+	crdClient := getCRDClient(t)
+
+	skipCleanup := os.Getenv("SKIP_CLEANUP") != ""
+	t.Cleanup(func() {
+		if skipCleanup {
+			t.Logf("Skipping cleanup, tfdir=%s", tfDir)
+			return
+		}
+
+		if !testInParallel {
+			exportKindLogsT(t)
+		}
+
+		terraform.Destroy(t, tfOptions)
+		assert.NoError(t, os.RemoveAll(tempDir))
+	})
+
+	// Deploy infrastructure with Terraform
+	terraform.InitAndApply(t, tfOptions)
+
+	// Get Terraform outputs
+	b, err := json.Marshal(terraform.OutputAll(t, tfOptions))
+	require.NoError(t, err)
+
+	var outputs vssK8SOutputs
+	require.NoError(t, json.Unmarshal(b, &outputs))
+
+	// Create VaultConnection and VaultAuth resources
+	vaultConn := &secretsv1beta1.VaultConnection{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-conn-requeue",
+			Namespace: outputs.AppK8sNamespace,
+		},
+		Spec: secretsv1beta1.VaultConnectionSpec{
+			Address: testVaultAddress,
+		},
+	}
+	require.NoError(t, crdClient.Create(ctx, vaultConn))
+
+	t.Cleanup(func() {
+		if !skipCleanup {
+			assert.NoError(t, crdClient.Delete(ctx, vaultConn))
+		}
+	})
+
+	vaultAuth := &secretsv1beta1.VaultAuth{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-auth-requeue",
+			Namespace: outputs.AppK8sNamespace,
+		},
+		Spec: secretsv1beta1.VaultAuthSpec{
+			VaultConnectionRef: ctrlclient.ObjectKeyFromObject(vaultConn).String(),
+			Namespace:          outputs.AppVaultNamespace,
+			Method:             "kubernetes",
+			Mount:              outputs.AuthMount,
+			Kubernetes: &secretsv1beta1.VaultAuthConfigKubernetes{
+				Role:           outputs.AuthRole,
+				ServiceAccount: "default",
+				TokenAudiences: []string{"vault"},
+			},
+			AllowedNamespaces: []string{outputs.AppK8sNamespace},
+		},
+	}
+	require.NoError(t, crdClient.Create(ctx, vaultAuth))
+
+	t.Cleanup(func() {
+		if !skipCleanup {
+			assert.NoError(t, crdClient.Delete(ctx, vaultAuth))
+		}
+	})
+
+	// Create VaultStaticSecret with instant updates enabled (WebSocket)
+	vssName := "test-vss-requeue"
+	vssObj := &secretsv1beta1.VaultStaticSecret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      vssName,
+			Namespace: outputs.AppK8sNamespace,
+		},
+		Spec: secretsv1beta1.VaultStaticSecretSpec{
+			VaultAuthRef: ctrlclient.ObjectKeyFromObject(vaultAuth).String(),
+			Namespace:    outputs.AppVaultNamespace,
+			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+				Mount: outputs.KVV2Mount,
+				Type:  consts.KVSecretTypeV2,
+				Path:  "requeue-test",
+			},
+			Destination: secretsv1beta1.Destination{
+				Name:   vssName,
+				Create: true,
+			},
+			RefreshAfter: "30s",
+			SyncConfig: &secretsv1beta1.SyncConfig{
+				InstantUpdates: true,
+			},
+		},
+	}
+
+	// Write initial secret to Vault
+	vClient := getVaultClient(t, outputs.AppVaultNamespace)
+	initialData := map[string]interface{}{
+		"initial-key": "initial-value",
+	}
+	_, err = vClient.KVv2(outputs.KVV2Mount).Put(ctx, vssObj.Spec.Path, initialData)
+	require.NoError(t, err)
+
+	// Create VaultStaticSecret in Kubernetes
+	require.NoError(t, crdClient.Create(ctx, vssObj))
+
+	t.Cleanup(func() {
+		if !skipCleanup {
+			assert.NoError(t, crdClient.Delete(ctx, vssObj))
+		}
+	})
+
+	// Wait for initial secret sync
+	_, err = waitForSecretData(t, ctx, crdClient, 60, time.Second, vssObj.Spec.Destination.Name,
+		vssObj.Namespace, initialData)
+	require.NoError(t, err, "initial secret sync failed")
+
+	// Wait for WebSocket event watcher to start
+	require.NoError(t, waitForEventWatcherStarted(t, ctx, crdClient, vssObj, 60))
+
+	// Simulate operator crash by deleting operator pod
+	oldPodUID := deleteOperatorPod(t, ctx, crdClient, operatorNS)
+
+	// Wait for new operator pod to be ready
+	require.NoError(t, waitForNewOperatorPod(t, ctx, crdClient, operatorNS, oldPodUID, 60))
+
+	// Update secret in Vault to trigger reconciliation
+	updatedData := map[string]interface{}{
+		"updated-key": "updated-value-after-restart",
+	}
+	_, err = vClient.KVv2(outputs.KVV2Mount).Put(ctx, vssObj.Spec.Path, updatedData)
+	require.NoError(t, err)
+
+	// Verify the resource gets requeued and reconciled
+	// The secret should be updated even though the WebSocket died
+	// This is the critical test - if this times out, requeue didn't work
+	_, err = waitForSecretData(t, ctx, crdClient, 120, time.Second*2, vssObj.Spec.Destination.Name,
+		vssObj.Namespace, updatedData)
+	require.NoError(t, err, "secret should sync after operator restart - requeue event should have been sent")
+
+	// Verify VaultStaticSecret status shows it's synced
+	verifyVSSIsSynced(t, ctx, crdClient, vssObj)
+}
+
+func TestVaultStaticSecret_RegistryCleanup(t *testing.T) {
+	// Test verifies event watcher registry properly cleans up when VaultStaticSecrets are deleted
+	// This ensures no memory leaks or orphaned goroutines
+	if testInParallel {
+		t.Parallel()
+	}
+
+	require.NotEmpty(t, clusterName, "KIND_CLUSTER_NAME is not set")
+
+	operatorNS := os.Getenv("OPERATOR_NAMESPACE")
+	require.NotEmpty(t, operatorNS, "OPERATOR_NAMESPACE is not set")
+
+	// Check if we should run this test (requires Vault Enterprise >= 1.16.3)
+	rootVaultClient := getVaultClient(t, "")
+	atLeast_v1_16_3 := vaultVersionGreaterThanOrEqual(t, rootVaultClient, "1.16.3")
+	if !entTests || !atLeast_v1_16_3 {
+		t.Skip("Skipping test - requires Vault Enterprise >= 1.16.3 for event watcher registry testing")
+	}
+
+	// Setup infrastructure
+	_, _, outputs := setupVSSTestInfrastructure(t, true)
+
+	ctx := context.Background()
+	crdClient := getCRDClient(t)
+	skipCleanup := os.Getenv("SKIP_CLEANUP") != ""
+
+	// Create VaultConnection and VaultAuth
+	vaultConn := createVaultConnection(t, ctx, crdClient, "test-conn-cleanup", outputs.AppK8sNamespace, skipCleanup)
+	vaultAuth := createVaultAuth(t, ctx, crdClient, "test-auth-cleanup", vaultConn, outputs, skipCleanup)
+
+	vClient := getVaultClient(t, outputs.AppVaultNamespace)
+
+	// Create 10 VaultStaticSecrets with instant updates
+	// This will create 10 event watchers (WebSocket connections) in the registry
+	numSecrets := 10
+	vssObjects := make([]*secretsv1beta1.VaultStaticSecret, numSecrets)
+
+	for i := 0; i < numSecrets; i++ {
+		secretName := fmt.Sprintf("test-vss-cleanup-%d", i)
+		secretPath := fmt.Sprintf("cleanup-test-%d", i)
+
+		// Write secret to Vault
+		secretData := map[string]interface{}{
+			"key": fmt.Sprintf("value-%d", i),
+		}
+		_, err := vClient.KVv2(outputs.KVV2Mount).Put(ctx, secretPath, secretData)
+		require.NoError(t, err)
+
+		// Create VaultStaticSecret with instant updates enabled
+		vssObj := &secretsv1beta1.VaultStaticSecret{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      secretName,
+				Namespace: outputs.AppK8sNamespace,
+			},
+			Spec: secretsv1beta1.VaultStaticSecretSpec{
+				VaultAuthRef: ctrlclient.ObjectKeyFromObject(vaultAuth).String(),
+				Namespace:    outputs.AppVaultNamespace,
+				VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+					Mount: outputs.KVV2Mount,
+					Type:  consts.KVSecretTypeV2,
+					Path:  secretPath,
+				},
+				Destination: secretsv1beta1.Destination{
+					Name:   secretName,
+					Create: true,
+				},
+				RefreshAfter: "1h",
+				SyncConfig: &secretsv1beta1.SyncConfig{
+					InstantUpdates: true,
+				},
+			},
+		}
+
+		require.NoError(t, crdClient.Create(ctx, vssObj))
+		vssObjects[i] = vssObj
+	}
+
+	// Wait for all secrets to sync
+	for i, vssObj := range vssObjects {
+		expectedData := map[string]interface{}{
+			"key": fmt.Sprintf("value-%d", i),
+		}
+
+		_, err := waitForSecretData(t, ctx, crdClient, 60, time.Second, vssObj.Spec.Destination.Name,
+			vssObj.Namespace, expectedData)
+		require.NoError(t, err, "secret %s should sync", vssObj.Name)
+	}
+
+	// Wait for all event watchers to start (registry should have 10 entries)
+	for _, vssObj := range vssObjects {
+		require.NoError(t, waitForEventWatcherStarted(t, ctx, crdClient, vssObj, 60))
+	}
+
+	// Delete all VaultStaticSecrets
+	// This should trigger cleanup of all event watchers from the registry
+	for _, vssObj := range vssObjects {
+		require.NoError(t, crdClient.Delete(ctx, vssObj))
+	}
+
+	// Give operator time to process deletions and clean up watchers
+	time.Sleep(10 * time.Second)
+
+	// Verify all VaultStaticSecrets are deleted
+	for i, vssObj := range vssObjects {
+		var vss secretsv1beta1.VaultStaticSecret
+		err := crdClient.Get(ctx, ctrlclient.ObjectKeyFromObject(vssObj), &vss)
+		require.True(t, err != nil && strings.Contains(err.Error(), "not found"),
+			"VaultStaticSecret %d should be deleted", i)
+	}
+
+	// Create new VaultStaticSecrets to verify registry can handle new entries after cleanup
+	// This proves there are no memory leaks or orphaned goroutines
+	newVSSObjects := make([]*secretsv1beta1.VaultStaticSecret, 3)
+
+	for i := 0; i < 3; i++ {
+		secretName := fmt.Sprintf("test-vss-after-cleanup-%d", i)
+		secretPath := fmt.Sprintf("after-cleanup-%d", i)
+
+		secretData := map[string]interface{}{
+			"key": fmt.Sprintf("new-value-%d", i),
+		}
+		_, err := vClient.KVv2(outputs.KVV2Mount).Put(ctx, secretPath, secretData)
+		require.NoError(t, err)
+
+		vssObj := &secretsv1beta1.VaultStaticSecret{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      secretName,
+				Namespace: outputs.AppK8sNamespace,
+			},
+			Spec: secretsv1beta1.VaultStaticSecretSpec{
+				VaultAuthRef: ctrlclient.ObjectKeyFromObject(vaultAuth).String(),
+				Namespace:    outputs.AppVaultNamespace,
+				VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+					Mount: outputs.KVV2Mount,
+					Type:  consts.KVSecretTypeV2,
+					Path:  secretPath,
+				},
+				Destination: secretsv1beta1.Destination{
+					Name:   secretName,
+					Create: true,
+				},
+				RefreshAfter: "1h",
+				SyncConfig: &secretsv1beta1.SyncConfig{
+					InstantUpdates: true,
+				},
+			},
+		}
+
+		require.NoError(t, crdClient.Create(ctx, vssObj))
+		newVSSObjects[i] = vssObj
+
+		t.Cleanup(func() {
+			if !skipCleanup {
+				assert.NoError(t, crdClient.Delete(ctx, vssObj))
+			}
+		})
+	}
+
+	// Verify new secrets sync successfully (proves registry is working after cleanup)
+	for i, vssObj := range newVSSObjects {
+		expectedData := map[string]interface{}{
+			"key": fmt.Sprintf("new-value-%d", i),
+		}
+
+		_, err := waitForSecretData(t, ctx, crdClient, 60, time.Second, vssObj.Spec.Destination.Name,
+			vssObj.Namespace, expectedData)
+		require.NoError(t, err, "new secret %s should sync", vssObj.Name)
+	}
+}
+
+func TestVaultStaticSecret_OrphanedRegistryRecovery(t *testing.T) {
+	if testInParallel {
+		t.Parallel()
+	}
+
+	require.NotEmpty(t, clusterName, "KIND_CLUSTER_NAME is not set")
+
+	operatorNS := os.Getenv("OPERATOR_NAMESPACE")
+	require.NotEmpty(t, operatorNS, "OPERATOR_NAMESPACE is not set")
+
+	// Requires Vault Enterprise >= 1.16.3 for event watcher functionality
+	rootVaultClient := getVaultClient(t, "")
+	atLeast_v1_16_3 := vaultVersionGreaterThanOrEqual(t, rootVaultClient, "1.16.3")
+	if !entTests || !atLeast_v1_16_3 {
+		t.Skip("Skipping test - requires Vault Enterprise >= 1.16.3 for orphaned registry testing")
+	}
+
+	// Setup Terraform infrastructure for test
+	tempDir, err := os.MkdirTemp(os.TempDir(), t.Name())
+	require.NoError(t, err)
+
+	tfDir := copyTerraformDir(t, path.Join(testRoot, "vaultstaticsecret/terraform"), tempDir)
+	copyModulesDirT(t, tfDir)
+
+	k8sConfigContext := os.Getenv("K8S_CLUSTER_CONTEXT")
+	if k8sConfigContext == "" {
+		k8sConfigContext = "kind-" + clusterName
+	}
+
+	tfOptions := &terraform.Options{
+		TerraformDir: tfDir,
+		Vars: map[string]interface{}{
+			"k8s_config_context": k8sConfigContext,
+			"vault_enterprise":   true,
+			"use_events":         true, // Enable instant updates via WebSocket events
+		},
+	}
+
+	tfOptions = setCommonTFOptions(t, tfOptions)
+
+	ctx := context.Background()
+	crdClient := getCRDClient(t)
+
+	skipCleanup := os.Getenv("SKIP_CLEANUP") != ""
+	t.Cleanup(func() {
+		if skipCleanup {
+			t.Logf("Skipping cleanup (SKIP_CLEANUP=1), tfdir=%s", tfDir)
+			return
+		}
+
+		if !testInParallel {
+			exportKindLogsT(t)
+		}
+
+		terraform.Destroy(t, tfOptions)
+		assert.NoError(t, os.RemoveAll(tempDir))
+	})
+
+	terraform.InitAndApply(t, tfOptions)
+
+	b, err := json.Marshal(terraform.OutputAll(t, tfOptions))
+	require.NoError(t, err)
+
+	var outputs vssK8SOutputs
+	require.NoError(t, json.Unmarshal(b, &outputs))
+
+	// Create VaultConnection
+	vaultConn := &secretsv1beta1.VaultConnection{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-conn-orphan",
+			Namespace: outputs.AppK8sNamespace,
+		},
+		Spec: secretsv1beta1.VaultConnectionSpec{
+			Address: testVaultAddress,
+		},
+	}
+	require.NoError(t, crdClient.Create(ctx, vaultConn))
+
+	t.Cleanup(func() {
+		if !skipCleanup {
+			assert.NoError(t, crdClient.Delete(ctx, vaultConn))
+		}
+	})
+
+	// Create VaultAuth with full namespace/name reference
+	vaultAuth := &secretsv1beta1.VaultAuth{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-auth-orphan",
+			Namespace: outputs.AppK8sNamespace,
+		},
+		Spec: secretsv1beta1.VaultAuthSpec{
+			VaultConnectionRef: ctrlclient.ObjectKeyFromObject(vaultConn).String(),
+			Namespace:          outputs.AppVaultNamespace,
+			Method:             "kubernetes",
+			Mount:              outputs.AuthMount,
+			Kubernetes: &secretsv1beta1.VaultAuthConfigKubernetes{
+				Role:           outputs.AuthRole,
+				ServiceAccount: "default",
+				TokenAudiences: []string{"vault"},
+			},
+			AllowedNamespaces: []string{outputs.AppK8sNamespace},
+		},
+	}
+	require.NoError(t, crdClient.Create(ctx, vaultAuth))
+
+	t.Cleanup(func() {
+		if !skipCleanup {
+			assert.NoError(t, crdClient.Delete(ctx, vaultAuth))
+		}
+	})
+
+	vClient := getVaultClient(t, outputs.AppVaultNamespace)
+
+	secretName := "test-vss-orphan"
+	secretPath := "orphan-test"
+
+	// Write initial secret to Vault
+	initialData := map[string]interface{}{
+		"key": "initial-value",
+	}
+	_, err = vClient.KVv2(outputs.KVV2Mount).Put(ctx, secretPath, initialData)
+	require.NoError(t, err)
+
+	// Create VaultStaticSecret with instant updates enabled
+	vssObj := &secretsv1beta1.VaultStaticSecret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      secretName,
+			Namespace: outputs.AppK8sNamespace,
+		},
+		Spec: secretsv1beta1.VaultStaticSecretSpec{
+			VaultAuthRef: ctrlclient.ObjectKeyFromObject(vaultAuth).String(),
+			Namespace:    outputs.AppVaultNamespace,
+			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
+				Mount: outputs.KVV2Mount,
+				Type:  consts.KVSecretTypeV2,
+				Path:  secretPath,
+			},
+			Destination: secretsv1beta1.Destination{
+				Name:   secretName,
+				Create: true,
+			},
+			RefreshAfter: "1h",
+			SyncConfig: &secretsv1beta1.SyncConfig{
+				InstantUpdates: true, // Enables WebSocket event watcher
+			},
+		},
+	}
+
+	require.NoError(t, crdClient.Create(ctx, vssObj))
+
+	t.Cleanup(func() {
+		if !skipCleanup {
+			assert.NoError(t, crdClient.Delete(ctx, vssObj))
+		}
+	})
+
+	// Wait for initial secret sync
+	_, err = waitForSecretData(t, ctx, crdClient, 60, time.Second, vssObj.Spec.Destination.Name,
+		vssObj.Namespace, initialData)
+	require.NoError(t, err, "initial secret sync failed")
+
+	// Wait for event watcher to start (creates registry entry)
+	require.NoError(t, backoff.Retry(func() error {
+		objEvents := corev1.EventList{}
+		err := crdClient.List(ctx, &objEvents,
+			ctrlclient.InNamespace(vssObj.Namespace),
+			ctrlclient.MatchingFields{
+				"involvedObject.name": vssObj.Name,
+				"reason":              consts.ReasonEventWatcherStarted,
+			},
+		)
+		if err != nil {
+			return err
+		}
+		if len(objEvents.Items) == 0 {
+			return fmt.Errorf("no EventWatcherStarted event for %s", vssObj.Name)
+		}
+		return nil
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 60)))
+
+	// Get current operator pod before simulating crash
+	podList := &corev1.PodList{}
+	require.NoError(t, crdClient.List(ctx, podList, ctrlclient.InNamespace(operatorNS),
+		ctrlclient.MatchingLabels{"control-plane": "controller-manager"}))
+	require.NotEmpty(t, podList.Items, "no operator pods found")
+
+	operatorPod := podList.Items[0]
+	originalPodUID := operatorPod.UID
+	originalPodName := operatorPod.Name
+
+	// Delete operator pod to simulate crash - this creates an orphaned registry entry
+	// because the event watcher doesn't get a chance to clean up properly
+	require.NoError(t, crdClient.Delete(ctx, &operatorPod))
+
+	// Verify old pod is actually deleted
+	require.NoError(t, backoff.Retry(func() error {
+		checkPodList := &corev1.PodList{}
+		if err := crdClient.List(ctx, checkPodList, ctrlclient.InNamespace(operatorNS),
+			ctrlclient.MatchingLabels{"control-plane": "controller-manager"}); err != nil {
+			return fmt.Errorf("error listing pods: %v", err)
+		}
+
+		// Check if old pod still exists
+		for _, pod := range checkPodList.Items {
+			if pod.UID == originalPodUID {
+				return fmt.Errorf("old pod %s (UID: %s) still exists", originalPodName, originalPodUID)
+			}
+		}
+		return nil
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 30)))
+
+	// Wait for new operator pod to start (recovery)
+	require.NoError(t, backoff.Retry(func() error {
+		newPodList := &corev1.PodList{}
+		if err := crdClient.List(ctx, newPodList, ctrlclient.InNamespace(operatorNS),
+			ctrlclient.MatchingLabels{"control-plane": "controller-manager"}); err != nil {
+			return err
+		}
+
+		if len(newPodList.Items) == 0 {
+			return fmt.Errorf("no operator pods found")
+		}
+
+		newPod := newPodList.Items[0]
+		if newPod.UID == originalPodUID {
+			return fmt.Errorf("still seeing old pod")
+		}
+
+		if newPod.Status.Phase != corev1.PodRunning {
+			return fmt.Errorf("new pod not running yet: %s", newPod.Status.Phase)
+		}
+
+		// Check if pod is ready
+		for _, cond := range newPod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("new pod not ready yet")
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second*2), 60)))
+
+	// Give operator time to detect orphans and reconcile
+	time.Sleep(15 * time.Second)
+
+	// Verify the VaultStaticSecret is still healthy after operator restart
+	verifyVSSIsSynced(t, ctx, crdClient, vssObj)
+
+	// Verify event watcher restarted (optional check - may not always emit new event)
+	require.NoError(t, backoff.Retry(func() error {
+		objEvents := corev1.EventList{}
+		err := crdClient.List(ctx, &objEvents,
+			ctrlclient.InNamespace(vssObj.Namespace),
+			ctrlclient.MatchingFields{
+				"involvedObject.name": vssObj.Name,
+				"reason":              consts.ReasonEventWatcherStarted,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		// Look for recent event (after operator restart)
+		for _, event := range objEvents.Items {
+			if event.LastTimestamp.Time.After(time.Now().Add(-30 * time.Second)) {
+				return nil
+			}
+		}
+
+		// If no recent event, check if there are multiple events (indicates restart)
+		if len(objEvents.Items) >= 2 {
+			return nil
+		}
+
+		return fmt.Errorf("no evidence of event watcher restart yet")
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second*2), 30)))
+
+	// Update secret in Vault to verify instant updates still work after recovery
+	updatedData := map[string]interface{}{
+		"key": "updated-after-recovery",
+	}
+	_, err = vClient.KVv2(outputs.KVV2Mount).Put(ctx, secretPath, updatedData)
+	require.NoError(t, err)
+
+	// Wait for secret to sync - proves instant updates working and registry properly recovered
+	_, err = waitForSecretData(t, ctx, crdClient, 60, time.Second*2, vssObj.Spec.Destination.Name,
+		vssObj.Namespace, updatedData)
+	require.NoError(t, err, "secret should sync after operator recovery")
 }

--- a/test/integration/vaultstaticsecret_integration_test.go
+++ b/test/integration/vaultstaticsecret_integration_test.go
@@ -1189,9 +1189,9 @@ func awaitNoRolloutRestartsVSS(t *testing.T, ctx context.Context, client ctrlcli
 // This verifies the fix for: "No Requeue Event After Event Loop Exit"
 func TestVaultStaticSecret_RequeueAfterEventLoopExit(t *testing.T) {
 	// Test initialization
-	if testInParallel {
-		t.Parallel()
-	}
+	// if testInParallel {
+	// 	t.Parallel()
+	// }
 
 	require.NotEmpty(t, clusterName, "KIND_CLUSTER_NAME is not set")
 
@@ -1380,9 +1380,9 @@ func TestVaultStaticSecret_RequeueAfterEventLoopExit(t *testing.T) {
 func TestVaultStaticSecret_RegistryCleanup(t *testing.T) {
 	// Test verifies event watcher registry properly cleans up when VaultStaticSecrets are deleted
 	// This ensures no memory leaks or orphaned goroutines
-	if testInParallel {
-		t.Parallel()
-	}
+	// if testInParallel {
+	// 	t.Parallel()
+	// }
 
 	require.NotEmpty(t, clusterName, "KIND_CLUSTER_NAME is not set")
 
@@ -1548,9 +1548,9 @@ func TestVaultStaticSecret_RegistryCleanup(t *testing.T) {
 }
 
 func TestVaultStaticSecret_OrphanedRegistryRecovery(t *testing.T) {
-	if testInParallel {
-		t.Parallel()
-	}
+	// if testInParallel {
+	// 	t.Parallel()
+	// }
 
 	require.NotEmpty(t, clusterName, "KIND_CLUSTER_NAME is not set")
 

--- a/test/integration/vaultstaticsecret_integration_test.go
+++ b/test/integration/vaultstaticsecret_integration_test.go
@@ -48,194 +48,6 @@ type vssK8SOutputs struct {
 	AdminK8sNamespace string `json:"admin_k8s_namespace"`
 }
 
-// Helper functions for common test operations
-
-// setupVSSTestInfrastructure sets up Terraform infrastructure for VSS tests
-func setupVSSTestInfrastructure(t *testing.T, useEvents bool) (string, *terraform.Options, vssK8SOutputs) {
-	tempDir, err := os.MkdirTemp(os.TempDir(), t.Name())
-	require.NoError(t, err)
-
-	tfDir := copyTerraformDir(t, path.Join(testRoot, "vaultstaticsecret/terraform"), tempDir)
-	copyModulesDirT(t, tfDir)
-
-	k8sConfigContext := os.Getenv("K8S_CLUSTER_CONTEXT")
-	if k8sConfigContext == "" {
-		k8sConfigContext = "kind-" + clusterName
-	}
-
-	tfOptions := &terraform.Options{
-		TerraformDir: tfDir,
-		Vars: map[string]interface{}{
-			"k8s_config_context": k8sConfigContext,
-			"vault_enterprise":   true,
-			"use_events":         useEvents,
-		},
-	}
-
-	tfOptions = setCommonTFOptions(t, tfOptions)
-
-	skipCleanup := os.Getenv("SKIP_CLEANUP") != ""
-	t.Cleanup(func() {
-		if skipCleanup {
-			t.Logf("Skipping cleanup (SKIP_CLEANUP=1), tfdir=%s", tfDir)
-			return
-		}
-
-		if !testInParallel {
-			exportKindLogsT(t)
-		}
-
-		terraform.Destroy(t, tfOptions)
-		assert.NoError(t, os.RemoveAll(tempDir))
-	})
-
-	terraform.InitAndApply(t, tfOptions)
-
-	b, err := json.Marshal(terraform.OutputAll(t, tfOptions))
-	require.NoError(t, err)
-
-	var outputs vssK8SOutputs
-	require.NoError(t, json.Unmarshal(b, &outputs))
-
-	return tfDir, tfOptions, outputs
-}
-
-// createVaultConnection creates a VaultConnection resource
-func createVaultConnection(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, name, namespace string, skipCleanup bool) *secretsv1beta1.VaultConnection {
-	vaultConn := &secretsv1beta1.VaultConnection{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: secretsv1beta1.VaultConnectionSpec{
-			Address: testVaultAddress,
-		},
-	}
-	require.NoError(t, crdClient.Create(ctx, vaultConn))
-
-	t.Cleanup(func() {
-		if !skipCleanup {
-			assert.NoError(t, crdClient.Delete(ctx, vaultConn))
-		}
-	})
-
-	return vaultConn
-}
-
-// createVaultAuth creates a VaultAuth resource with kubernetes auth
-func createVaultAuth(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, name string, vaultConn *secretsv1beta1.VaultConnection, outputs vssK8SOutputs, skipCleanup bool) *secretsv1beta1.VaultAuth {
-	vaultAuth := &secretsv1beta1.VaultAuth{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      name,
-			Namespace: vaultConn.Namespace,
-		},
-		Spec: secretsv1beta1.VaultAuthSpec{
-			VaultConnectionRef: ctrlclient.ObjectKeyFromObject(vaultConn).String(),
-			Namespace:          outputs.AppVaultNamespace,
-			Method:             "kubernetes",
-			Mount:              outputs.AuthMount,
-			Kubernetes: &secretsv1beta1.VaultAuthConfigKubernetes{
-				Role:           outputs.AuthRole,
-				ServiceAccount: "default",
-				TokenAudiences: []string{"vault"},
-			},
-			AllowedNamespaces: []string{outputs.AppK8sNamespace},
-		},
-	}
-	require.NoError(t, crdClient.Create(ctx, vaultAuth))
-
-	t.Cleanup(func() {
-		if !skipCleanup {
-			assert.NoError(t, crdClient.Delete(ctx, vaultAuth))
-		}
-	})
-
-	return vaultAuth
-}
-
-// waitForEventWatcherStarted waits for the EventWatcherStarted event for a VaultStaticSecret
-func waitForEventWatcherStarted(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, vssObj *secretsv1beta1.VaultStaticSecret, maxRetries uint64) error {
-	return backoff.Retry(func() error {
-		objEvents := corev1.EventList{}
-		err := crdClient.List(ctx, &objEvents,
-			ctrlclient.InNamespace(vssObj.Namespace),
-			ctrlclient.MatchingFields{
-				"involvedObject.name": vssObj.Name,
-				"reason":              consts.ReasonEventWatcherStarted,
-			},
-		)
-		if err != nil {
-			return err
-		}
-		if len(objEvents.Items) == 0 {
-			return fmt.Errorf("no EventWatcherStarted event for %s", vssObj.Name)
-		}
-		return nil
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), maxRetries))
-}
-
-// waitForNewOperatorPod waits for a new operator pod to be ready after the old one is deleted
-func waitForNewOperatorPod(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, operatorNS, oldPodUID string, maxRetries uint64) error {
-	return backoff.Retry(func() error {
-		newPodList := &corev1.PodList{}
-		if err := crdClient.List(ctx, newPodList, ctrlclient.InNamespace(operatorNS),
-			ctrlclient.MatchingLabels{"control-plane": "controller-manager"}); err != nil {
-			return err
-		}
-
-		if len(newPodList.Items) == 0 {
-			return fmt.Errorf("no operator pods found")
-		}
-
-		newPod := newPodList.Items[0]
-		if string(newPod.UID) == oldPodUID {
-			return fmt.Errorf("still seeing old pod")
-		}
-
-		if newPod.Status.Phase != corev1.PodRunning {
-			return fmt.Errorf("new pod not running yet: %s", newPod.Status.Phase)
-		}
-
-		// Check if pod is ready
-		for _, cond := range newPod.Status.Conditions {
-			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-				return nil
-			}
-		}
-
-		return fmt.Errorf("new pod not ready yet")
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second*2), maxRetries))
-}
-
-// deleteOperatorPod deletes the operator pod and returns its UID
-func deleteOperatorPod(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, operatorNS string) string {
-	podList := &corev1.PodList{}
-	require.NoError(t, crdClient.List(ctx, podList, ctrlclient.InNamespace(operatorNS),
-		ctrlclient.MatchingLabels{"control-plane": "controller-manager"}))
-	require.NotEmpty(t, podList.Items, "no operator pods found")
-
-	operatorPod := podList.Items[0]
-	oldPodUID := string(operatorPod.UID)
-	require.NoError(t, crdClient.Delete(ctx, &operatorPod))
-
-	return oldPodUID
-}
-
-// verifyVSSIsSynced verifies that a VaultStaticSecret has synced status
-func verifyVSSIsSynced(t *testing.T, ctx context.Context, crdClient ctrlclient.Client, vssObj *secretsv1beta1.VaultStaticSecret) {
-	var currentVSS secretsv1beta1.VaultStaticSecret
-	require.NoError(t, crdClient.Get(ctx, ctrlclient.ObjectKeyFromObject(vssObj), &currentVSS))
-
-	var synced bool
-	for _, cond := range currentVSS.Status.Conditions {
-		if cond.Type == consts.TypeSecretSynced && cond.Status == v1.ConditionTrue {
-			synced = true
-			break
-		}
-	}
-	require.True(t, synced, "VaultStaticSecret should be synced")
-}
-
 func TestVaultStaticSecret(t *testing.T) {
 	if testInParallel {
 		t.Parallel()
@@ -810,19 +622,56 @@ func TestVaultStaticSecretEventWatcherShortTTLNoEOF(t *testing.T) {
 		t.Skip("Skipping because this test requires Vault Enterprise >= 1.16.3")
 	}
 
-	// Setup infrastructure
-	_, _, outputs := setupVSSTestInfrastructure(t, true)
+	tempDir, err := os.MkdirTemp(os.TempDir(), t.Name())
+	require.NoError(t, err)
+
+	tfDir := copyTerraformDir(t, path.Join(testRoot, "vaultstaticsecret/terraform"), tempDir)
+	copyModulesDirT(t, tfDir)
+
+	k8sConfigContext := os.Getenv("K8S_CLUSTER_CONTEXT")
+	if k8sConfigContext == "" {
+		k8sConfigContext = "kind-" + clusterName
+	}
+
+	tfOptions := setCommonTFOptions(t, &terraform.Options{
+		TerraformDir: tfDir,
+		Vars: map[string]interface{}{
+			"k8s_config_context": k8sConfigContext,
+			"vault_enterprise":   true,
+			"use_events":         true,
+		},
+	})
 
 	ctx := context.Background()
 	crdClient := getCRDClient(t)
+
 	skipCleanup := os.Getenv("SKIP_CLEANUP") != ""
+	t.Cleanup(func() {
+		if skipCleanup {
+			t.Logf("Skipping cleanup, tfdir=%s", tfDir)
+			return
+		}
+		if !testInParallel {
+			exportKindLogsT(t)
+		}
+		terraform.Destroy(t, tfOptions)
+		assert.NoError(t, os.RemoveAll(tempDir))
+	})
+
+	terraform.InitAndApply(t, tfOptions)
+
+	b, err := json.Marshal(terraform.OutputAll(t, tfOptions))
+	require.NoError(t, err)
+
+	var outputs vssK8SOutputs
+	require.NoError(t, json.Unmarshal(b, &outputs))
 
 	authClient := getVaultClient(t, outputs.AppVaultNamespace)
 
 	// Reproduce the reported short-lived Kubernetes auth token scenario by
 	// setting both the auth mount and auth role TTLs to 1 minute.
 	tunePath := fmt.Sprintf("sys/auth/%s/tune", outputs.AuthMount)
-	_, err := authClient.Logical().Write(tunePath, map[string]interface{}{
+	_, err = authClient.Logical().Write(tunePath, map[string]interface{}{
 		"default_lease_ttl": "1m",
 		"max_lease_ttl":     "1m",
 	})
@@ -924,8 +773,25 @@ func TestVaultStaticSecretEventWatcherShortTTLNoEOF(t *testing.T) {
 		vssObj.ObjectMeta.Namespace, expectedData)
 	require.NoError(t, err)
 
-	// Ensure the event watcher is active before validating behavior
-	require.NoError(t, waitForEventWatcherStarted(t, ctx, crdClient, vssObj, 60))
+	// Ensure the event watcher is active before validating behavior across
+	// token renewal boundaries.
+	require.NoError(t, backoff.Retry(func() error {
+		objEvents := corev1.EventList{}
+		err := crdClient.List(ctx, &objEvents,
+			ctrlclient.InNamespace(vssObj.Namespace),
+			ctrlclient.MatchingFields{
+				"involvedObject.name": vssObj.Name,
+				"reason":              consts.ReasonEventWatcherStarted,
+			},
+		)
+		if err != nil {
+			return err
+		}
+		if len(objEvents.Items) == 0 {
+			return fmt.Errorf("no EventWatcherStarted event for %s", vssObj.Name)
+		}
+		return nil
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 60)))
 
 	// Wait through 3 TTL cycles (~1 minute each) and mutate Vault data each
 	// cycle to verify websocket event streaming continues to drive sync updates.
@@ -1182,657 +1048,4 @@ func awaitNoRolloutRestartsVSS(t *testing.T, ctx context.Context, client ctrlcli
 		},
 		backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second*1), 30),
 	))
-}
-
-// TestVaultStaticSecret_RequeueAfterEventLoopExit tests that when an event loop
-// exits (WebSocket connection dies), the resource is requeued and reconciled again.
-// This verifies the fix for: "No Requeue Event After Event Loop Exit"
-func TestVaultStaticSecret_RequeueAfterEventLoopExit(t *testing.T) {
-	// Test initialization
-	// if testInParallel {
-	// 	t.Parallel()
-	// }
-
-	require.NotEmpty(t, clusterName, "KIND_CLUSTER_NAME is not set")
-
-	operatorNS := os.Getenv("OPERATOR_NAMESPACE")
-	require.NotEmpty(t, operatorNS, "OPERATOR_NAMESPACE is not set")
-
-	// Setup Terraform directory
-	tempDir, err := os.MkdirTemp(os.TempDir(), t.Name())
-	require.Nil(t, err)
-
-	tfDir := copyTerraformDir(t, path.Join(testRoot, "vaultstaticsecret/terraform"), tempDir)
-	copyModulesDirT(t, tfDir)
-
-	// Configure Terraform options
-	k8sConfigContext := os.Getenv("K8S_CLUSTER_CONTEXT")
-	if k8sConfigContext == "" {
-		k8sConfigContext = "kind-" + clusterName
-	}
-
-	tfOptions := &terraform.Options{
-		TerraformDir: tfDir,
-		Vars: map[string]interface{}{
-			"k8s_config_context": k8sConfigContext,
-		},
-	}
-
-	// Enable events for this test (requires Vault Enterprise >= 1.16.3)
-	rootVaultClient := getVaultClient(t, "")
-	atLeast_v1_16_3 := vaultVersionGreaterThanOrEqual(t, rootVaultClient, "1.16.3")
-	if entTests && atLeast_v1_16_3 {
-		tfOptions.Vars["vault_enterprise"] = true
-		tfOptions.Vars["use_events"] = true
-	} else {
-		t.Skip("Skipping test - requires Vault Enterprise >= 1.16.3 for event loop testing")
-	}
-
-	tfOptions = setCommonTFOptions(t, tfOptions)
-
-	ctx := context.Background()
-	crdClient := getCRDClient(t)
-
-	skipCleanup := os.Getenv("SKIP_CLEANUP") != ""
-	t.Cleanup(func() {
-		if skipCleanup {
-			t.Logf("Skipping cleanup, tfdir=%s", tfDir)
-			return
-		}
-
-		if !testInParallel {
-			exportKindLogsT(t)
-		}
-
-		terraform.Destroy(t, tfOptions)
-		assert.NoError(t, os.RemoveAll(tempDir))
-	})
-
-	// Deploy infrastructure with Terraform
-	terraform.InitAndApply(t, tfOptions)
-
-	// Get Terraform outputs
-	b, err := json.Marshal(terraform.OutputAll(t, tfOptions))
-	require.NoError(t, err)
-
-	var outputs vssK8SOutputs
-	require.NoError(t, json.Unmarshal(b, &outputs))
-
-	// Create VaultConnection and VaultAuth resources
-	vaultConn := &secretsv1beta1.VaultConnection{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "test-conn-requeue",
-			Namespace: outputs.AppK8sNamespace,
-		},
-		Spec: secretsv1beta1.VaultConnectionSpec{
-			Address: testVaultAddress,
-		},
-	}
-	require.NoError(t, crdClient.Create(ctx, vaultConn))
-
-	t.Cleanup(func() {
-		if !skipCleanup {
-			assert.NoError(t, crdClient.Delete(ctx, vaultConn))
-		}
-	})
-
-	vaultAuth := &secretsv1beta1.VaultAuth{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "test-auth-requeue",
-			Namespace: outputs.AppK8sNamespace,
-		},
-		Spec: secretsv1beta1.VaultAuthSpec{
-			VaultConnectionRef: ctrlclient.ObjectKeyFromObject(vaultConn).String(),
-			Namespace:          outputs.AppVaultNamespace,
-			Method:             "kubernetes",
-			Mount:              outputs.AuthMount,
-			Kubernetes: &secretsv1beta1.VaultAuthConfigKubernetes{
-				Role:           outputs.AuthRole,
-				ServiceAccount: "default",
-				TokenAudiences: []string{"vault"},
-			},
-			AllowedNamespaces: []string{outputs.AppK8sNamespace},
-		},
-	}
-	require.NoError(t, crdClient.Create(ctx, vaultAuth))
-
-	t.Cleanup(func() {
-		if !skipCleanup {
-			assert.NoError(t, crdClient.Delete(ctx, vaultAuth))
-		}
-	})
-
-	// Create VaultStaticSecret with instant updates enabled (WebSocket)
-	vssName := "test-vss-requeue"
-	vssObj := &secretsv1beta1.VaultStaticSecret{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      vssName,
-			Namespace: outputs.AppK8sNamespace,
-		},
-		Spec: secretsv1beta1.VaultStaticSecretSpec{
-			VaultAuthRef: ctrlclient.ObjectKeyFromObject(vaultAuth).String(),
-			Namespace:    outputs.AppVaultNamespace,
-			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
-				Mount: outputs.KVV2Mount,
-				Type:  consts.KVSecretTypeV2,
-				Path:  "requeue-test",
-			},
-			Destination: secretsv1beta1.Destination{
-				Name:   vssName,
-				Create: true,
-			},
-			RefreshAfter: "30s",
-			SyncConfig: &secretsv1beta1.SyncConfig{
-				InstantUpdates: true,
-			},
-		},
-	}
-
-	// Write initial secret to Vault
-	vClient := getVaultClient(t, outputs.AppVaultNamespace)
-	initialData := map[string]interface{}{
-		"initial-key": "initial-value",
-	}
-	_, err = vClient.KVv2(outputs.KVV2Mount).Put(ctx, vssObj.Spec.Path, initialData)
-	require.NoError(t, err)
-
-	// Create VaultStaticSecret in Kubernetes
-	require.NoError(t, crdClient.Create(ctx, vssObj))
-
-	t.Cleanup(func() {
-		if !skipCleanup {
-			assert.NoError(t, crdClient.Delete(ctx, vssObj))
-		}
-	})
-
-	// Wait for initial secret sync
-	_, err = waitForSecretData(t, ctx, crdClient, 60, time.Second, vssObj.Spec.Destination.Name,
-		vssObj.Namespace, initialData)
-	require.NoError(t, err, "initial secret sync failed")
-
-	// Wait for WebSocket event watcher to start
-	require.NoError(t, waitForEventWatcherStarted(t, ctx, crdClient, vssObj, 60))
-
-	// Simulate operator crash by deleting operator pod
-	oldPodUID := deleteOperatorPod(t, ctx, crdClient, operatorNS)
-
-	// Wait for new operator pod to be ready
-	require.NoError(t, waitForNewOperatorPod(t, ctx, crdClient, operatorNS, oldPodUID, 60))
-
-	// Update secret in Vault to trigger reconciliation
-	updatedData := map[string]interface{}{
-		"updated-key": "updated-value-after-restart",
-	}
-	_, err = vClient.KVv2(outputs.KVV2Mount).Put(ctx, vssObj.Spec.Path, updatedData)
-	require.NoError(t, err)
-
-	// Verify the resource gets requeued and reconciled
-	// The secret should be updated even though the WebSocket died
-	// This is the critical test - if this times out, requeue didn't work
-	_, err = waitForSecretData(t, ctx, crdClient, 120, time.Second*2, vssObj.Spec.Destination.Name,
-		vssObj.Namespace, updatedData)
-	require.NoError(t, err, "secret should sync after operator restart - requeue event should have been sent")
-
-	// Verify VaultStaticSecret status shows it's synced
-	verifyVSSIsSynced(t, ctx, crdClient, vssObj)
-}
-
-func TestVaultStaticSecret_RegistryCleanup(t *testing.T) {
-	// Test verifies event watcher registry properly cleans up when VaultStaticSecrets are deleted
-	// This ensures no memory leaks or orphaned goroutines
-	// if testInParallel {
-	// 	t.Parallel()
-	// }
-
-	require.NotEmpty(t, clusterName, "KIND_CLUSTER_NAME is not set")
-
-	operatorNS := os.Getenv("OPERATOR_NAMESPACE")
-	require.NotEmpty(t, operatorNS, "OPERATOR_NAMESPACE is not set")
-
-	// Check if we should run this test (requires Vault Enterprise >= 1.16.3)
-	rootVaultClient := getVaultClient(t, "")
-	atLeast_v1_16_3 := vaultVersionGreaterThanOrEqual(t, rootVaultClient, "1.16.3")
-	if !entTests || !atLeast_v1_16_3 {
-		t.Skip("Skipping test - requires Vault Enterprise >= 1.16.3 for event watcher registry testing")
-	}
-
-	// Setup infrastructure
-	_, _, outputs := setupVSSTestInfrastructure(t, true)
-
-	ctx := context.Background()
-	crdClient := getCRDClient(t)
-	skipCleanup := os.Getenv("SKIP_CLEANUP") != ""
-
-	// Create VaultConnection and VaultAuth
-	vaultConn := createVaultConnection(t, ctx, crdClient, "test-conn-cleanup", outputs.AppK8sNamespace, skipCleanup)
-	vaultAuth := createVaultAuth(t, ctx, crdClient, "test-auth-cleanup", vaultConn, outputs, skipCleanup)
-
-	vClient := getVaultClient(t, outputs.AppVaultNamespace)
-
-	// Create 10 VaultStaticSecrets with instant updates
-	// This will create 10 event watchers (WebSocket connections) in the registry
-	numSecrets := 10
-	vssObjects := make([]*secretsv1beta1.VaultStaticSecret, numSecrets)
-
-	for i := 0; i < numSecrets; i++ {
-		secretName := fmt.Sprintf("test-vss-cleanup-%d", i)
-		secretPath := fmt.Sprintf("cleanup-test-%d", i)
-
-		// Write secret to Vault
-		secretData := map[string]interface{}{
-			"key": fmt.Sprintf("value-%d", i),
-		}
-		_, err := vClient.KVv2(outputs.KVV2Mount).Put(ctx, secretPath, secretData)
-		require.NoError(t, err)
-
-		// Create VaultStaticSecret with instant updates enabled
-		vssObj := &secretsv1beta1.VaultStaticSecret{
-			ObjectMeta: v1.ObjectMeta{
-				Name:      secretName,
-				Namespace: outputs.AppK8sNamespace,
-			},
-			Spec: secretsv1beta1.VaultStaticSecretSpec{
-				VaultAuthRef: ctrlclient.ObjectKeyFromObject(vaultAuth).String(),
-				Namespace:    outputs.AppVaultNamespace,
-				VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
-					Mount: outputs.KVV2Mount,
-					Type:  consts.KVSecretTypeV2,
-					Path:  secretPath,
-				},
-				Destination: secretsv1beta1.Destination{
-					Name:   secretName,
-					Create: true,
-				},
-				RefreshAfter: "1h",
-				SyncConfig: &secretsv1beta1.SyncConfig{
-					InstantUpdates: true,
-				},
-			},
-		}
-
-		require.NoError(t, crdClient.Create(ctx, vssObj))
-		vssObjects[i] = vssObj
-	}
-
-	// Wait for all secrets to sync
-	for i, vssObj := range vssObjects {
-		expectedData := map[string]interface{}{
-			"key": fmt.Sprintf("value-%d", i),
-		}
-
-		_, err := waitForSecretData(t, ctx, crdClient, 60, time.Second, vssObj.Spec.Destination.Name,
-			vssObj.Namespace, expectedData)
-		require.NoError(t, err, "secret %s should sync", vssObj.Name)
-	}
-
-	// Wait for all event watchers to start (registry should have 10 entries)
-	for _, vssObj := range vssObjects {
-		require.NoError(t, waitForEventWatcherStarted(t, ctx, crdClient, vssObj, 60))
-	}
-
-	// Delete all VaultStaticSecrets
-	// This should trigger cleanup of all event watchers from the registry
-	for _, vssObj := range vssObjects {
-		require.NoError(t, crdClient.Delete(ctx, vssObj))
-	}
-
-	// Give operator time to process deletions and clean up watchers
-	time.Sleep(10 * time.Second)
-
-	// Verify all VaultStaticSecrets are deleted
-	for i, vssObj := range vssObjects {
-		var vss secretsv1beta1.VaultStaticSecret
-		err := crdClient.Get(ctx, ctrlclient.ObjectKeyFromObject(vssObj), &vss)
-		require.True(t, err != nil && strings.Contains(err.Error(), "not found"),
-			"VaultStaticSecret %d should be deleted", i)
-	}
-
-	// Create new VaultStaticSecrets to verify registry can handle new entries after cleanup
-	// This proves there are no memory leaks or orphaned goroutines
-	newVSSObjects := make([]*secretsv1beta1.VaultStaticSecret, 3)
-
-	for i := 0; i < 3; i++ {
-		secretName := fmt.Sprintf("test-vss-after-cleanup-%d", i)
-		secretPath := fmt.Sprintf("after-cleanup-%d", i)
-
-		secretData := map[string]interface{}{
-			"key": fmt.Sprintf("new-value-%d", i),
-		}
-		_, err := vClient.KVv2(outputs.KVV2Mount).Put(ctx, secretPath, secretData)
-		require.NoError(t, err)
-
-		vssObj := &secretsv1beta1.VaultStaticSecret{
-			ObjectMeta: v1.ObjectMeta{
-				Name:      secretName,
-				Namespace: outputs.AppK8sNamespace,
-			},
-			Spec: secretsv1beta1.VaultStaticSecretSpec{
-				VaultAuthRef: ctrlclient.ObjectKeyFromObject(vaultAuth).String(),
-				Namespace:    outputs.AppVaultNamespace,
-				VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
-					Mount: outputs.KVV2Mount,
-					Type:  consts.KVSecretTypeV2,
-					Path:  secretPath,
-				},
-				Destination: secretsv1beta1.Destination{
-					Name:   secretName,
-					Create: true,
-				},
-				RefreshAfter: "1h",
-				SyncConfig: &secretsv1beta1.SyncConfig{
-					InstantUpdates: true,
-				},
-			},
-		}
-
-		require.NoError(t, crdClient.Create(ctx, vssObj))
-		newVSSObjects[i] = vssObj
-
-		t.Cleanup(func() {
-			if !skipCleanup {
-				assert.NoError(t, crdClient.Delete(ctx, vssObj))
-			}
-		})
-	}
-
-	// Verify new secrets sync successfully (proves registry is working after cleanup)
-	for i, vssObj := range newVSSObjects {
-		expectedData := map[string]interface{}{
-			"key": fmt.Sprintf("new-value-%d", i),
-		}
-
-		_, err := waitForSecretData(t, ctx, crdClient, 60, time.Second, vssObj.Spec.Destination.Name,
-			vssObj.Namespace, expectedData)
-		require.NoError(t, err, "new secret %s should sync", vssObj.Name)
-	}
-}
-
-func TestVaultStaticSecret_OrphanedRegistryRecovery(t *testing.T) {
-	// if testInParallel {
-	// 	t.Parallel()
-	// }
-
-	require.NotEmpty(t, clusterName, "KIND_CLUSTER_NAME is not set")
-
-	operatorNS := os.Getenv("OPERATOR_NAMESPACE")
-	require.NotEmpty(t, operatorNS, "OPERATOR_NAMESPACE is not set")
-
-	// Requires Vault Enterprise >= 1.16.3 for event watcher functionality
-	rootVaultClient := getVaultClient(t, "")
-	atLeast_v1_16_3 := vaultVersionGreaterThanOrEqual(t, rootVaultClient, "1.16.3")
-	if !entTests || !atLeast_v1_16_3 {
-		t.Skip("Skipping test - requires Vault Enterprise >= 1.16.3 for orphaned registry testing")
-	}
-
-	// Setup Terraform infrastructure for test
-	tempDir, err := os.MkdirTemp(os.TempDir(), t.Name())
-	require.NoError(t, err)
-
-	tfDir := copyTerraformDir(t, path.Join(testRoot, "vaultstaticsecret/terraform"), tempDir)
-	copyModulesDirT(t, tfDir)
-
-	k8sConfigContext := os.Getenv("K8S_CLUSTER_CONTEXT")
-	if k8sConfigContext == "" {
-		k8sConfigContext = "kind-" + clusterName
-	}
-
-	tfOptions := &terraform.Options{
-		TerraformDir: tfDir,
-		Vars: map[string]interface{}{
-			"k8s_config_context": k8sConfigContext,
-			"vault_enterprise":   true,
-			"use_events":         true, // Enable instant updates via WebSocket events
-		},
-	}
-
-	tfOptions = setCommonTFOptions(t, tfOptions)
-
-	ctx := context.Background()
-	crdClient := getCRDClient(t)
-
-	skipCleanup := os.Getenv("SKIP_CLEANUP") != ""
-	t.Cleanup(func() {
-		if skipCleanup {
-			t.Logf("Skipping cleanup (SKIP_CLEANUP=1), tfdir=%s", tfDir)
-			return
-		}
-
-		if !testInParallel {
-			exportKindLogsT(t)
-		}
-
-		terraform.Destroy(t, tfOptions)
-		assert.NoError(t, os.RemoveAll(tempDir))
-	})
-
-	terraform.InitAndApply(t, tfOptions)
-
-	b, err := json.Marshal(terraform.OutputAll(t, tfOptions))
-	require.NoError(t, err)
-
-	var outputs vssK8SOutputs
-	require.NoError(t, json.Unmarshal(b, &outputs))
-
-	// Create VaultConnection
-	vaultConn := &secretsv1beta1.VaultConnection{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "test-conn-orphan",
-			Namespace: outputs.AppK8sNamespace,
-		},
-		Spec: secretsv1beta1.VaultConnectionSpec{
-			Address: testVaultAddress,
-		},
-	}
-	require.NoError(t, crdClient.Create(ctx, vaultConn))
-
-	t.Cleanup(func() {
-		if !skipCleanup {
-			assert.NoError(t, crdClient.Delete(ctx, vaultConn))
-		}
-	})
-
-	// Create VaultAuth with full namespace/name reference
-	vaultAuth := &secretsv1beta1.VaultAuth{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "test-auth-orphan",
-			Namespace: outputs.AppK8sNamespace,
-		},
-		Spec: secretsv1beta1.VaultAuthSpec{
-			VaultConnectionRef: ctrlclient.ObjectKeyFromObject(vaultConn).String(),
-			Namespace:          outputs.AppVaultNamespace,
-			Method:             "kubernetes",
-			Mount:              outputs.AuthMount,
-			Kubernetes: &secretsv1beta1.VaultAuthConfigKubernetes{
-				Role:           outputs.AuthRole,
-				ServiceAccount: "default",
-				TokenAudiences: []string{"vault"},
-			},
-			AllowedNamespaces: []string{outputs.AppK8sNamespace},
-		},
-	}
-	require.NoError(t, crdClient.Create(ctx, vaultAuth))
-
-	t.Cleanup(func() {
-		if !skipCleanup {
-			assert.NoError(t, crdClient.Delete(ctx, vaultAuth))
-		}
-	})
-
-	vClient := getVaultClient(t, outputs.AppVaultNamespace)
-
-	secretName := "test-vss-orphan"
-	secretPath := "orphan-test"
-
-	// Write initial secret to Vault
-	initialData := map[string]interface{}{
-		"key": "initial-value",
-	}
-	_, err = vClient.KVv2(outputs.KVV2Mount).Put(ctx, secretPath, initialData)
-	require.NoError(t, err)
-
-	// Create VaultStaticSecret with instant updates enabled
-	vssObj := &secretsv1beta1.VaultStaticSecret{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      secretName,
-			Namespace: outputs.AppK8sNamespace,
-		},
-		Spec: secretsv1beta1.VaultStaticSecretSpec{
-			VaultAuthRef: ctrlclient.ObjectKeyFromObject(vaultAuth).String(),
-			Namespace:    outputs.AppVaultNamespace,
-			VaultStaticSecretCommon: secretsv1beta1.VaultStaticSecretCommon{
-				Mount: outputs.KVV2Mount,
-				Type:  consts.KVSecretTypeV2,
-				Path:  secretPath,
-			},
-			Destination: secretsv1beta1.Destination{
-				Name:   secretName,
-				Create: true,
-			},
-			RefreshAfter: "1h",
-			SyncConfig: &secretsv1beta1.SyncConfig{
-				InstantUpdates: true, // Enables WebSocket event watcher
-			},
-		},
-	}
-
-	require.NoError(t, crdClient.Create(ctx, vssObj))
-
-	t.Cleanup(func() {
-		if !skipCleanup {
-			assert.NoError(t, crdClient.Delete(ctx, vssObj))
-		}
-	})
-
-	// Wait for initial secret sync
-	_, err = waitForSecretData(t, ctx, crdClient, 60, time.Second, vssObj.Spec.Destination.Name,
-		vssObj.Namespace, initialData)
-	require.NoError(t, err, "initial secret sync failed")
-
-	// Wait for event watcher to start (creates registry entry)
-	require.NoError(t, backoff.Retry(func() error {
-		objEvents := corev1.EventList{}
-		err := crdClient.List(ctx, &objEvents,
-			ctrlclient.InNamespace(vssObj.Namespace),
-			ctrlclient.MatchingFields{
-				"involvedObject.name": vssObj.Name,
-				"reason":              consts.ReasonEventWatcherStarted,
-			},
-		)
-		if err != nil {
-			return err
-		}
-		if len(objEvents.Items) == 0 {
-			return fmt.Errorf("no EventWatcherStarted event for %s", vssObj.Name)
-		}
-		return nil
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 60)))
-
-	// Get current operator pod before simulating crash
-	podList := &corev1.PodList{}
-	require.NoError(t, crdClient.List(ctx, podList, ctrlclient.InNamespace(operatorNS),
-		ctrlclient.MatchingLabels{"control-plane": "controller-manager"}))
-	require.NotEmpty(t, podList.Items, "no operator pods found")
-
-	operatorPod := podList.Items[0]
-	originalPodUID := operatorPod.UID
-	originalPodName := operatorPod.Name
-
-	// Delete operator pod to simulate crash - this creates an orphaned registry entry
-	// because the event watcher doesn't get a chance to clean up properly
-	require.NoError(t, crdClient.Delete(ctx, &operatorPod))
-
-	// Verify old pod is actually deleted
-	require.NoError(t, backoff.Retry(func() error {
-		checkPodList := &corev1.PodList{}
-		if err := crdClient.List(ctx, checkPodList, ctrlclient.InNamespace(operatorNS),
-			ctrlclient.MatchingLabels{"control-plane": "controller-manager"}); err != nil {
-			return fmt.Errorf("error listing pods: %v", err)
-		}
-
-		// Check if old pod still exists
-		for _, pod := range checkPodList.Items {
-			if pod.UID == originalPodUID {
-				return fmt.Errorf("old pod %s (UID: %s) still exists", originalPodName, originalPodUID)
-			}
-		}
-		return nil
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 30)))
-
-	// Wait for new operator pod to start (recovery)
-	require.NoError(t, backoff.Retry(func() error {
-		newPodList := &corev1.PodList{}
-		if err := crdClient.List(ctx, newPodList, ctrlclient.InNamespace(operatorNS),
-			ctrlclient.MatchingLabels{"control-plane": "controller-manager"}); err != nil {
-			return err
-		}
-
-		if len(newPodList.Items) == 0 {
-			return fmt.Errorf("no operator pods found")
-		}
-
-		newPod := newPodList.Items[0]
-		if newPod.UID == originalPodUID {
-			return fmt.Errorf("still seeing old pod")
-		}
-
-		if newPod.Status.Phase != corev1.PodRunning {
-			return fmt.Errorf("new pod not running yet: %s", newPod.Status.Phase)
-		}
-
-		// Check if pod is ready
-		for _, cond := range newPod.Status.Conditions {
-			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-				return nil
-			}
-		}
-
-		return fmt.Errorf("new pod not ready yet")
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second*2), 60)))
-
-	// Give operator time to detect orphans and reconcile
-	time.Sleep(15 * time.Second)
-
-	// Verify the VaultStaticSecret is still healthy after operator restart
-	verifyVSSIsSynced(t, ctx, crdClient, vssObj)
-
-	// Verify event watcher restarted (optional check - may not always emit new event)
-	require.NoError(t, backoff.Retry(func() error {
-		objEvents := corev1.EventList{}
-		err := crdClient.List(ctx, &objEvents,
-			ctrlclient.InNamespace(vssObj.Namespace),
-			ctrlclient.MatchingFields{
-				"involvedObject.name": vssObj.Name,
-				"reason":              consts.ReasonEventWatcherStarted,
-			},
-		)
-		if err != nil {
-			return err
-		}
-
-		// Look for recent event (after operator restart)
-		for _, event := range objEvents.Items {
-			if event.LastTimestamp.Time.After(time.Now().Add(-30 * time.Second)) {
-				return nil
-			}
-		}
-
-		// If no recent event, check if there are multiple events (indicates restart)
-		if len(objEvents.Items) >= 2 {
-			return nil
-		}
-
-		return fmt.Errorf("no evidence of event watcher restart yet")
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second*2), 30)))
-
-	// Update secret in Vault to verify instant updates still work after recovery
-	updatedData := map[string]interface{}{
-		"key": "updated-after-recovery",
-	}
-	_, err = vClient.KVv2(outputs.KVV2Mount).Put(ctx, secretPath, updatedData)
-	require.NoError(t, err)
-
-	// Wait for secret to sync - proves instant updates working and registry properly recovered
-	_, err = waitForSecretData(t, ctx, crdClient, 60, time.Second*2, vssObj.Spec.Destination.Name,
-		vssObj.Namespace, updatedData)
-	require.NoError(t, err, "secret should sync after operator recovery")
 }

--- a/vault/client.go
+++ b/vault/client.go
@@ -1162,6 +1162,25 @@ func (c *defaultClient) getOrCreateWebSocket(
 		return nil, fmt.Errorf("failed to create shared websocket: %w", err)
 	}
 	// Remove this websocket from the client registry when its event loop stops.
+	//
+	// onStop is called in two distinct situations, and both must be handled:
+	//
+	//   1. Normal stop (primary cleanup path): the event loop exits on its own,
+	//      e.g. because the reconnect threshold was exceeded. In this case onStop
+	//      is the only thing that removes the registry entry — without it the
+	//      dead socket would stay in the map forever.
+	//
+	//   2. Double cleanup after dead-socket replacement: when a caller finds a
+	//      dead socket above (lines 1142-1157), it eagerly calls ws.Close() and
+	//      delete(c.websockets, eventType) before creating this new socket.
+	//      ws.Close() cancels the old socket's context, but its event loop
+	//      goroutine is still running and will eventually exit — at which point
+	//      it fires onStop() a second time, after the registry entry was already
+	//      removed. The `current == ws` pointer identity check makes this
+	//      redundant invocation a safe no-op: if a new socket was created for
+	//      the same eventType, current != ws (current points to the new socket,
+	//      ws to the old one), so the delete is skipped and the new socket is
+	//      left untouched in the registry.
 	ws.onStop = func() {
 		c.websocketMu.Lock()
 		defer c.websocketMu.Unlock()

--- a/vault/client.go
+++ b/vault/client.go
@@ -1161,6 +1161,14 @@ func (c *defaultClient) getOrCreateWebSocket(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create shared websocket: %w", err)
 	}
+	// Remove this websocket from the client registry when its event loop stops.
+	ws.onStop = func() {
+		c.websocketMu.Lock()
+		defer c.websocketMu.Unlock()
+		if current, exists := c.websockets[eventType]; exists && current == ws {
+			delete(c.websockets, eventType)
+		}
+	}
 
 	// Initialize map if needed
 	if c.websockets == nil {

--- a/vault/client.go
+++ b/vault/client.go
@@ -207,7 +207,11 @@ type Client interface {
 	// WebSocket connections.
 	GetWebSocketSubscriberCount() int
 	GetMountType(context.Context, string) (string, error)
-	GetWebSocket(EventType) *SharedWebSocket
+	// IsWebSocketHealthy reports whether a live, healthy SharedWebSocket exists
+	// for the given EventType. Callers that only need to check liveness should
+	// use this rather than obtaining the concrete *SharedWebSocket, which would
+	// couple them to the internal type.
+	IsWebSocketHealthy(EventType) bool
 }
 
 var _ Client = (*defaultClient)(nil)
@@ -1243,9 +1247,11 @@ func (c *defaultClient) GetWebSocketSubscriberCount() int {
 	return total
 }
 
-// GetWebSocket returns the SharedWebSocket for the given event type, or nil if not found
-func (c *defaultClient) GetWebSocket(eventType EventType) *SharedWebSocket {
+// IsWebSocketHealthy reports whether a live, healthy SharedWebSocket exists
+// for the given event type.
+func (c *defaultClient) IsWebSocketHealthy(eventType EventType) bool {
 	c.websocketMu.RLock()
 	defer c.websocketMu.RUnlock()
-	return c.websockets[eventType]
+	ws, exists := c.websockets[eventType]
+	return exists && ws.IsHealthy()
 }

--- a/vault/client.go
+++ b/vault/client.go
@@ -1144,12 +1144,15 @@ func (c *defaultClient) getOrCreateWebSocket(
 		if ws.IsHealthy() {
 			return ws, nil
 		}
-		// WebSocket exists but is dead, remove it from map
+		// WebSocket exists but is dead, close it properly before removing from map
 		logger := log.FromContext(ctx).WithValues(
 			"clientID", c.id,
 			"eventType", eventType,
 		)
-		logger.Info("Removing dead WebSocket from map before creating new one")
+		logger.Info("Closing dead WebSocket before creating new one")
+		if err := ws.Close(); err != nil {
+			logger.Error(err, "Failed to close dead WebSocket")
+		}
 		delete(c.websockets, eventType)
 	}
 

--- a/vault/client.go
+++ b/vault/client.go
@@ -207,6 +207,7 @@ type Client interface {
 	// WebSocket connections.
 	GetWebSocketSubscriberCount() int
 	GetMountType(context.Context, string) (string, error)
+	GetWebSocket(EventType) *SharedWebSocket
 }
 
 var _ Client = (*defaultClient)(nil)
@@ -1125,9 +1126,9 @@ func (c *defaultClient) getOrCreateWebSocket(
 	ctx context.Context,
 	eventType EventType,
 ) (*SharedWebSocket, error) {
-	// Check if WebSocket already exists (read lock)
+	// Check if WebSocket already exists and is healthy (read lock)
 	c.websocketMu.RLock()
-	if ws, exists := c.websockets[eventType]; exists {
+	if ws, exists := c.websockets[eventType]; exists && ws.IsHealthy() {
 		c.websocketMu.RUnlock()
 		return ws, nil
 	}
@@ -1139,7 +1140,17 @@ func (c *defaultClient) getOrCreateWebSocket(
 
 	// Double-check after acquiring write lock
 	if ws, exists := c.websockets[eventType]; exists {
-		return ws, nil
+		// Check if it's healthy
+		if ws.IsHealthy() {
+			return ws, nil
+		}
+		// WebSocket exists but is dead, remove it from map
+		logger := log.FromContext(ctx).WithValues(
+			"clientID", c.id,
+			"eventType", eventType,
+		)
+		logger.Info("Removing dead WebSocket from map before creating new one")
+		delete(c.websockets, eventType)
 	}
 
 	// Create new SharedWebSocket
@@ -1200,4 +1211,11 @@ func (c *defaultClient) GetWebSocketSubscriberCount() int {
 		total += ws.GetSubscriberCount()
 	}
 	return total
+}
+
+// GetWebSocket returns the SharedWebSocket for the given event type, or nil if not found
+func (c *defaultClient) GetWebSocket(eventType EventType) *SharedWebSocket {
+	c.websocketMu.RLock()
+	defer c.websocketMu.RUnlock()
+	return c.websockets[eventType]
 }

--- a/vault/client_test.go
+++ b/vault/client_test.go
@@ -1289,6 +1289,54 @@ func Test_defaultClient_WebSocketManagement(t *testing.T) {
 	})
 }
 
+// Test_defaultClient_WebSocketOnStop_RemovesCurrentWebSocket verifies that the
+// websocket onStop callback removes the same websocket instance from the
+// client's registry when the event loop exits.
+func Test_defaultClient_WebSocketOnStop_RemovesCurrentWebSocket(t *testing.T) {
+	c := &defaultClient{
+		id:         "test-client-id",
+		websockets: make(map[EventType]*SharedWebSocket),
+	}
+	ws := newTestSharedWebSocket(EventTypeKV)
+	c.websockets[EventTypeKV] = ws
+	ws.onStop = func() {
+		c.websocketMu.Lock()
+		defer c.websocketMu.Unlock()
+		if current, exists := c.websockets[EventTypeKV]; exists && current == ws {
+			delete(c.websockets, EventTypeKV)
+		}
+	}
+
+	ws.onStop()
+
+	assert.Equal(t, 0, c.GetWebSocketCount())
+}
+
+// Test_defaultClient_WebSocketOnStop_DoesNotRemoveReplacementWebSocket ensures
+// that a stopping websocket does not delete a newer replacement websocket that
+// is already registered for the same event type.
+func Test_defaultClient_WebSocketOnStop_DoesNotRemoveReplacementWebSocket(t *testing.T) {
+	c := &defaultClient{
+		id:         "test-client-id",
+		websockets: make(map[EventType]*SharedWebSocket),
+	}
+	oldWS := newTestSharedWebSocket(EventTypeKV)
+	newWS := newTestSharedWebSocket(EventTypeKV)
+	c.websockets[EventTypeKV] = newWS
+	oldWS.onStop = func() {
+		c.websocketMu.Lock()
+		defer c.websocketMu.Unlock()
+		if current, exists := c.websockets[EventTypeKV]; exists && current == oldWS {
+			delete(c.websockets, EventTypeKV)
+		}
+	}
+
+	oldWS.onStop()
+
+	require.Same(t, newWS, c.websockets[EventTypeKV])
+	assert.Equal(t, 1, c.GetWebSocketCount())
+}
+
 func Test_defaultClient_WebSocketLifecycle(t *testing.T) {
 	t.Parallel()
 

--- a/vault/client_test.go
+++ b/vault/client_test.go
@@ -1203,14 +1203,14 @@ func Test_defaultClient_WebSocketManagement(t *testing.T) {
 			ResourceKey:  types.NamespacedName{Namespace: "default", Name: "secret-1"},
 			VaultNS:      "",
 			VaultPath:    "kv/data/app/config",
-			ResourceType: "VaultStaticSecret",
+			ResourceType: ResourceTypeVaultStaticSecret,
 			ReconcileCh:  make(chan event.GenericEvent, 1),
 		}
 		sub2 := &Subscriber{
 			ResourceKey:  types.NamespacedName{Namespace: "default", Name: "secret-2"},
 			VaultNS:      "",
 			VaultPath:    "kv/data/app/config",
-			ResourceType: "VaultStaticSecret",
+			ResourceType: ResourceTypeVaultStaticSecret,
 			ReconcileCh:  make(chan event.GenericEvent, 1),
 		}
 		require.NoError(t, ws.Subscribe(sub1))
@@ -1232,14 +1232,14 @@ func Test_defaultClient_WebSocketManagement(t *testing.T) {
 			ResourceKey:  types.NamespacedName{Namespace: "default", Name: "kv-secret-1"},
 			VaultNS:      "",
 			VaultPath:    "kv/data/app/config",
-			ResourceType: "VaultStaticSecret",
+			ResourceType: ResourceTypeVaultStaticSecret,
 			ReconcileCh:  make(chan event.GenericEvent, 1),
 		}
 		sub2 := &Subscriber{
 			ResourceKey:  types.NamespacedName{Namespace: "default", Name: "kv-secret-2"},
 			VaultNS:      "",
 			VaultPath:    "kv/data/app/config",
-			ResourceType: "VaultStaticSecret",
+			ResourceType: ResourceTypeVaultStaticSecret,
 			ReconcileCh:  make(chan event.GenericEvent, 1),
 		}
 		require.NoError(t, kvWS.Subscribe(sub1))
@@ -1252,7 +1252,7 @@ func Test_defaultClient_WebSocketManagement(t *testing.T) {
 			ResourceKey:  types.NamespacedName{Namespace: "default", Name: "db-secret"},
 			VaultNS:      "",
 			VaultPath:    "database/creds/readonly",
-			ResourceType: "VaultDynamicSecret",
+			ResourceType: ResourceTypeVaultDynamicSecret,
 			ReconcileCh:  make(chan event.GenericEvent, 1),
 		}
 		require.NoError(t, dbWS.Subscribe(sub3))
@@ -1355,7 +1355,7 @@ func Test_defaultClient_WebSocketLifecycle(t *testing.T) {
 			},
 			VaultNS:      "",
 			VaultPath:    "kv/data/app/config",
-			ResourceType: "VaultStaticSecret",
+			ResourceType: ResourceTypeVaultStaticSecret,
 			ReconcileCh:  make(chan event.GenericEvent, 1),
 		}
 
@@ -1393,7 +1393,7 @@ func Test_defaultClient_WebSocketLifecycle(t *testing.T) {
 			},
 			VaultNS:      "",
 			VaultPath:    "kv/data/app/config",
-			ResourceType: "VaultStaticSecret",
+			ResourceType: ResourceTypeVaultStaticSecret,
 			ReconcileCh:  make(chan event.GenericEvent, 1),
 		}
 		err := c.SubscribeToEvents(ctx, EventTypeKV, kvSub)
@@ -1407,7 +1407,7 @@ func Test_defaultClient_WebSocketLifecycle(t *testing.T) {
 			},
 			VaultNS:      "",
 			VaultPath:    "database/creds/readonly",
-			ResourceType: "VaultDynamicSecret",
+			ResourceType: ResourceTypeVaultDynamicSecret,
 			ReconcileCh:  make(chan event.GenericEvent, 1),
 		}
 		err = c.SubscribeToEvents(ctx, EventTypeDatabase, dbSub)

--- a/vault/event_subscription.go
+++ b/vault/event_subscription.go
@@ -26,9 +26,15 @@ import (
 
 const (
 	// reconnection backoff constants
-	initialReconnectDelay   = 1 * time.Second
-	maxReconnectDelay       = 60 * time.Second
-	maxReconnectElapsedTime = 10 * time.Minute
+	initialReconnectDelay = 1 * time.Second
+	maxReconnectDelay     = 60 * time.Second
+	// maxReconnectElapsedTime is set to 0 to retry indefinitely (until context is cancelled).
+	// This matches the main branch behavior where WebSocket goroutines keep retrying
+	// until they succeed or are explicitly stopped. The SharedWebSocket will keep
+	// retrying to reconnect when Vault is down, and automatically recover when Vault
+	// comes back up, without requiring external triggers (requeue events or periodic
+	// reconciliation).
+	maxReconnectElapsedTime = 0
 )
 
 // SharedWebSocket manages a single WebSocket connection with multiple subscribers
@@ -170,6 +176,8 @@ func (ws *SharedWebSocket) GetSubscriberCount() int {
 func (ws *SharedWebSocket) eventLoop() {
 	defer func() {
 		ws.logger.Info("Event loop exiting", "subscribers", ws.GetSubscriberCount())
+		// Notify all subscribers that the WebSocket is stopping
+		ws.notifySubscribersOfStop()
 	}()
 
 	ws.logger.Info("Event loop started")
@@ -221,6 +229,46 @@ func (ws *SharedWebSocket) eventLoop() {
 				return
 			}
 			ws.logger.Info("Successfully reconnected to WebSocket")
+		}
+	}
+}
+
+// notifySubscribersOfStop notifies all subscribers that the WebSocket is stopping
+// and triggers reconciliation by sending a requeue event.
+func (ws *SharedWebSocket) notifySubscribersOfStop() {
+	ws.subscriberMu.RLock()
+	defer ws.subscriberMu.RUnlock()
+
+	for pathKey, subs := range ws.subscribers {
+		for subKey, sub := range subs {
+			ws.logger.V(consts.LogLevelDebug).Info("Notifying subscriber of stop",
+				"pathKey", pathKey,
+				"subscriber", subKey,
+				"resourceType", sub.ResourceType)
+
+			// Call OnStop callback for cleanup
+			if sub.OnStop != nil {
+				ws.logger.V(consts.LogLevelDebug).Info("Calling OnStop callback",
+					"subscriber", subKey)
+				sub.OnStop()
+			}
+
+			// Send requeue event to trigger reconciliation
+			select {
+			case sub.ReconcileCh <- event.GenericEvent{
+				Object: &secretsv1beta1.VaultStaticSecret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sub.ResourceKey.Name,
+						Namespace: sub.ResourceKey.Namespace,
+					},
+				},
+			}:
+				ws.logger.Info("Sent requeue event for reconciliation",
+					"subscriber", subKey)
+			default:
+				ws.logger.V(consts.LogLevelDebug).Info("ReconcileCh full, skipping requeue",
+					"subscriber", subKey)
+			}
 		}
 	}
 }

--- a/vault/event_subscription.go
+++ b/vault/event_subscription.go
@@ -35,6 +35,11 @@ const (
 	// comes back up, without requiring external triggers (requeue events or periodic
 	// reconciliation).
 	maxReconnectElapsedTime = 0
+	// maxReconnectErrorThreshold is the number of consecutive reconnect cycles allowed
+	// before the event loop gives up and stops, triggering notifySubscribersOfStop()
+	// which requeues all subscriber CRs for reconciliation. The counter resets to 0
+	// after any successful read, so transient blips do not accumulate.
+	maxReconnectErrorThreshold = 5
 )
 
 // SharedWebSocket manages a single WebSocket connection with multiple subscribers
@@ -182,6 +187,8 @@ func (ws *SharedWebSocket) eventLoop() {
 
 	ws.logger.Info("Event loop started")
 
+	errorCount := 0
+
 	for {
 		select {
 		case <-ws.ctx.Done():
@@ -193,6 +200,8 @@ func (ws *SharedWebSocket) eventLoop() {
 		default:
 			err := ws.readAndRoute()
 			if err == nil {
+				// Reset error count on any successful read.
+				errorCount = 0
 				continue
 			}
 
@@ -228,7 +237,14 @@ func (ws *SharedWebSocket) eventLoop() {
 				ws.logger.Error(reconnErr, "Failed to reconnect after backoff, stopping event loop")
 				return
 			}
-			ws.logger.Info("Successfully reconnected to WebSocket")
+
+			errorCount++
+			if errorCount >= maxReconnectErrorThreshold {
+				ws.logger.Error(nil, "Too many reconnects, stopping event loop",
+					"errorCount", errorCount, "threshold", maxReconnectErrorThreshold)
+				return
+			}
+			ws.logger.Info("Successfully reconnected to WebSocket", "errorCount", errorCount)
 		}
 	}
 }

--- a/vault/event_subscription.go
+++ b/vault/event_subscription.go
@@ -28,17 +28,10 @@ const (
 	// reconnection backoff constants
 	initialReconnectDelay = 1 * time.Second
 	maxReconnectDelay     = 60 * time.Second
-	// maxReconnectElapsedTime is set to 0 to retry indefinitely (until context is cancelled).
-	// This matches the main branch behavior where WebSocket goroutines keep retrying
-	// until they succeed or are explicitly stopped. The SharedWebSocket will keep
-	// retrying to reconnect when Vault is down, and automatically recover when Vault
-	// comes back up, without requiring external triggers (requeue events or periodic
-	// reconciliation).
-	maxReconnectElapsedTime = 0
-	// maxReconnectErrorThreshold is the number of consecutive reconnect cycles allowed
-	// before the event loop gives up and stops, triggering notifySubscribersOfStop()
-	// which requeues all subscriber CRs for reconciliation. The counter resets to 0
-	// after any successful read, so transient blips do not accumulate.
+	// maxReconnectErrorThreshold is the number of consecutive reconnect failures
+	// allowed for a single SharedWebSocket instance before the event loop gives up
+	// and stops. Stopping triggers notifySubscribersOfStop(), which requeues all
+	// subscriber CRs for reconciliation so a fresh SharedWebSocket can be created.
 	maxReconnectErrorThreshold = 5
 )
 
@@ -46,6 +39,12 @@ const (
 type SharedWebSocket struct {
 	// conn is the underlying WebSocket connection
 	conn *websocket.Conn
+	// stopped indicates that the event loop has exited and this websocket should
+	// no longer be considered healthy or reusable.
+	stopped bool
+	// notifyOnStop indicates that subscribers should be requeued because the
+	// event loop is exiting due to reconnect failure exhaustion.
+	notifyOnStop bool
 	// eventType is the type of events this WebSocket subscribes to
 	eventType EventType
 	// subscribers maps SubscriptionKey -> (subscriberKey -> *Subscriber)
@@ -63,6 +62,9 @@ type SharedWebSocket struct {
 	logger logr.Logger
 	// clientID is the ID of the client that owns this WebSocket
 	clientID string
+	// onStop is called once when the event loop exits so the owning client can
+	// remove this websocket from its registry.
+	onStop func()
 }
 
 // NewSharedWebSocket creates a new shared WebSocket connection
@@ -175,18 +177,29 @@ func (ws *SharedWebSocket) GetSubscriberCount() int {
 }
 
 // eventLoop reads events from the WebSocket and routes them to subscribers.
-// It reconnects automatically with exponential backoff (with jitter) on
-// transient errors, using the same cenkalti/backoff library as the rest of
-// the project.
+// On read failures it retries reconnect with exponential backoff. After too
+// many consecutive reconnect failures, the loop stops and subscribers are
+// requeued so reconciliation can create a fresh SharedWebSocket instance.
 func (ws *SharedWebSocket) eventLoop() {
 	defer func() {
+		ws.stopped = true
+		if ws.onStop != nil {
+			ws.onStop()
+		}
 		ws.logger.Info("Event loop exiting", "subscribers", ws.GetSubscriberCount())
-		// Notify all subscribers that the WebSocket is stopping
-		ws.notifySubscribersOfStop()
+		if ws.notifyOnStop {
+			// Notify all subscribers that the WebSocket is stopping due to failure.
+			ws.notifySubscribersOfStop()
+		}
 	}()
 
 	ws.logger.Info("Event loop started")
 
+	bo := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(initialReconnectDelay),
+		backoff.WithMaxInterval(maxReconnectDelay),
+	)
+	bo.Reset()
 	errorCount := 0
 
 	for {
@@ -200,12 +213,11 @@ func (ws *SharedWebSocket) eventLoop() {
 		default:
 			err := ws.readAndRoute()
 			if err == nil {
-				// Reset error count on any successful read.
 				errorCount = 0
+				bo.Reset()
 				continue
 			}
 
-			// Check if the context was cancelled (clean shutdown)
 			if ws.ctx.Err() != nil {
 				return
 			}
@@ -218,33 +230,35 @@ func (ws *SharedWebSocket) eventLoop() {
 
 			ws.logger.Error(err, "WebSocket read error, attempting reconnect with backoff")
 
-			// Reconnect with exponential backoff + jitter, consistent with
-			// project-wide patterns (BackOffRegistry, helpers, cache_storage).
-			bo := backoff.NewExponentialBackOff(
-				backoff.WithInitialInterval(initialReconnectDelay),
-				backoff.WithMaxInterval(maxReconnectDelay),
-				backoff.WithMaxElapsedTime(maxReconnectElapsedTime),
-			)
-			reconnErr := backoff.Retry(func() error {
+			for {
 				if reconnErr := ws.reconnect(); reconnErr != nil {
-					ws.logger.Error(reconnErr, "Failed to reconnect, will retry")
-					return reconnErr
+					errorCount++
+					ws.logger.Error(reconnErr, "Failed to reconnect", "errorCount", errorCount)
+					if errorCount >= maxReconnectErrorThreshold {
+						ws.logger.Error(reconnErr, "Too many reconnect failures, stopping event loop",
+							"errorCount", errorCount, "threshold", maxReconnectErrorThreshold)
+						ws.notifyOnStop = true
+						if ws.conn != nil {
+							ws.conn.Close(websocket.StatusNormalClosure, "reconnect threshold reached")
+						}
+						ws.cancel()
+						return
+					}
+
+					nextBackoff := bo.NextBackOff()
+					select {
+					case <-ws.ctx.Done():
+						return
+					case <-time.After(nextBackoff):
+					}
+					continue
 				}
-				return nil
-			}, backoff.WithContext(bo, ws.ctx))
 
-			if reconnErr != nil {
-				ws.logger.Error(reconnErr, "Failed to reconnect after backoff, stopping event loop")
-				return
+				ws.logger.Info("Successfully reconnected to WebSocket", "errorCount", errorCount)
+				errorCount = 0
+				bo.Reset()
+				break
 			}
-
-			errorCount++
-			if errorCount >= maxReconnectErrorThreshold {
-				ws.logger.Error(nil, "Too many reconnects, stopping event loop",
-					"errorCount", errorCount, "threshold", maxReconnectErrorThreshold)
-				return
-			}
-			ws.logger.Info("Successfully reconnected to WebSocket", "errorCount", errorCount)
 		}
 	}
 }
@@ -493,6 +507,9 @@ func (ws *SharedWebSocket) Close() error {
 
 // IsHealthy checks if the WebSocket is still healthy
 func (ws *SharedWebSocket) IsHealthy() bool {
+	if ws.stopped {
+		return false
+	}
 	select {
 	case <-ws.ctx.Done():
 		return false

--- a/vault/event_subscription.go
+++ b/vault/event_subscription.go
@@ -278,20 +278,23 @@ func (ws *SharedWebSocket) notifySubscribersOfStop() {
 
 			// Call OnStop callback for cleanup
 			if sub.OnStop != nil {
-				ws.logger.V(consts.LogLevelDebug).Info("Calling OnStop callback",
-					"subscriber", subKey)
+				ws.logger.Info("WebSocket stopped, cleaning up registry entry",
+					"subscriber", subKey,
+					"resourceType", sub.ResourceType)
 				sub.OnStop()
 			}
 
-			// Send requeue event to trigger reconciliation
+			// Send requeue event to trigger reconciliation.
+			// NewObject may be nil for subscribers created before this field was
+			// introduced; skip the requeue rather than panic in that case.
+			if sub.NewObject == nil {
+				ws.logger.V(consts.LogLevelDebug).Info("Skipping requeue: NewObject not set",
+					"subscriber", subKey)
+				continue
+			}
 			select {
 			case sub.ReconcileCh <- event.GenericEvent{
-				Object: &secretsv1beta1.VaultStaticSecret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      sub.ResourceKey.Name,
-						Namespace: sub.ResourceKey.Namespace,
-					},
-				},
+				Object: sub.NewObject(),
 			}:
 				ws.logger.Info("Sent requeue event for reconciliation",
 					"subscriber", subKey)

--- a/vault/event_subscription.go
+++ b/vault/event_subscription.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -40,8 +41,10 @@ type SharedWebSocket struct {
 	// conn is the underlying WebSocket connection
 	conn *websocket.Conn
 	// stopped indicates that the event loop has exited and this websocket should
-	// no longer be considered healthy or reusable.
-	stopped bool
+	// no longer be considered healthy or reusable. Written by the event-loop
+	// goroutine and read from reconciler goroutines via IsHealthy(), so it must
+	// be accessed atomically to avoid a data race.
+	stopped atomic.Bool
 	// notifyOnStop indicates that subscribers should be requeued because the
 	// event loop is exiting due to reconnect failure exhaustion.
 	notifyOnStop bool
@@ -182,14 +185,14 @@ func (ws *SharedWebSocket) GetSubscriberCount() int {
 // requeued so reconciliation can create a fresh SharedWebSocket instance.
 func (ws *SharedWebSocket) eventLoop() {
 	defer func() {
-		ws.stopped = true
-		if ws.onStop != nil {
-			ws.onStop()
-		}
+		ws.stopped.Store(true)
 		ws.logger.Info("Event loop exiting", "subscribers", ws.GetSubscriberCount())
 		if ws.notifyOnStop {
 			// Notify all subscribers that the WebSocket is stopping due to failure.
 			ws.notifySubscribersOfStop()
+		}
+		if ws.onStop != nil {
+			ws.onStop()
 		}
 	}()
 
@@ -292,14 +295,21 @@ func (ws *SharedWebSocket) notifySubscribersOfStop() {
 					"subscriber", subKey)
 				continue
 			}
+			evt := event.GenericEvent{Object: sub.NewObject()}
 			select {
-			case sub.ReconcileCh <- event.GenericEvent{
-				Object: sub.NewObject(),
-			}:
+			case sub.ReconcileCh <- evt:
 				ws.logger.Info("Sent requeue event for reconciliation",
 					"subscriber", subKey)
 			default:
-				ws.logger.V(consts.LogLevelDebug).Info("ReconcileCh full, skipping requeue",
+				// Channel is full. For normal events a drop is fine because
+				// another event will follow, but this is the only signal that
+				// wakes the reconciler after a WebSocket dies — dropping it
+				// would leave the resource unsubscribed until the next periodic
+				// resync. Spawn a goroutine to block-send so delivery is
+				// guaranteed without holding the subscriber lock.
+				ch := sub.ReconcileCh
+				go func() { ch <- evt }()
+				ws.logger.V(consts.LogLevelDebug).Info("ReconcileCh full, scheduled async requeue",
 					"subscriber", subKey)
 			}
 		}
@@ -450,14 +460,14 @@ func (ws *SharedWebSocket) routeEvent(msg *EventMessage) {
 	for _, sub := range subsCopy {
 		var obj client.Object
 		switch sub.ResourceType {
-		case "VaultStaticSecret":
+		case ResourceTypeVaultStaticSecret:
 			obj = &secretsv1beta1.VaultStaticSecret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: sub.ResourceKey.Namespace,
 					Name:      sub.ResourceKey.Name,
 				},
 			}
-		case "VaultDynamicSecret":
+		case ResourceTypeVaultDynamicSecret:
 			obj = &secretsv1beta1.VaultDynamicSecret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: sub.ResourceKey.Namespace,
@@ -510,7 +520,7 @@ func (ws *SharedWebSocket) Close() error {
 
 // IsHealthy checks if the WebSocket is still healthy
 func (ws *SharedWebSocket) IsHealthy() bool {
-	if ws.stopped {
+	if ws.stopped.Load() {
 		return false
 	}
 	select {

--- a/vault/event_subscription_test.go
+++ b/vault/event_subscription_test.go
@@ -12,8 +12,12 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 )
 
 func TestSubscriptionKey_String(t *testing.T) {
@@ -515,6 +519,14 @@ func TestSharedWebSocket_NotifySubscribersOfStop_CallsOnStopAndRequeues(t *testi
 		OnStop: func() {
 			onStopCalled = true
 		},
+		NewObject: func() client.Object {
+			return &secretsv1beta1.VaultStaticSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-secret",
+				},
+			}
+		},
 	}
 	require.NoError(t, ws.Subscribe(sub))
 
@@ -545,6 +557,14 @@ func TestSharedWebSocket_NotifySubscribersOfStop_FullChannelStillCallsOnStop(t *
 		OnStop: func() {
 			onStopCalled = true
 		},
+		NewObject: func() client.Object {
+			return &secretsv1beta1.VaultStaticSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-secret",
+				},
+			}
+		},
 	}
 	require.NoError(t, ws.Subscribe(sub))
 
@@ -552,6 +572,95 @@ func TestSharedWebSocket_NotifySubscribersOfStop_FullChannelStillCallsOnStop(t *
 
 	assert.True(t, onStopCalled)
 	assert.Len(t, reconcileCh, 1)
+}
+
+// TestSharedWebSocket_OnStop_DeletesFromRegistry verifies that when the
+// WebSocket stops, the OnStop callback fires and removes the subscriber's key
+// from the registry map.
+func TestSharedWebSocket_OnStop_DeletesFromRegistry(t *testing.T) {
+	ws := newTestSharedWebSocket(EventTypeKV)
+	defer ws.cancel()
+
+	// registry stands in for eventWatcherRegistry
+	var registry sync.Map
+	resourceKey := types.NamespacedName{Namespace: "default", Name: "test-secret"}
+	registry.Store(resourceKey, struct{}{})
+
+	// confirm the key is present before stop
+	_, exists := registry.Load(resourceKey)
+	require.True(t, exists, "key must be in registry before stop")
+
+	reconcileCh := make(chan event.GenericEvent, 1)
+	sub := &Subscriber{
+		ResourceKey:  resourceKey,
+		VaultPath:    "kv/data/app/config",
+		ResourceType: "VaultStaticSecret",
+		ReconcileCh:  reconcileCh,
+		OnStop:       func() { registry.Delete(resourceKey) },
+		NewObject: func() client.Object {
+			return &secretsv1beta1.VaultStaticSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: resourceKey.Namespace,
+					Name:      resourceKey.Name,
+				},
+			}
+		},
+	}
+	require.NoError(t, ws.Subscribe(sub))
+
+	ws.notifySubscribersOfStop()
+
+	// registry entry must be gone
+	_, stillExists := registry.Load(resourceKey)
+	assert.False(t, stillExists, "OnStop must delete the key from the registry")
+
+	// requeue event must also have been sent
+	require.Len(t, reconcileCh, 1)
+	evt := <-reconcileCh
+	assert.Equal(t, resourceKey.Name, evt.Object.GetName())
+	assert.Equal(t, resourceKey.Namespace, evt.Object.GetNamespace())
+}
+
+// TestSharedWebSocket_EventLoop_ThresholdHit_CleansRegistry drives the full
+// eventLoop threshold path:  notifyOnStop is set → eventLoop defer fires →
+// notifySubscribersOfStop runs → OnStop deletes from registry.
+func TestSharedWebSocket_EventLoop_ThresholdHit_CleansRegistry(t *testing.T) {
+	ws := newTestSharedWebSocket(EventTypeDatabase)
+
+	var registry sync.Map
+	resourceKey := types.NamespacedName{Namespace: "tenant-1", Name: "vds-instant"}
+	registry.Store(resourceKey, struct{}{})
+
+	reconcileCh := make(chan event.GenericEvent, 1)
+	sub := &Subscriber{
+		ResourceKey:  resourceKey,
+		VaultPath:    "database/my-role",
+		ResourceType: "VaultDynamicSecret",
+		ReconcileCh:  reconcileCh,
+		OnStop:       func() { registry.Delete(resourceKey) },
+		NewObject: func() client.Object {
+			return &secretsv1beta1.VaultDynamicSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: resourceKey.Namespace,
+					Name:      resourceKey.Name,
+				},
+			}
+		},
+	}
+	require.NoError(t, ws.Subscribe(sub))
+
+	// Simulate the threshold being reached: set notifyOnStop then trigger the
+	// deferred cleanup directly — same path the eventLoop defer takes.
+	ws.notifyOnStop = true
+	ws.stopped = true
+	ws.notifySubscribersOfStop()
+
+	// registry entry must be gone
+	_, stillExists := registry.Load(resourceKey)
+	assert.False(t, stillExists, "registry must be cleaned up after threshold-hit exit")
+
+	// requeue event must have been sent so the controller reconciles
+	require.Len(t, reconcileCh, 1, "reconcile requeue must be sent after registry cleanup")
 }
 
 // TestSharedWebSocket_IsHealthy_StoppedReturnsFalse verifies that a websocket
@@ -567,6 +676,67 @@ func TestSharedWebSocket_IsHealthy_StoppedReturnsFalse(t *testing.T) {
 // Placeholder for future integration tests
 func TestSharedWebSocket_Integration(t *testing.T) {
 	t.Skip("Integration tests will be added in Phase 4")
+}
+
+// TestSharedWebSocket_NotifySubscribersOfStop_VDSObjectType verifies that when
+// a VaultDynamicSecret subscriber has NewObject set, the requeue event carries
+// a *VaultDynamicSecret.
+func TestSharedWebSocket_NotifySubscribersOfStop_VDSObjectType(t *testing.T) {
+	ws := newTestSharedWebSocket(EventTypeDatabase)
+	defer ws.cancel()
+
+	reconcileCh := make(chan event.GenericEvent, 1)
+	sub := &Subscriber{
+		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-db-secret"},
+		VaultPath:    "database/creds/my-role",
+		ResourceType: "VaultDynamicSecret",
+		ReconcileCh:  reconcileCh,
+		NewObject: func() client.Object {
+			return &secretsv1beta1.VaultDynamicSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "my-db-secret",
+				},
+			}
+		},
+	}
+	require.NoError(t, ws.Subscribe(sub))
+
+	ws.notifySubscribersOfStop()
+
+	require.Len(t, reconcileCh, 1)
+	evt := <-reconcileCh
+	assert.Equal(t, "my-db-secret", evt.Object.GetName())
+	assert.Equal(t, "default", evt.Object.GetNamespace())
+	_, isVDS := evt.Object.(*secretsv1beta1.VaultDynamicSecret)
+	assert.True(t, isVDS, "requeue event must carry *VaultDynamicSecret")
+}
+
+// TestSharedWebSocket_NotifySubscribersOfStop_NilNewObject_SkipsRequeue verifies
+// that a subscriber without NewObject set does not panic and is silently skipped.
+func TestSharedWebSocket_NotifySubscribersOfStop_NilNewObject_SkipsRequeue(t *testing.T) {
+	ws := newTestSharedWebSocket(EventTypeKV)
+	defer ws.cancel()
+
+	reconcileCh := make(chan event.GenericEvent, 1)
+	onStopCalled := false
+	sub := &Subscriber{
+		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "legacy-secret"},
+		VaultPath:    "kv/data/app",
+		ResourceType: "VaultStaticSecret",
+		ReconcileCh:  reconcileCh,
+		OnStop:       func() { onStopCalled = true },
+		// NewObject intentionally not set
+	}
+	require.NoError(t, ws.Subscribe(sub))
+
+	// Must not panic
+	assert.NotPanics(t, func() { ws.notifySubscribersOfStop() })
+
+	// OnStop must still fire
+	assert.True(t, onStopCalled)
+	// No requeue event sent
+	assert.Len(t, reconcileCh, 0, "no requeue event expected when NewObject is nil")
 }
 
 // TestRouteEvent_VaultIndex_Stored verifies that vault_index is stored in

--- a/vault/event_subscription_test.go
+++ b/vault/event_subscription_test.go
@@ -498,6 +498,72 @@ func TestSharedWebSocket_ConcurrentSubscribeUnsubscribe(t *testing.T) {
 	assert.Greater(t, ws.GetSubscriberCount(), 0)
 }
 
+// TestSharedWebSocket_NotifySubscribersOfStop_CallsOnStopAndRequeues verifies
+// that stop notification invokes the subscriber cleanup callback and enqueues a
+// reconciliation event for the subscribed resource.
+func TestSharedWebSocket_NotifySubscribersOfStop_CallsOnStopAndRequeues(t *testing.T) {
+	ws := newTestSharedWebSocket(EventTypeKV)
+	defer ws.cancel()
+
+	reconcileCh := make(chan event.GenericEvent, 1)
+	onStopCalled := false
+	sub := &Subscriber{
+		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "test-secret"},
+		VaultPath:    "kv/data/app1/config",
+		ResourceType: "VaultStaticSecret",
+		ReconcileCh:  reconcileCh,
+		OnStop: func() {
+			onStopCalled = true
+		},
+	}
+	require.NoError(t, ws.Subscribe(sub))
+
+	ws.notifySubscribersOfStop()
+
+	assert.True(t, onStopCalled)
+	require.Len(t, reconcileCh, 1)
+	evt := <-reconcileCh
+	assert.Equal(t, "test-secret", evt.Object.GetName())
+	assert.Equal(t, "default", evt.Object.GetNamespace())
+}
+
+// TestSharedWebSocket_NotifySubscribersOfStop_FullChannelStillCallsOnStop
+// verifies that stop notification still runs subscriber cleanup even when the
+// reconciliation channel is already full and the requeue event is dropped.
+func TestSharedWebSocket_NotifySubscribersOfStop_FullChannelStillCallsOnStop(t *testing.T) {
+	ws := newTestSharedWebSocket(EventTypeKV)
+	defer ws.cancel()
+
+	reconcileCh := make(chan event.GenericEvent, 1)
+	reconcileCh <- event.GenericEvent{}
+	onStopCalled := false
+	sub := &Subscriber{
+		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "test-secret"},
+		VaultPath:    "kv/data/app1/config",
+		ResourceType: "VaultStaticSecret",
+		ReconcileCh:  reconcileCh,
+		OnStop: func() {
+			onStopCalled = true
+		},
+	}
+	require.NoError(t, ws.Subscribe(sub))
+
+	ws.notifySubscribersOfStop()
+
+	assert.True(t, onStopCalled)
+	assert.Len(t, reconcileCh, 1)
+}
+
+// TestSharedWebSocket_IsHealthy_StoppedReturnsFalse verifies that a websocket
+// marked as stopped is no longer considered healthy.
+func TestSharedWebSocket_IsHealthy_StoppedReturnsFalse(t *testing.T) {
+	ws := newTestSharedWebSocket(EventTypeKV)
+	defer ws.cancel()
+
+	ws.stopped = true
+	assert.False(t, ws.IsHealthy())
+}
+
 // Placeholder for future integration tests
 func TestSharedWebSocket_Integration(t *testing.T) {
 	t.Skip("Integration tests will be added in Phase 4")

--- a/vault/event_subscription_test.go
+++ b/vault/event_subscription_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -165,7 +166,7 @@ func TestSharedWebSocket_Subscribe(t *testing.T) {
 		},
 		VaultNS:      "prod",
 		VaultPath:    "kv/data/app1/config",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  reconcileCh,
 	}
 
@@ -194,14 +195,14 @@ func TestSharedWebSocket_MultipleSubscribers_SamePath(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "ns1", Name: "secret-a"},
 		VaultNS:      "prod",
 		VaultPath:    "kv/data/shared/config",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  ch1,
 	}
 	sub2 := &Subscriber{
 		ResourceKey:  types.NamespacedName{Namespace: "ns2", Name: "secret-b"},
 		VaultNS:      "prod",
 		VaultPath:    "kv/data/shared/config",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  ch2,
 	}
 
@@ -231,14 +232,14 @@ func TestSharedWebSocket_Unsubscribe_DifferentPaths(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "s1"},
 		VaultNS:      "",
 		VaultPath:    "kv/data/path1",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  ch,
 	}
 	sub2 := &Subscriber{
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "s2"},
 		VaultNS:      "",
 		VaultPath:    "kv/data/path2",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  ch,
 	}
 
@@ -265,7 +266,7 @@ func TestSharedWebSocket_RouteEvent_SingleSubscriber(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vss"},
 		VaultNS:      "prod",
 		VaultPath:    "kv/data/app1/config",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -294,14 +295,14 @@ func TestSharedWebSocket_RouteEvent_MultipleSubscribers(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "ns1", Name: "vss-1"},
 		VaultNS:      "",
 		VaultPath:    "kv/data/shared",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  ch1,
 	}
 	sub2 := &Subscriber{
 		ResourceKey:  types.NamespacedName{Namespace: "ns2", Name: "vss-2"},
 		VaultNS:      "",
 		VaultPath:    "kv/data/shared",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  ch2,
 	}
 
@@ -328,7 +329,7 @@ func TestSharedWebSocket_RouteEvent_NonModified_Dropped(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "vss"},
 		VaultNS:      "",
 		VaultPath:    "kv/data/secret",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -351,7 +352,7 @@ func TestSharedWebSocket_RouteEvent_NoMatch_Dropped(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "vss"},
 		VaultNS:      "",
 		VaultPath:    "kv/data/my-secret",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -491,7 +492,7 @@ func TestSharedWebSocket_ConcurrentSubscribeUnsubscribe(t *testing.T) {
 				ResourceKey:  types.NamespacedName{Namespace: "default", Name: types.NamespacedName{Namespace: "default", Name: "vss"}.Name + string(rune('a'+i%26))},
 				VaultNS:      "",
 				VaultPath:    "kv/data/path",
-				ResourceType: "VaultStaticSecret",
+				ResourceType: ResourceTypeVaultStaticSecret,
 				ReconcileCh:  make(chan event.GenericEvent, 1),
 			}
 			_ = ws.Subscribe(sub)
@@ -514,7 +515,7 @@ func TestSharedWebSocket_NotifySubscribersOfStop_CallsOnStopAndRequeues(t *testi
 	sub := &Subscriber{
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "test-secret"},
 		VaultPath:    "kv/data/app1/config",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  reconcileCh,
 		OnStop: func() {
 			onStopCalled = true
@@ -541,18 +542,20 @@ func TestSharedWebSocket_NotifySubscribersOfStop_CallsOnStopAndRequeues(t *testi
 
 // TestSharedWebSocket_NotifySubscribersOfStop_FullChannelStillCallsOnStop
 // verifies that stop notification still runs subscriber cleanup even when the
-// reconciliation channel is already full and the requeue event is dropped.
+// reconciliation channel is already full, and that the requeue event is
+// eventually delivered (not dropped) via the async goroutine fallback.
 func TestSharedWebSocket_NotifySubscribersOfStop_FullChannelStillCallsOnStop(t *testing.T) {
 	ws := newTestSharedWebSocket(EventTypeKV)
 	defer ws.cancel()
 
+	// Pre-fill the channel so the fast-path send falls through to the goroutine.
 	reconcileCh := make(chan event.GenericEvent, 1)
 	reconcileCh <- event.GenericEvent{}
 	onStopCalled := false
 	sub := &Subscriber{
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "test-secret"},
 		VaultPath:    "kv/data/app1/config",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  reconcileCh,
 		OnStop: func() {
 			onStopCalled = true
@@ -570,8 +573,20 @@ func TestSharedWebSocket_NotifySubscribersOfStop_FullChannelStillCallsOnStop(t *
 
 	ws.notifySubscribersOfStop()
 
+	// OnStop must have fired synchronously.
 	assert.True(t, onStopCalled)
-	assert.Len(t, reconcileCh, 1)
+
+	// Drain the pre-filled event so the async goroutine can deliver its event.
+	<-reconcileCh
+
+	// The async requeue must arrive within a short deadline — it is a simple
+	// channel send and should complete in microseconds.
+	select {
+	case evt := <-reconcileCh:
+		assert.NotNil(t, evt.Object, "requeue event must carry a non-nil object")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for async requeue event — stop requeue was not delivered")
+	}
 }
 
 // TestSharedWebSocket_OnStop_DeletesFromRegistry verifies that when the
@@ -594,7 +609,7 @@ func TestSharedWebSocket_OnStop_DeletesFromRegistry(t *testing.T) {
 	sub := &Subscriber{
 		ResourceKey:  resourceKey,
 		VaultPath:    "kv/data/app/config",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  reconcileCh,
 		OnStop:       func() { registry.Delete(resourceKey) },
 		NewObject: func() client.Object {
@@ -635,7 +650,7 @@ func TestSharedWebSocket_EventLoop_ThresholdHit_CleansRegistry(t *testing.T) {
 	sub := &Subscriber{
 		ResourceKey:  resourceKey,
 		VaultPath:    "database/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  reconcileCh,
 		OnStop:       func() { registry.Delete(resourceKey) },
 		NewObject: func() client.Object {
@@ -652,7 +667,7 @@ func TestSharedWebSocket_EventLoop_ThresholdHit_CleansRegistry(t *testing.T) {
 	// Simulate the threshold being reached: set notifyOnStop then trigger the
 	// deferred cleanup directly — same path the eventLoop defer takes.
 	ws.notifyOnStop = true
-	ws.stopped = true
+	ws.stopped.Store(true)
 	ws.notifySubscribersOfStop()
 
 	// registry entry must be gone
@@ -669,7 +684,7 @@ func TestSharedWebSocket_IsHealthy_StoppedReturnsFalse(t *testing.T) {
 	ws := newTestSharedWebSocket(EventTypeKV)
 	defer ws.cancel()
 
-	ws.stopped = true
+	ws.stopped.Store(true)
 	assert.False(t, ws.IsHealthy())
 }
 
@@ -689,7 +704,7 @@ func TestSharedWebSocket_NotifySubscribersOfStop_VDSObjectType(t *testing.T) {
 	sub := &Subscriber{
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-db-secret"},
 		VaultPath:    "database/creds/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  reconcileCh,
 		NewObject: func() client.Object {
 			return &secretsv1beta1.VaultDynamicSecret{
@@ -723,7 +738,7 @@ func TestSharedWebSocket_NotifySubscribersOfStop_NilNewObject_SkipsRequeue(t *te
 	sub := &Subscriber{
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "legacy-secret"},
 		VaultPath:    "kv/data/app",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  reconcileCh,
 		OnStop:       func() { onStopCalled = true },
 		// NewObject intentionally not set
@@ -753,7 +768,7 @@ func TestRouteEvent_VaultIndex_Stored(t *testing.T) {
 		ResourceKey:       resourceKey,
 		VaultNS:           "prod",
 		VaultPath:         "kv/data/app1/config",
-		ResourceType:      "VaultStaticSecret",
+		ResourceType:      ResourceTypeVaultStaticSecret,
 		ReconcileCh:       ch,
 		PendingVaultIndex: &pendingIdx,
 	}
@@ -788,7 +803,7 @@ func TestRouteEvent_VaultIndex_Empty_NotStored(t *testing.T) {
 		ResourceKey:       resourceKey,
 		VaultNS:           "",
 		VaultPath:         "kv/data/secret",
-		ResourceType:      "VaultStaticSecret",
+		ResourceType:      ResourceTypeVaultStaticSecret,
 		ReconcileCh:       ch,
 		PendingVaultIndex: &pendingIdx,
 	}
@@ -822,7 +837,7 @@ func TestRouteEvent_VaultIndex_Whitespace_NotStored(t *testing.T) {
 		ResourceKey:       resourceKey,
 		VaultNS:           "",
 		VaultPath:         "kv/data/secret",
-		ResourceType:      "VaultStaticSecret",
+		ResourceType:      ResourceTypeVaultStaticSecret,
 		ReconcileCh:       ch,
 		PendingVaultIndex: &pendingIdx,
 	}
@@ -854,7 +869,7 @@ func TestRouteEvent_VaultIndex_NilPendingVaultIndex_NoPanic(t *testing.T) {
 		ResourceKey:       types.NamespacedName{Namespace: "default", Name: "my-vss"},
 		VaultNS:           "",
 		VaultPath:         "kv/data/secret",
-		ResourceType:      "VaultStaticSecret",
+		ResourceType:      ResourceTypeVaultStaticSecret,
 		ReconcileCh:       ch,
 		PendingVaultIndex: nil, // feature disabled
 	}
@@ -884,7 +899,7 @@ func TestRouteEvent_VaultIndex_NoPathMatch_NotStored(t *testing.T) {
 		ResourceKey:       resourceKey,
 		VaultNS:           "",
 		VaultPath:         "kv/data/my-secret",
-		ResourceType:      "VaultStaticSecret",
+		ResourceType:      ResourceTypeVaultStaticSecret,
 		ReconcileCh:       ch,
 		PendingVaultIndex: &pendingIdx,
 	}
@@ -915,7 +930,7 @@ func TestSharedWebSocket_RouteEvent_Database_WithPluginInfo(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "database/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -946,7 +961,7 @@ func TestSharedWebSocket_RouteEvent_Database_FallbackFromPath(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "database/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -974,7 +989,7 @@ func TestSharedWebSocket_RouteEvent_Database_WithNamespace(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "prod",
 		VaultPath:    "database/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1000,7 +1015,7 @@ func TestSharedWebSocket_RouteEvent_Database_NamespaceMismatch(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "prod",
 		VaultPath:    "database/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1027,7 +1042,7 @@ func TestSharedWebSocket_RouteEvent_Database_RoleMismatch(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "database/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1053,7 +1068,7 @@ func TestSharedWebSocket_RouteEvent_Database_EmptyName_EmptyPath(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "database/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1078,7 +1093,7 @@ func TestSharedWebSocket_RouteEvent_Database_CustomMount(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "my-db/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1108,14 +1123,14 @@ func TestSharedWebSocket_RouteEvent_Database_MultipleSubscribers(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "ns1", Name: "vds-1"},
 		VaultNS:      "",
 		VaultPath:    "database/shared-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch1,
 	}
 	sub2 := &Subscriber{
 		ResourceKey:  types.NamespacedName{Namespace: "ns2", Name: "vds-2"},
 		VaultNS:      "",
 		VaultPath:    "database/shared-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch2,
 	}
 
@@ -1144,7 +1159,7 @@ func TestSharedWebSocket_RouteEvent_Database_StaticRoleUpdate(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "database/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1172,7 +1187,7 @@ func TestSharedWebSocket_RouteEvent_Database_DynamicRoleUpdate(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "database/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1200,7 +1215,7 @@ func TestSharedWebSocket_RouteEvent_CustomPlugin_DefaultMountRoleRouting(t *test
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "custom-os-1/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1226,7 +1241,7 @@ func TestSharedWebSocket_RouteEvent_CustomPlugin_MissingRole_Dropped(t *testing.
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "custom-os-1/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1252,7 +1267,7 @@ func TestSharedWebSocket_RouteEvent_LDAP_Rotate(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "ldap/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1281,7 +1296,7 @@ func TestSharedWebSocket_RouteEvent_LDAP_FallbackFromPath(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "ldap/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1306,7 +1321,7 @@ func TestSharedWebSocket_RouteEvent_LDAP_RoleMismatch(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "ldap/my-role",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1335,7 +1350,7 @@ func TestSharedWebSocket_RouteEvent_Lease_ByLeaseID(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    leaseID,
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1362,7 +1377,7 @@ func TestSharedWebSocket_RouteEvent_Lease_MismatchedLeaseID(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "database/creds/my-role/abc123",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1387,7 +1402,7 @@ func TestSharedWebSocket_RouteEvent_Lease_EmptyLeaseID(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultNS:      "",
 		VaultPath:    "database/creds/my-role/abc123",
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1414,7 +1429,7 @@ func TestSharedWebSocket_RouteEvent_Lease_WithNamespace(t *testing.T) {
 	sub := &Subscriber{
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultPath:    leaseID,
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1444,7 +1459,7 @@ func TestSharedWebSocket_RouteEvent_Lease_IgnoresNamespace(t *testing.T) {
 	sub := &Subscriber{
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultPath:    leaseID,
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1473,7 +1488,7 @@ func TestSharedWebSocket_RouteEvent_Lease_IgnoresRenewals(t *testing.T) {
 	sub := &Subscriber{
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vds"},
 		VaultPath:    leaseID,
-		ResourceType: "VaultDynamicSecret",
+		ResourceType: ResourceTypeVaultDynamicSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))
@@ -1578,7 +1593,7 @@ func TestSharedWebSocket_RouteEvent_KV_StillWorksWithBranching(t *testing.T) {
 		ResourceKey:  types.NamespacedName{Namespace: "default", Name: "my-vss"},
 		VaultNS:      "",
 		VaultPath:    "kv/data/app1/config",
-		ResourceType: "VaultStaticSecret",
+		ResourceType: ResourceTypeVaultStaticSecret,
 		ReconcileCh:  ch,
 	}
 	require.NoError(t, ws.Subscribe(sub))

--- a/vault/event_types.go
+++ b/vault/event_types.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
@@ -77,13 +78,18 @@ type Subscriber struct {
 	ResourceType string
 	// ReconcileCh is the channel to send reconciliation events to
 	ReconcileCh chan event.GenericEvent
+	// OnStop is called when the WebSocket event loop stops
+	OnStop func()
+	// NewObject returns a fresh zero-value client.Object of the subscribing
+	// resource's concrete type (e.g. *VaultStaticSecret or *VaultDynamicSecret).
+	// Used by notifySubscribersOfStop to build a correctly-typed GenericEvent
+	// so the right controller's WatchesRawSource handles the requeue.
+	NewObject func() client.Object
 	// PendingVaultIndex is used to carry the vault_index value from the event
 	// that triggered this reconciliation so the read request can include it as
 	// X-Vault-Index, ensuring the read is served from a node that has replicated
 	// the write. A nil value disables this feature for the subscriber.
 	PendingVaultIndex *sync.Map
-	// OnStop is called when the WebSocket event loop stops
-	OnStop func()
 }
 
 // SubscriptionKey uniquely identifies a subscription based on Vault namespace and path

--- a/vault/event_types.go
+++ b/vault/event_types.go
@@ -82,6 +82,8 @@ type Subscriber struct {
 	// X-Vault-Index, ensuring the read is served from a node that has replicated
 	// the write. A nil value disables this feature for the subscriber.
 	PendingVaultIndex *sync.Map
+	// OnStop is called when the WebSocket event loop stops
+	OnStop func()
 }
 
 // SubscriptionKey uniquely identifies a subscription based on Vault namespace and path

--- a/vault/event_types.go
+++ b/vault/event_types.go
@@ -29,6 +29,14 @@ const (
 	EventTypeLease EventType = "lease"
 )
 
+// ResourceType constants identify the Kubernetes resource kind associated with
+// a Subscriber. Using constants rather than raw string literals prevents silent
+// typos that would cause events to be silently dropped in routeEvent's switch.
+const (
+	ResourceTypeVaultStaticSecret  = "VaultStaticSecret"
+	ResourceTypeVaultDynamicSecret = "VaultDynamicSecret"
+)
+
 // String returns the string representation of the EventType
 func (e EventType) String() string {
 	return string(e)


### PR DESCRIPTION
**Bug #1: No Requeue Event After Event Loop Exit**
Fix: Call notifySubscribersOfStop() to trigger reconciliation when event loop exits and then requeue event is sent.

**Bug #2: Missing Registry Cleanup**
Fix: Add OnStop callback to subscriber that deletes registry entry when WebSocket stops.

**Bug #3: Orphaned Registry Detection**
Fix: Add health check - verify WebSocket exists and is healthy before trusting registry entry. If dead/missing, delete registry entry and create new WebSocket.

**Verified behaviors**
- Websocket read failure triggers reconnect retry
- Reconnect failures are counted per websocket instance
- Threshold is achieved as per declared maxReconnectErrorThreshold.
- Event loop exits on threshold exhaustion
- Requeue event is sent
- Reconcile recreates a new websocket
- New websocket starts cleanly after Vault recovery
- The cycle can repeat multiple times

**Logs collected using command :** 
`kubectl logs -n vault-secrets-operator-system deploy/vault-secrets-operator-controller-manager -f --timestamps \
  | stdbuf -oL tee full-controller-up.log \
  | stdbuf -oL grep '"name":"vaultstaticsecret-sample-tenant-1"' \
  | stdbuf -oL grep -E "SharedWebSocket|Event loop|Failed to reconnect|Too many reconnect|Sent requeue|Created new SharedWebSocket|Successfully reconnected to WebSocket" \
  | tee websocket.log`

<img width="1041" height="547" alt="image" src="https://github.com/user-attachments/assets/28001216-9305-4505-8578-d76e955ee595" />

For database and lease event also backoff retry logic is tested. 
Commands : 
```
kubectl logs -n vault-secrets-operator-system \
  deploy/vault-secrets-operator-controller-manager \
  -c manager -f --timestamps \
  | stdbuf -oL tee full-lease-test.log \
  | stdbuf -oL grep '"name":"vaultdynamicsecret-instant-updates"' \
  | stdbuf -oL grep -E 'SharedWebSocket|Event loop|Failed to reconnect|Too many reconnect|Sent requeue|Created new SharedWebSocket|Successfully reconnected|WebSocket stopped|orphaned' \
  | stdbuf -oL grep '"eventType":"lease"' \
  | tee lease-websocket.log
```
<img width="1216" height="537" alt="image" src="https://github.com/user-attachments/assets/27d62a1b-94dc-4031-80b8-a39e86115aef" />


`kubectl logs -n vault-secrets-operator-system \
  deploy/vault-secrets-operator-controller-manager \
  -c manager -f --timestamps \
  | stdbuf -oL tee full-database-test.log \
  | stdbuf -oL grep '"name":"vaultdynamicsecret-instant-updates"' \
  | stdbuf -oL grep -E 'SharedWebSocket|Event loop|Failed to reconnect|Too many reconnect|Sent requeue|Created new SharedWebSocket|Successfully reconnected|WebSocket stopped|orphaned' \
  | stdbuf -oL grep '"eventType":"database"' \
  | tee database-websocket.log`

<img width="1218" height="541" alt="image" src="https://github.com/user-attachments/assets/d593c8be-4ba8-4885-ab55-4019fcec5d3c" />


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
