### PR TITLE
feat(rollout): Add support for Strimzi KafkaConnect as a rolloutrestart target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+Enhancements:
+* Support rollout-restart of Strimzi `KafkaConnect` resources: ([#TBD](https://github.com/hashicorp/vault-secrets-operator/pull/TBD))
+
+
 ## 1.4.0 (May 5th, 2026)
 
 Fix:

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -44,10 +44,14 @@ type Destination struct {
 // with a timestamp value of when the trigger was executed.
 // E.g. vso.secrets.hashicorp.com/restartedAt: "2023-03-23T13:39:31Z"
 //
-// Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout
+// For Strimzi KafkaConnect the annotation is instead applied to
+// 'spec.template.pod.metadata.annotations', which is where Strimzi propagates
+// pod-level annotations from.
+//
+// Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout, KafkaConnect
 type RolloutRestartTarget struct {
 	// Kind of the resource
-	// +kubebuilder:validation:Enum={Deployment,DaemonSet,StatefulSet,argo.Rollout}
+	// +kubebuilder:validation:Enum={Deployment,DaemonSet,StatefulSet,argo.Rollout,KafkaConnect}
 	Kind string `json:"kind"`
 	// Name of the resource
 	Name string `json:"name"`

--- a/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -225,7 +225,11 @@ spec:
                     with a timestamp value of when the trigger was executed.
                     E.g. vso.secrets.hashicorp.com/restartedAt: "2023-03-23T13:39:31Z"
 
-                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout
+                    For Strimzi KafkaConnect the annotation is instead applied to
+                    'spec.template.pod.metadata.annotations', which is where Strimzi propagates
+                    pod-level annotations from.
+
+                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout, KafkaConnect
                   properties:
                     kind:
                       description: Kind of the resource
@@ -234,6 +238,7 @@ spec:
                       - DaemonSet
                       - StatefulSet
                       - argo.Rollout
+                      - KafkaConnect
                       type: string
                     name:
                       description: Name of the resource

--- a/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -289,7 +289,11 @@ spec:
                     with a timestamp value of when the trigger was executed.
                     E.g. vso.secrets.hashicorp.com/restartedAt: "2023-03-23T13:39:31Z"
 
-                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout
+                    For Strimzi KafkaConnect the annotation is instead applied to
+                    'spec.template.pod.metadata.annotations', which is where Strimzi propagates
+                    pod-level annotations from.
+
+                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout, KafkaConnect
                   properties:
                     kind:
                       description: Kind of the resource
@@ -298,6 +302,7 @@ spec:
                       - DaemonSet
                       - StatefulSet
                       - argo.Rollout
+                      - KafkaConnect
                       type: string
                     name:
                       description: Name of the resource

--- a/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -306,7 +306,11 @@ spec:
                     with a timestamp value of when the trigger was executed.
                     E.g. vso.secrets.hashicorp.com/restartedAt: "2023-03-23T13:39:31Z"
 
-                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout
+                    For Strimzi KafkaConnect the annotation is instead applied to
+                    'spec.template.pod.metadata.annotations', which is where Strimzi propagates
+                    pod-level annotations from.
+
+                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout, KafkaConnect
                   properties:
                     kind:
                       description: Kind of the resource
@@ -315,6 +319,7 @@ spec:
                       - DaemonSet
                       - StatefulSet
                       - argo.Rollout
+                      - KafkaConnect
                       type: string
                     name:
                       description: Name of the resource

--- a/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -250,7 +250,11 @@ spec:
                     with a timestamp value of when the trigger was executed.
                     E.g. vso.secrets.hashicorp.com/restartedAt: "2023-03-23T13:39:31Z"
 
-                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout
+                    For Strimzi KafkaConnect the annotation is instead applied to
+                    'spec.template.pod.metadata.annotations', which is where Strimzi propagates
+                    pod-level annotations from.
+
+                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout, KafkaConnect
                   properties:
                     kind:
                       description: Kind of the resource
@@ -259,6 +263,7 @@ spec:
                       - DaemonSet
                       - StatefulSet
                       - argo.Rollout
+                      - KafkaConnect
                       type: string
                     name:
                       description: Name of the resource

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -75,6 +75,15 @@ rules:
     - patch
     - watch
 - apiGroups:
+    - kafka.strimzi.io
+  resources:
+    - kafkaconnects
+  verbs:
+    - get
+    - list
+    - patch
+    - watch
+- apiGroups:
     - secrets.hashicorp.com
   resources:
     - csisecrets

--- a/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -225,7 +225,11 @@ spec:
                     with a timestamp value of when the trigger was executed.
                     E.g. vso.secrets.hashicorp.com/restartedAt: "2023-03-23T13:39:31Z"
 
-                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout
+                    For Strimzi KafkaConnect the annotation is instead applied to
+                    'spec.template.pod.metadata.annotations', which is where Strimzi propagates
+                    pod-level annotations from.
+
+                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout, KafkaConnect
                   properties:
                     kind:
                       description: Kind of the resource
@@ -234,6 +238,7 @@ spec:
                       - DaemonSet
                       - StatefulSet
                       - argo.Rollout
+                      - KafkaConnect
                       type: string
                     name:
                       description: Name of the resource

--- a/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultdynamicsecrets.yaml
@@ -289,7 +289,11 @@ spec:
                     with a timestamp value of when the trigger was executed.
                     E.g. vso.secrets.hashicorp.com/restartedAt: "2023-03-23T13:39:31Z"
 
-                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout
+                    For Strimzi KafkaConnect the annotation is instead applied to
+                    'spec.template.pod.metadata.annotations', which is where Strimzi propagates
+                    pod-level annotations from.
+
+                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout, KafkaConnect
                   properties:
                     kind:
                       description: Kind of the resource
@@ -298,6 +302,7 @@ spec:
                       - DaemonSet
                       - StatefulSet
                       - argo.Rollout
+                      - KafkaConnect
                       type: string
                     name:
                       description: Name of the resource

--- a/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultpkisecrets.yaml
@@ -306,7 +306,11 @@ spec:
                     with a timestamp value of when the trigger was executed.
                     E.g. vso.secrets.hashicorp.com/restartedAt: "2023-03-23T13:39:31Z"
 
-                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout
+                    For Strimzi KafkaConnect the annotation is instead applied to
+                    'spec.template.pod.metadata.annotations', which is where Strimzi propagates
+                    pod-level annotations from.
+
+                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout, KafkaConnect
                   properties:
                     kind:
                       description: Kind of the resource
@@ -315,6 +319,7 @@ spec:
                       - DaemonSet
                       - StatefulSet
                       - argo.Rollout
+                      - KafkaConnect
                       type: string
                     name:
                       description: Name of the resource

--- a/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -250,7 +250,11 @@ spec:
                     with a timestamp value of when the trigger was executed.
                     E.g. vso.secrets.hashicorp.com/restartedAt: "2023-03-23T13:39:31Z"
 
-                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout
+                    For Strimzi KafkaConnect the annotation is instead applied to
+                    'spec.template.pod.metadata.annotations', which is where Strimzi propagates
+                    pod-level annotations from.
+
+                    Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout, KafkaConnect
                   properties:
                     kind:
                       description: Kind of the resource
@@ -259,6 +263,7 @@ spec:
                       - DaemonSet
                       - StatefulSet
                       - argo.Rollout
+                      - KafkaConnect
                       type: string
                     name:
                       description: Name of the resource

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,6 +66,15 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkaconnects
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - secrets.hashicorp.com
   resources:
   - csisecrets

--- a/controllers/hcpvaultsecretsapp_controller.go
+++ b/controllers/hcpvaultsecretsapp_controller.go
@@ -98,6 +98,7 @@ type HCPVaultSecretsAppReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=argoproj.io,resources=rollouts,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkaconnects,verbs=get;list;watch;patch
 //
 
 // Reconcile a secretsv1beta1.HCPVaultSecretsApp Custom Resource instance. Each

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -93,6 +93,7 @@ type VaultDynamicSecretReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=argoproj.io,resources=rollouts,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkaconnects,verbs=get;list;watch;patch
 //
 // needed for managing cached Clients, duplicated in vaultconnection_controller.go
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;delete;update;patch

--- a/controllers/vaultpkisecret_controller.go
+++ b/controllers/vaultpkisecret_controller.go
@@ -64,6 +64,7 @@ type VaultPKISecretReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=argoproj.io,resources=rollouts,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkaconnects,verbs=get;list;watch;patch
 //
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -71,6 +71,7 @@ type VaultStaticSecretReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=argoproj.io,resources=rollouts,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkaconnects,verbs=get;list;watch;patch
 //
 
 func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -391,7 +391,11 @@ The rollout-restart is triggered by patching the target resource's
 with a timestamp value of when the trigger was executed.
 E.g. vso.secrets.hashicorp.com/restartedAt: "2023-03-23T13:39:31Z"
 
-Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout
+For Strimzi KafkaConnect the annotation is instead applied to
+'spec.template.pod.metadata.annotations', which is where Strimzi propagates
+pod-level annotations from.
+
+Supported resources: Deployment, DaemonSet, StatefulSet, argo.Rollout, KafkaConnect
 
 
 
@@ -403,7 +407,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `kind` _string_ | Kind of the resource |  | Enum: [Deployment DaemonSet StatefulSet argo.Rollout] <br /> |
+| `kind` _string_ | Kind of the resource |  | Enum: [Deployment DaemonSet StatefulSet argo.Rollout KafkaConnect] <br /> |
 | `name` _string_ | Name of the resource |  |  |
 
 

--- a/helpers/rollout_restart.go
+++ b/helpers/rollout_restart.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	argorolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -23,6 +26,16 @@ import (
 
 // AnnotationRestartedAt is updated to trigger a rollout-restart
 const AnnotationRestartedAt = "vso.secrets.hashicorp.com/restartedAt"
+
+// strimziKafkaConnectGVK identifies the Strimzi KafkaConnect CRD targeted for
+// rollout-restart. It is handled as an unstructured object so that VSO does not
+// depend on the Strimzi Go API. Strimzi serves this resource under the
+// kafka.strimzi.io/v1 API.
+var strimziKafkaConnectGVK = schema.GroupVersionKind{
+	Group:   "kafka.strimzi.io",
+	Version: "v1",
+	Kind:    "KafkaConnect",
+}
 
 // HandleRolloutRestarts for all v1beta1.RolloutRestartTarget(s) configured for obj.
 // Supported objs are: v1beta1.VaultDynamicSecret, v1beta1.VaultStaticSecret, v1beta1.VaultPKISecret
@@ -78,7 +91,7 @@ func HandleRolloutRestarts(ctx context.Context, client ctrlclient.Client, obj ct
 }
 
 // RolloutRestart patches the target in namespace for rollout-restart.
-// Supported target Kinds are: DaemonSet, Deployment, StatefulSet
+// Supported target Kinds are: DaemonSet, Deployment, StatefulSet, argo.Rollout, KafkaConnect
 func RolloutRestart(ctx context.Context, namespace string, target v1beta1.RolloutRestartTarget, client ctrlclient.Client) error {
 	if namespace == "" {
 		return fmt.Errorf("namespace cannot be empty")
@@ -107,6 +120,12 @@ func RolloutRestart(ctx context.Context, namespace string, target v1beta1.Rollou
 		obj = &argorolloutsv1alpha1.Rollout{
 			ObjectMeta: objectMeta,
 		}
+	case "KafkaConnect":
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(strimziKafkaConnectGVK)
+		u.SetNamespace(namespace)
+		u.SetName(target.Name)
+		obj = u
 	default:
 		return fmt.Errorf("unsupported Kind %q for %T", target.Kind, target)
 	}
@@ -149,6 +168,28 @@ func patchForRolloutRestart(ctx context.Context, obj ctrlclient.Object, client c
 		// use MergeFrom() since it supports CRDs whereas StrategicMergeFrom() does not.
 		patch := ctrlclient.MergeFrom(t.DeepCopy())
 		t.Spec.RestartAt = &metav1.Time{Time: time.Now()}
+		return client.Patch(ctx, t, patch)
+	case *unstructured.Unstructured:
+		// Strimzi CRDs (e.g. KafkaConnect) are handled as unstructured objects so
+		// that VSO does not depend on the Strimzi Go API. Strimzi triggers a
+		// rolling update of the managed pods when the annotations under
+		// spec.template.pod.metadata.annotations change. Use MergeFrom() since it
+		// supports CRDs whereas StrategicMergeFrom() does not.
+		annotationsPath := []string{"spec", "template", "pod", "metadata", "annotations"}
+		patch := ctrlclient.MergeFrom(t.DeepCopy())
+		annotations, _, err := unstructured.NestedStringMap(t.Object, annotationsPath...)
+		if err != nil {
+			return fmt.Errorf("failed to read %s for %s, err=%w",
+				strings.Join(annotationsPath, "."), ctrlclient.ObjectKeyFromObject(t), err)
+		}
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[AnnotationRestartedAt] = time.Now().Format(time.RFC3339)
+		if err := unstructured.SetNestedStringMap(t.Object, annotations, annotationsPath...); err != nil {
+			return fmt.Errorf("failed to set %s for %s, err=%w",
+				strings.Join(annotationsPath, "."), ctrlclient.ObjectKeyFromObject(t), err)
+		}
 		return client.Patch(ctx, t, patch)
 	default:
 		return fmt.Errorf("unsupported type %T for rollout-restart patching", t)

--- a/helpers/rollout_restart_test.go
+++ b/helpers/rollout_restart_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/hashicorp/vault-secrets-operator/api/v1beta1"
@@ -129,6 +130,15 @@ func TestRolloutRestart(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 		},
+		{
+			name: "KafkaConnect",
+			obj:  newKafkaConnect("default", "baz"),
+			target: v1beta1.RolloutRestartTarget{
+				Kind: "KafkaConnect",
+				Name: "baz",
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -171,6 +181,12 @@ func assertPatchedRolloutRestartObj(t *testing.T, ctx context.Context, obj ctrlc
 	case *argorolloutsv1alpha1.Rollout:
 		attr = "argo.rollout.spec.restartAt"
 		restartAtTime = o.Spec.RestartAt.Time
+	case *unstructured.Unstructured:
+		attr = "spec.template.pod.metadata.annotations." + AnnotationRestartedAt
+		annotations, _, err := unstructured.NestedStringMap(o.Object,
+			"spec", "template", "pod", "metadata", "annotations")
+		require.NoError(t, err)
+		restartAt = annotations[AnnotationRestartedAt]
 	default:
 		t.Fatalf("rollout restart object type not supported %v", o)
 	}
@@ -184,4 +200,19 @@ func assertPatchedRolloutRestartObj(t *testing.T, ctx context.Context, obj ctrlc
 	assert.True(t, restartAtTime.After(beforeRolloutRestart),
 		"restartAt should be after beforeRolloutRestart",
 		attr, restartAtTime, "beforeRolloutRestart", beforeRolloutRestart)
+}
+
+// newKafkaConnect returns a minimal Strimzi KafkaConnect resource as an
+// unstructured object, matching how VSO targets it for rollout-restart.
+func newKafkaConnect(namespace, name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(strimziKafkaConnectGVK)
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	// bootstrapServers is a required field on the KafkaConnect spec.
+	if err := unstructured.SetNestedField(u.Object,
+		"my-cluster-kafka-bootstrap:9092", "spec", "bootstrapServers"); err != nil {
+		panic(err)
+	}
+	return u
 }


### PR DESCRIPTION
We use [Strimzi](https://strimzi.io/) to run [Debezium](https://debezium.io/) as a CDC system for our databases.
As we use Vault to dynamically provision credentials we need to restart the Debezium connectors when credentials change.

Adds support for annotating the `KafkaConnect`  pods in the same way as arg rollouts etc do.