### PR TITLE
VSS: Add key templating for transformed secret data

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -54,6 +54,12 @@ type RolloutRestartTarget struct {
 }
 
 type Transformation struct {
+	// KeyTemplate is a Go text template used to transform each included source
+	// secret data key before writing it to the destination Secret. The template is
+	// executed once per source key with .Name set to the original source key. For
+	// example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+	// Templates are not affected by KeyTemplate.
+	KeyTemplate string `json:"keyTemplate,omitempty"`
 	// Templates maps a template name to its Template. Templates are always included
 	// in the rendered K8s Secret, and take precedence over templates defined in a
 	// SecretTransformation.

--- a/api/v1beta1/secrettransformation_types.go
+++ b/api/v1beta1/secrettransformation_types.go
@@ -34,6 +34,11 @@ type SecretTransformation struct {
 
 // SecretTransformationSpec defines the desired state of SecretTransformation
 type SecretTransformationSpec struct {
+	// KeyTemplate is a Go text template used to transform each included source
+	// secret data key before writing it to the destination Secret. The template is
+	// executed once per source key with .Name set to the original source key. For
+	// example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+	KeyTemplate string `json:"keyTemplate,omitempty"`
 	// Templates maps a template name to its Template. Templates are always included
 	// in the rendered secret with the specified key.
 	Templates map[string]Template `json:"templates,omitempty"`

--- a/chart/crds/secrets.hashicorp.com_csisecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_csisecrets.yaml
@@ -123,6 +123,14 @@ spec:
                         items:
                           type: string
                         type: array
+                      keyTemplate:
+                        description: |-
+                          KeyTemplate is a Go text template used to transform each included source
+                          secret data key before writing it to the destination Secret. The template is
+                          executed once per source key with .Name set to the original source key. For
+                          example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                          Templates are not affected by KeyTemplate.
+                        type: string
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.
@@ -272,6 +280,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            keyTemplate:
+                              description: |-
+                                KeyTemplate is a Go text template used to transform each included source
+                                secret data key before writing it to the destination Secret. The template is
+                                executed once per source key with .Name set to the original source key. For
+                                example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                                Templates are not affected by KeyTemplate.
+                              type: string
                             templates:
                               additionalProperties:
                                 description: Template provides templating configuration.
@@ -409,6 +425,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            keyTemplate:
+                              description: |-
+                                KeyTemplate is a Go text template used to transform each included source
+                                secret data key before writing it to the destination Secret. The template is
+                                executed once per source key with .Name set to the original source key. For
+                                example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                                Templates are not affected by KeyTemplate.
+                              type: string
                             templates:
                               additionalProperties:
                                 description: Template provides templating configuration.

--- a/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -110,6 +110,14 @@ spec:
                         items:
                           type: string
                         type: array
+                      keyTemplate:
+                        description: |-
+                          KeyTemplate is a Go text template used to transform each included source
+                          secret data key before writing it to the destination Secret. The template is
+                          executed once per source key with .Name set to the original source key. For
+                          example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                          Templates are not affected by KeyTemplate.
+                        type: string
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.

--- a/chart/crds/secrets.hashicorp.com_secrettransformations.yaml
+++ b/chart/crds/secrets.hashicorp.com_secrettransformations.yaml
@@ -75,6 +75,13 @@ spec:
                 items:
                   type: string
                 type: array
+              keyTemplate:
+                description: |-
+                  KeyTemplate is a Go text template used to transform each included source
+                  secret data key before writing it to the destination Secret. The template is
+                  executed once per source key with .Name set to the original source key. For
+                  example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                type: string
               sourceTemplates:
                 description: |-
                   SourceTemplates are never included in the rendered secret, they can be

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -129,6 +129,14 @@ spec:
                         items:
                           type: string
                         type: array
+                      keyTemplate:
+                        description: |-
+                          KeyTemplate is a Go text template used to transform each included source
+                          secret data key before writing it to the destination Secret. The template is
+                          executed once per source key with .Name set to the original source key. For
+                          example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                          Templates are not affected by KeyTemplate.
+                        type: string
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.

--- a/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -139,6 +139,14 @@ spec:
                         items:
                           type: string
                         type: array
+                      keyTemplate:
+                        description: |-
+                          KeyTemplate is a Go text template used to transform each included source
+                          secret data key before writing it to the destination Secret. The template is
+                          executed once per source key with .Name set to the original source key. For
+                          example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                          Templates are not affected by KeyTemplate.
+                        type: string
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.

--- a/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -121,6 +121,14 @@ spec:
                         items:
                           type: string
                         type: array
+                      keyTemplate:
+                        description: |-
+                          KeyTemplate is a Go text template used to transform each included source
+                          secret data key before writing it to the destination Secret. The template is
+                          executed once per source key with .Name set to the original source key. For
+                          example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                          Templates are not affected by KeyTemplate.
+                        type: string
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.

--- a/config/crd/bases/secrets.hashicorp.com_csisecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_csisecrets.yaml
@@ -123,6 +123,14 @@ spec:
                         items:
                           type: string
                         type: array
+                      keyTemplate:
+                        description: |-
+                          KeyTemplate is a Go text template used to transform each included source
+                          secret data key before writing it to the destination Secret. The template is
+                          executed once per source key with .Name set to the original source key. For
+                          example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                          Templates are not affected by KeyTemplate.
+                        type: string
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.
@@ -272,6 +280,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            keyTemplate:
+                              description: |-
+                                KeyTemplate is a Go text template used to transform each included source
+                                secret data key before writing it to the destination Secret. The template is
+                                executed once per source key with .Name set to the original source key. For
+                                example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                                Templates are not affected by KeyTemplate.
+                              type: string
                             templates:
                               additionalProperties:
                                 description: Template provides templating configuration.
@@ -409,6 +425,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            keyTemplate:
+                              description: |-
+                                KeyTemplate is a Go text template used to transform each included source
+                                secret data key before writing it to the destination Secret. The template is
+                                executed once per source key with .Name set to the original source key. For
+                                example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                                Templates are not affected by KeyTemplate.
+                              type: string
                             templates:
                               additionalProperties:
                                 description: Template provides templating configuration.

--- a/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -110,6 +110,14 @@ spec:
                         items:
                           type: string
                         type: array
+                      keyTemplate:
+                        description: |-
+                          KeyTemplate is a Go text template used to transform each included source
+                          secret data key before writing it to the destination Secret. The template is
+                          executed once per source key with .Name set to the original source key. For
+                          example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                          Templates are not affected by KeyTemplate.
+                        type: string
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.

--- a/config/crd/bases/secrets.hashicorp.com_secrettransformations.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_secrettransformations.yaml
@@ -75,6 +75,13 @@ spec:
                 items:
                   type: string
                 type: array
+              keyTemplate:
+                description: |-
+                  KeyTemplate is a Go text template used to transform each included source
+                  secret data key before writing it to the destination Secret. The template is
+                  executed once per source key with .Name set to the original source key. For
+                  example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                type: string
               sourceTemplates:
                 description: |-
                   SourceTemplates are never included in the rendered secret, they can be

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -129,6 +129,14 @@ spec:
                         items:
                           type: string
                         type: array
+                      keyTemplate:
+                        description: |-
+                          KeyTemplate is a Go text template used to transform each included source
+                          secret data key before writing it to the destination Secret. The template is
+                          executed once per source key with .Name set to the original source key. For
+                          example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                          Templates are not affected by KeyTemplate.
+                        type: string
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.

--- a/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -139,6 +139,14 @@ spec:
                         items:
                           type: string
                         type: array
+                      keyTemplate:
+                        description: |-
+                          KeyTemplate is a Go text template used to transform each included source
+                          secret data key before writing it to the destination Secret. The template is
+                          executed once per source key with .Name set to the original source key. For
+                          example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                          Templates are not affected by KeyTemplate.
+                        type: string
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.

--- a/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -121,6 +121,14 @@ spec:
                         items:
                           type: string
                         type: array
+                      keyTemplate:
+                        description: |-
+                          KeyTemplate is a Go text template used to transform each included source
+                          secret data key before writing it to the destination Secret. The template is
+                          executed once per source key with .Name set to the original source key. For
+                          example, "{{ .Name }}.json" renders a source key named "db" as "db.json".
+                          Templates are not affected by KeyTemplate.
+                        type: string
                       templates:
                         additionalProperties:
                           description: Template provides templating configuration.

--- a/controllers/validators.go
+++ b/controllers/validators.go
@@ -22,6 +22,12 @@ func ValidateSecretTransformation(_ context.Context, o client.Object) error {
 	case *v1beta1.SecretTransformation:
 		stmpl := template.NewSecretTemplate(t.Name)
 		objKey := client.ObjectKeyFromObject(o)
+		if t.Spec.KeyTemplate != "" {
+			if err := stmpl.Parse(fmt.Sprintf("%s/keyTemplate", objKey), t.Spec.KeyTemplate); err != nil {
+				errs = errors.Join(errs, err)
+			}
+		}
+
 		for idx, tmpl := range t.Spec.SourceTemplates {
 			var name string
 			if tmpl.Name == "" {

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -475,6 +475,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `keyTemplate` _string_ | KeyTemplate is a Go text template used to transform each included source<br />secret data key before writing it to the destination Secret. The template is<br />executed once per source key with .Name set to the original source key. For<br />example, "\{\{ .Name \}\}.json" renders a source key named "db" as "db.json". |  |  |
 | `templates` _object (keys:string, values:[Template](#template))_ | Templates maps a template name to its Template. Templates are always included<br />in the rendered secret with the specified key. |  |  |
 | `sourceTemplates` _[SourceTemplate](#sourcetemplate) array_ | SourceTemplates are never included in the rendered secret, they can be<br />used to provide common template definitions, etc. |  |  |
 | `includes` _string array_ | Includes contains regex patterns used to filter top-level source secret data<br />fields for inclusion in the final secret data. These pattern filters are<br />never applied to templated fields as defined in Templates. They are always<br />applied last. |  |  |
@@ -586,6 +587,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `keyTemplate` _string_ | KeyTemplate is a Go text template used to transform each included source<br />secret data key before writing it to the destination Secret. The template is<br />executed once per source key with .Name set to the original source key. For<br />example, "\{\{ .Name \}\}.json" renders a source key named "db" as "db.json".<br />Templates are not affected by KeyTemplate. |  |  |
 | `templates` _object (keys:string, values:[Template](#template))_ | Templates maps a template name to its Template. Templates are always included<br />in the rendered K8s Secret, and take precedence over templates defined in a<br />SecretTransformation. |  |  |
 | `transformationRefs` _[TransformationRef](#transformationref) array_ | TransformationRefs contain references to template configuration from<br />SecretTransformation. |  |  |
 | `includes` _string array_ | Includes contains regex patterns used to filter top-level source secret data<br />fields for inclusion in the final K8s Secret data. These pattern filters are<br />never applied to templated fields as defined in Templates. They are always<br />applied last. |  |  |

--- a/helpers/secrets.go
+++ b/helpers/secrets.go
@@ -691,8 +691,13 @@ func makeK8sData[V any](secretData map[string]V, extraData map[string][]byte,
 		return nil, err
 	}
 
-	// include the filtered fields that are not already in data
-	for k, v := range filtered {
+	transformed, err := TransformDataKeys(opt, filtered)
+	if err != nil {
+		return nil, err
+	}
+
+	// include the transformed fields that are not already in data
+	for k, v := range transformed {
 		if _, ok := data[k]; !ok {
 			bv, err := marshalJSON(v)
 			if err != nil {

--- a/helpers/secrets_test.go
+++ b/helpers/secrets_test.go
@@ -655,6 +655,60 @@ func TestSecretDataBuilder_WithVaultData(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "key-template",
+			opt: &SecretTransformationOption{
+				KeyTemplate: "{{ .Name }}.json",
+			},
+			data: map[string]interface{}{
+				"auth":  "auth-value",
+				"db":    "db-value",
+				"redis": "redis-value",
+			},
+			raw: map[string]interface{}{
+				"auth":  "auth-value",
+				"db":    "db-value",
+				"redis": "redis-value",
+			},
+			want: map[string][]byte{
+				"auth.json":  []byte("auth-value"),
+				"db.json":    []byte("db-value"),
+				"redis.json": []byte("redis-value"),
+				SecretDataKeyRaw: marshalRaw(t, map[string]any{
+					"auth":  "auth-value",
+					"db":    "db-value",
+					"redis": "redis-value",
+				}),
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "filters-before-key-template",
+			opt: &SecretTransformationOption{
+				Includes:    []string{"^(auth|db)$"},
+				KeyTemplate: "{{ .Name }}.json",
+			},
+			data: map[string]interface{}{
+				"auth":  "auth-value",
+				"db":    "db-value",
+				"redis": "redis-value",
+			},
+			raw: map[string]interface{}{
+				"auth":  "auth-value",
+				"db":    "db-value",
+				"redis": "redis-value",
+			},
+			want: map[string][]byte{
+				"auth.json": []byte("auth-value"),
+				"db.json":   []byte("db-value"),
+				SecretDataKeyRaw: marshalRaw(t, map[string]any{
+					"auth":  "auth-value",
+					"db":    "db-value",
+					"redis": "redis-value",
+				}),
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name:    "result-is-never-nil",
 			want:    map[string][]byte{},
 			wantErr: assert.NoError,

--- a/helpers/template.go
+++ b/helpers/template.go
@@ -74,6 +74,9 @@ func (e *TemplateNotFoundError) Error() string {
 // SecretTransformationOption provides the configuration necessary when
 // performing source secret data transformations.
 type SecretTransformationOption struct {
+	// KeyTemplate is used to transform each included raw source secret data key
+	// before writing it to the destination K8s Secret.
+	KeyTemplate string
 	// Excludes contains regex patterns that are applied to the raw secret data. All
 	// matches will be excluded for resulting K8s Secret data.
 	Excludes []string
@@ -136,11 +139,12 @@ func NewSecretTransformationOptionWithTransformation(ctx context.Context, client
 ) (*SecretTransformationOption, error) {
 	opt := &SecretTransformationOption{}
 	if transformation != nil {
-		keyedTemplates, ff, err := gatherTemplates(ctx, client, obj, transformation)
+		keyedTemplates, ff, keyTemplate, err := gatherTemplates(ctx, client, obj, transformation)
 		if err != nil {
 			return nil, err
 		}
 
+		opt.KeyTemplate = keyTemplate
 		opt.Annotations = obj.GetAnnotations()
 		opt.Labels = obj.GetLabels()
 		opt.Excludes = ff.excludes()
@@ -160,12 +164,12 @@ func NewSecretTransformationOptionWithTransformation(ctx context.Context, client
 
 // gatherTemplates attempts to collect all v1beta1.Template(s) for the
 // syncable secret object.
-func gatherTemplates(ctx context.Context, client ctrlclient.Client, obj ctrlclient.Object, transformation *secretsv1beta1.Transformation) ([]*KeyedTemplate, *fieldFilters, error) {
+func gatherTemplates(ctx context.Context, client ctrlclient.Client, obj ctrlclient.Object, transformation *secretsv1beta1.Transformation) ([]*KeyedTemplate, *fieldFilters, string, error) {
 	var errs error
 	var keyedTemplates []*KeyedTemplate
 
 	if transformation == nil {
-		return nil, nil, fmt.Errorf("transformation is nil")
+		return nil, nil, "", fmt.Errorf("transformation is nil")
 	}
 
 	// used to deduplicate templates by name
@@ -195,8 +199,10 @@ func gatherTemplates(ctx context.Context, client ctrlclient.Client, obj ctrlclie
 
 	objKey := ctrlclient.ObjectKeyFromObject(obj)
 	if err := common.ValidateObjectKey(objKey); err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
+
+	keyTemplate := transformation.KeyTemplate
 
 	// get the in-line template templates
 	for key, tmpl := range transformation.Templates {
@@ -231,6 +237,10 @@ func gatherTemplates(ctx context.Context, client ctrlclient.Client, obj ctrlclie
 		if err != nil {
 			errs = errors.Join(errs, err)
 			continue
+		}
+
+		if keyTemplate == "" {
+			keyTemplate = obj.Spec.KeyTemplate
 		}
 
 		if !ptr.Deref(obj.Status.Valid, false) {
@@ -306,14 +316,14 @@ func gatherTemplates(ctx context.Context, client ctrlclient.Client, obj ctrlclie
 	}
 
 	if errs != nil {
-		return nil, nil, errs
+		return nil, nil, "", errs
 	}
 
 	slices.SortFunc(keyedTemplates, func(a, b *KeyedTemplate) int {
 		return a.Cmp(b)
 	})
 
-	return keyedTemplates, ff, nil
+	return keyedTemplates, ff, keyTemplate, nil
 }
 
 // loadTemplates parses all v1beta1.Template(s) into a single
@@ -368,6 +378,35 @@ func renderTemplates(opt *SecretTransformationOption,
 	}
 
 	return data, nil
+}
+
+const keyTemplateName = "_keyTemplate"
+
+func loadKeyTemplate(text string) (template.SecretTemplate, error) {
+	t := template.NewSecretTemplate("")
+	if err := t.Parse(keyTemplateName, text); err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}
+
+type keyTemplateInput struct {
+	// Name is the original source secret data key.
+	Name string `json:"name"`
+}
+
+func renderKeyTemplate(tmpl template.SecretTemplate, name string) (string, error) {
+	input := keyTemplateInput{Name: name}
+	b, err := tmpl.ExecuteTemplate(keyTemplateName, input)
+	if err != nil {
+		return "", err
+	}
+	if len(b) == 0 {
+		return "", fmt.Errorf("rendered key template is empty for source key %q", name)
+	}
+
+	return string(b), nil
 }
 
 func matchField(pat, f string) (bool, error) {
@@ -442,6 +481,33 @@ func FilterData[V any](opt *SecretTransformationOption, data map[string]V) (map[
 	}
 
 	return m, nil
+}
+
+// TransformDataKeys applies KeyTemplate to each source data key. If
+// SecretTransformationOption is nil, data is returned unchanged.
+func TransformDataKeys[V any](opt *SecretTransformationOption, data map[string]V) (map[string]V, error) {
+	if opt == nil || opt.KeyTemplate == "" {
+		return data, nil
+	}
+
+	tmpl, err := loadKeyTemplate(opt.KeyTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	transformed := make(map[string]V, len(data))
+	for k, v := range data {
+		key, err := renderKeyTemplate(tmpl, k)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := transformed[key]; ok {
+			return nil, fmt.Errorf("key template rendered duplicate key %q", key)
+		}
+		transformed[key] = v
+	}
+
+	return transformed, nil
 }
 
 // SecretInput provides a standard data structure for secret template rendering.

--- a/helpers/template_test.go
+++ b/helpers/template_test.go
@@ -549,6 +549,100 @@ func TestSecretDataBuilder_FilterData_with_any(t *testing.T) {
 	}
 }
 
+func TestSecretDataBuilder_TransformDataKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		opt     *SecretTransformationOption
+		d       map[string]any
+		want    map[string]any
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "key-template",
+			opt: &SecretTransformationOption{
+				KeyTemplate: "{{ .Name }}.json",
+			},
+			d: map[string]any{
+				"auth":  "auth-value",
+				"db":    "db-value",
+				"redis": "redis-value",
+			},
+			want: map[string]any{
+				"auth.json":  "auth-value",
+				"db.json":    "db-value",
+				"redis.json": "redis-value",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "key-template-with-function",
+			opt: &SecretTransformationOption{
+				KeyTemplate: "{{ .Name | upper }}.json",
+			},
+			d: map[string]any{
+				"db": "db-value",
+			},
+			want: map[string]any{
+				"DB.json": "db-value",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "duplicate-rendered-key",
+			opt: &SecretTransformationOption{
+				KeyTemplate: "config.json",
+			},
+			d: map[string]any{
+				"auth": "auth-value",
+				"db":   "db-value",
+			},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err, `key template rendered duplicate key "config.json"`)
+			},
+		},
+		{
+			name: "empty-rendered-key",
+			opt: &SecretTransformationOption{
+				KeyTemplate: "",
+			},
+			d: map[string]any{
+				"db": "db-value",
+			},
+			want: map[string]any{
+				"db": "db-value",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "invalid-key-template",
+			opt: &SecretTransformationOption{
+				KeyTemplate: "{{",
+			},
+			d: map[string]any{
+				"db": "db-value",
+			},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "parse error")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+			got, err := TransformDataKeys[any](tt.opt, tt.d)
+			if !tt.wantErr(t, err, fmt.Sprintf(
+				"TransformDataKeys(%v, %v)", tt.opt, tt.d)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got,
+				"TransformDataKeys(%v, %v)", tt.opt, tt.d)
+		})
+	}
+}
+
 func TestNewSecretTransformationOption(t *testing.T) {
 	t.Parallel()
 
@@ -692,6 +786,70 @@ func TestNewSecretTransformationOption(t *testing.T) {
 				}),
 			want: &SecretTransformationOption{
 				Includes: []string{".+"},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "inline-key-template",
+			obj: newSecretObj(t,
+				secretsv1beta1.Transformation{
+					KeyTemplate: "{{ .Name }}.json",
+					Includes:    []string{".+"},
+				}),
+			want: &SecretTransformationOption{
+				KeyTemplate: "{{ .Name }}.json",
+				Includes:    []string{".+"},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "inline-key-template-takes-precedence",
+			obj: newSecretObj(t,
+				secretsv1beta1.Transformation{
+					KeyTemplate: "{{ .Name }}.json",
+					TransformationRefs: []secretsv1beta1.TransformationRef{
+						{
+							Namespace: "default",
+							Name:      "templates",
+						},
+					},
+				}),
+			secretTransObjs: []*secretsv1beta1.SecretTransformation{
+				newTransObj(t,
+					defaultTransObjMeta,
+					secretsv1beta1.SecretTransformationSpec{
+						KeyTemplate: "{{ .Name }}.txt",
+					},
+					nil,
+				),
+			},
+			want: &SecretTransformationOption{
+				KeyTemplate: "{{ .Name }}.json",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "trans-refs-key-template",
+			obj: newSecretObj(t,
+				secretsv1beta1.Transformation{
+					TransformationRefs: []secretsv1beta1.TransformationRef{
+						{
+							Namespace: "default",
+							Name:      "templates",
+						},
+					},
+				}),
+			secretTransObjs: []*secretsv1beta1.SecretTransformation{
+				newTransObj(t,
+					defaultTransObjMeta,
+					secretsv1beta1.SecretTransformationSpec{
+						KeyTemplate: "{{ .Name }}.json",
+					},
+					nil,
+				),
+			},
+			want: &SecretTransformationOption{
+				KeyTemplate: "{{ .Name }}.json",
 			},
 			wantErr: assert.NoError,
 		},


### PR DESCRIPTION
We want to implement the use of this operator, however we have a lot of secrets that have keys like `db`, `connection`, etc which we need to result in kubernetes secrets with corresponding keys `db.json`, `connection.json` to mount in our pods.

Current transformation only allows to hardcode new name for a specific key, but doesn't allow to dynamically change names of all keys in the secret.

This change allows that by adding `keyTemplate` to secret transformations so source secret data keys can be renamed with a Go template before being written to the destination Kubernetes Secret.

for example:

```
spec:
  destination:
    create: true
    name: test
    overwrite: false
    transformation:
      keyTemplate: "{{ .Name }}.json"
```

This makes:
`db` -> `db.json`
`connection` -> `connection.json`

---

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] ~~If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.~~

- [ ] ~~If applicable, I've documented the impact of any changes to security controls.~~

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

