### PR TITLE
Deprecation release to prepare for the HCP Vault Secrets sunset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Breaking Changes:
   Secret ID.
 
 Deprecations:
-* HCPAuth and HCPVaultSecretsApp (HCP Vault Secrets) are deprecated and will be removed in a future release of the Vault Secrets Operator. The operator now emits a `Deprecated` warning event on each reconcile of these resources, and `kubectl` will surface a deprecation warning for the corresponding CRDs. Migrate off HCP Vault Secrets and remove any `HCPVaultSecretsApp` and `HCPAuth` resources before upgrading to the removal release.
+* HCPAuth and HCPVaultSecretsApp (HCP Vault Secrets) are deprecated and will be removed in a future release of the Vault Secrets Operator. The operator now emits a `Deprecated` warning event on each reconcile of these resources, and `kubectl` will surface a deprecation warning for the corresponding CRDs. Migrate off HCP Vault Secrets and remove any `HCPVaultSecretsApp` and `HCPAuth` resources before upgrading to the removal release. ([#1293](https://github.com/hashicorp/vault-secrets-operator/pull/1293))
 
 ## 1.4.1 (June 30th, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Breaking Changes:
   `spec.appRole.secretRef` instead, which references a Kubernetes Secret containing the AppRole
   Secret ID.
 
+Deprecations:
+* HCPAuth and HCPVaultSecretsApp (HCP Vault Secrets) are deprecated and will be removed in a future release of the Vault Secrets Operator. The operator now emits a `Deprecated` warning event on each reconcile of these resources, and `kubectl` will surface a deprecation warning for the corresponding CRDs. Migrate off HCP Vault Secrets and remove any `HCPVaultSecretsApp` and `HCPAuth` resources before upgrading to the removal release.
+
 ## 1.4.1 (June 30th, 2026)
 
 Build:

--- a/api/v1beta1/hcpauth_types.go
+++ b/api/v1beta1/hcpauth_types.go
@@ -8,6 +8,10 @@ import (
 )
 
 // HCPAuthSpec defines the desired state of HCPAuth
+//
+// Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+// removed in a future release of the Vault Secrets Operator. Migrate off HCP
+// Vault Secrets before upgrading to the removal release.
 type HCPAuthSpec struct {
 	// OrganizationID of the HCP organization.
 	OrganizationID string `json:"organizationID"`
@@ -35,6 +39,10 @@ type HCPAuthSpec struct {
 
 // HCPAuthServicePrincipal provides HCPAuth configuration options needed for
 // authenticating to HCP using a service principal configured in SecretRef.
+//
+// Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+// removed in a future release of the Vault Secrets Operator. Migrate off HCP
+// Vault Secrets before upgrading to the removal release.
 type HCPAuthServicePrincipal struct {
 	// SecretRef is the name of a Kubernetes secret in the consumer's
 	// (VDS/VSS/PKI/HCP) namespace which provides the HCP ServicePrincipal clientID,
@@ -47,6 +55,10 @@ type HCPAuthServicePrincipal struct {
 }
 
 // HCPAuthStatus defines the observed state of HCPAuth
+//
+// Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+// removed in a future release of the Vault Secrets Operator. Migrate off HCP
+// Vault Secrets before upgrading to the removal release.
 type HCPAuthStatus struct {
 	// Valid auth mechanism.
 	Valid *bool  `json:"valid"`
@@ -58,8 +70,13 @@ type HCPAuthStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion:warning="HCPAuth is deprecated and will be removed in a future release of the Vault Secrets Operator. HCP Vault Secrets support is being retired; migrate off HCP Vault Secrets before upgrading to the removal release."
 
 // HCPAuth is the Schema for the hcpauths API
+//
+// Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+// removed in a future release of the Vault Secrets Operator. Migrate off HCP
+// Vault Secrets before upgrading to the removal release.
 type HCPAuth struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -71,6 +88,10 @@ type HCPAuth struct {
 // +kubebuilder:object:root=true
 
 // HCPAuthList contains a list of HCPAuth
+//
+// Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+// removed in a future release of the Vault Secrets Operator. Migrate off HCP
+// Vault Secrets before upgrading to the removal release.
 type HCPAuthList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/hcpvaultsecretsapp_types.go
+++ b/api/v1beta1/hcpvaultsecretsapp_types.go
@@ -8,6 +8,10 @@ import (
 )
 
 // HCPVaultSecretsAppSpec defines the desired state of HCPVaultSecretsApp
+//
+// Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+// and will be removed in a future release of the Vault Secrets Operator.
+// Migrate off HCP Vault Secrets before upgrading to the removal release.
 type HCPVaultSecretsAppSpec struct {
 	// AppName of the Vault Secrets Application that is to be synced.
 	AppName string `json:"appName"`
@@ -37,12 +41,18 @@ type HCPVaultSecretsAppSpec struct {
 }
 
 // HVSSyncConfig configures sync behavior from HVS to VSO
+//
+// Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+// future release of the Vault Secrets Operator.
 type HVSSyncConfig struct {
 	// Dynamic configures sync behavior for dynamic secrets.
 	Dynamic *HVSDynamicSyncConfig `json:"dynamic,omitempty"`
 }
 
 // HVSDynamicSyncConfig configures sync behavior for HVS dynamic secrets.
+//
+// Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+// future release of the Vault Secrets Operator.
 type HVSDynamicSyncConfig struct {
 	// RenewalPercent is the percent out of 100 of a dynamic secret's TTL when
 	// new secrets are generated. Defaults to 67 percent plus up to 10% jitter.
@@ -54,6 +64,9 @@ type HVSDynamicSyncConfig struct {
 
 // HVSDynamicStatus defines the observed state of a dynamic secret within an HCP
 // Vault Secrets App
+//
+// Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+// future release of the Vault Secrets Operator.
 type HVSDynamicStatus struct {
 	// Name of the dynamic secret
 	Name string `json:"name,omitempty"`
@@ -66,6 +79,10 @@ type HVSDynamicStatus struct {
 }
 
 // HCPVaultSecretsAppStatus defines the observed state of HCPVaultSecretsApp
+//
+// Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+// and will be removed in a future release of the Vault Secrets Operator.
+// Migrate off HCP Vault Secrets before upgrading to the removal release.
 type HCPVaultSecretsAppStatus struct {
 	// LastGeneration is the Generation of the last reconciled resource.
 	LastGeneration int64 `json:"lastGeneration"`
@@ -88,8 +105,13 @@ type HCPVaultSecretsAppStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion:warning="HCPVaultSecretsApp is deprecated and will be removed in a future release of the Vault Secrets Operator. HCP Vault Secrets support is being retired; migrate off HCP Vault Secrets before upgrading to the removal release."
 
 // HCPVaultSecretsApp is the Schema for the hcpvaultsecretsapps API
+//
+// Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+// and will be removed in a future release of the Vault Secrets Operator.
+// Migrate off HCP Vault Secrets before upgrading to the removal release.
 type HCPVaultSecretsApp struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -101,6 +123,10 @@ type HCPVaultSecretsApp struct {
 // +kubebuilder:object:root=true
 
 // HCPVaultSecretsAppList contains a list of HCPVaultSecretsApp
+//
+// Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+// and will be removed in a future release of the Vault Secrets Operator.
+// Migrate off HCP Vault Secrets before upgrading to the removal release.
 type HCPVaultSecretsAppList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/chart/crds/secrets.hashicorp.com_hcpauths.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpauths.yaml
@@ -17,10 +17,19 @@ spec:
     singular: hcpauth
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: HCPAuth is deprecated and will be removed in a future release
+      of the Vault Secrets Operator. HCP Vault Secrets support is being retired; migrate
+      off HCP Vault Secrets before upgrading to the removal release.
+    name: v1beta1
     schema:
       openAPIV3Schema:
-        description: HCPAuth is the Schema for the hcpauths API
+        description: |-
+          HCPAuth is the Schema for the hcpauths API
+
+          Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+          removed in a future release of the Vault Secrets Operator. Migrate off HCP
+          Vault Secrets before upgrading to the removal release.
         properties:
           apiVersion:
             description: |-
@@ -40,7 +49,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: HCPAuthSpec defines the desired state of HCPAuth
+            description: |-
+              HCPAuthSpec defines the desired state of HCPAuth
+
+              Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+              removed in a future release of the Vault Secrets Operator. Migrate off HCP
+              Vault Secrets before upgrading to the removal release.
             properties:
               allowedNamespaces:
                 description: |-
@@ -92,7 +106,12 @@ spec:
             - projectID
             type: object
           status:
-            description: HCPAuthStatus defines the observed state of HCPAuth
+            description: |-
+              HCPAuthStatus defines the observed state of HCPAuth
+
+              Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+              removed in a future release of the Vault Secrets Operator. Migrate off HCP
+              Vault Secrets before upgrading to the removal release.
             properties:
               conditions:
                 description: |-

--- a/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/chart/crds/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -17,11 +17,19 @@ spec:
     singular: hcpvaultsecretsapp
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: HCPVaultSecretsApp is deprecated and will be removed in a
+      future release of the Vault Secrets Operator. HCP Vault Secrets support is being
+      retired; migrate off HCP Vault Secrets before upgrading to the removal release.
+    name: v1beta1
     schema:
       openAPIV3Schema:
-        description: HCPVaultSecretsApp is the Schema for the hcpvaultsecretsapps
-          API
+        description: |-
+          HCPVaultSecretsApp is the Schema for the hcpvaultsecretsapps API
+
+          Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+          and will be removed in a future release of the Vault Secrets Operator.
+          Migrate off HCP Vault Secrets before upgrading to the removal release.
         properties:
           apiVersion:
             description: |-
@@ -41,7 +49,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: HCPVaultSecretsAppSpec defines the desired state of HCPVaultSecretsApp
+            description: |-
+              HCPVaultSecretsAppSpec defines the desired state of HCPVaultSecretsApp
+
+              Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+              and will be removed in a future release of the Vault Secrets Operator.
+              Migrate off HCP Vault Secrets before upgrading to the removal release.
             properties:
               appName:
                 description: AppName of the Vault Secrets Application that is to be
@@ -264,7 +277,12 @@ spec:
             - destination
             type: object
           status:
-            description: HCPVaultSecretsAppStatus defines the observed state of HCPVaultSecretsApp
+            description: |-
+              HCPVaultSecretsAppStatus defines the observed state of HCPVaultSecretsApp
+
+              Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+              and will be removed in a future release of the Vault Secrets Operator.
+              Migrate off HCP Vault Secrets before upgrading to the removal release.
             properties:
               conditions:
                 description: |-
@@ -333,6 +351,9 @@ spec:
                   description: |-
                     HVSDynamicStatus defines the observed state of a dynamic secret within an HCP
                     Vault Secrets App
+
+                    Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+                    future release of the Vault Secrets Operator.
                   properties:
                     createdAt:
                       description: CreatedAt is the timestamp string of when the dynamic

--- a/common/common.go
+++ b/common/common.go
@@ -605,6 +605,9 @@ func GetVaultAuthWithRetry(ctx context.Context, c client.Client, key types.Names
 
 // GetHCPAuthForObj returns the corresponding secretsv1beta1.HCPAuth for obj.
 // Supported client.Object: secretsv1beta1.HCPVaultSecretsApp
+//
+// Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+// future release of the Vault Secrets Operator.
 func GetHCPAuthForObj(ctx context.Context, c client.Client, obj client.Object) (*secretsv1beta1.HCPAuth, error) {
 	authRef, err := getAuthRefNamespacedName(obj)
 	if err != nil {
@@ -627,6 +630,11 @@ func GetHCPAuthForObj(ctx context.Context, c client.Client, obj client.Object) (
 	return authObj, nil
 }
 
+// GetHCPAuthWithRetry returns the secretsv1beta1.HCPAuth for key, retrying on
+// transient not-found errors.
+//
+// Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+// future release of the Vault Secrets Operator.
 func GetHCPAuthWithRetry(ctx context.Context, c client.Client, key types.NamespacedName,
 	delay time.Duration, max uint64,
 ) (*secretsv1beta1.HCPAuth, error) {

--- a/config/crd/bases/secrets.hashicorp.com_hcpauths.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpauths.yaml
@@ -17,10 +17,19 @@ spec:
     singular: hcpauth
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: HCPAuth is deprecated and will be removed in a future release
+      of the Vault Secrets Operator. HCP Vault Secrets support is being retired; migrate
+      off HCP Vault Secrets before upgrading to the removal release.
+    name: v1beta1
     schema:
       openAPIV3Schema:
-        description: HCPAuth is the Schema for the hcpauths API
+        description: |-
+          HCPAuth is the Schema for the hcpauths API
+
+          Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+          removed in a future release of the Vault Secrets Operator. Migrate off HCP
+          Vault Secrets before upgrading to the removal release.
         properties:
           apiVersion:
             description: |-
@@ -40,7 +49,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: HCPAuthSpec defines the desired state of HCPAuth
+            description: |-
+              HCPAuthSpec defines the desired state of HCPAuth
+
+              Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+              removed in a future release of the Vault Secrets Operator. Migrate off HCP
+              Vault Secrets before upgrading to the removal release.
             properties:
               allowedNamespaces:
                 description: |-
@@ -92,7 +106,12 @@ spec:
             - projectID
             type: object
           status:
-            description: HCPAuthStatus defines the observed state of HCPAuth
+            description: |-
+              HCPAuthStatus defines the observed state of HCPAuth
+
+              Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+              removed in a future release of the Vault Secrets Operator. Migrate off HCP
+              Vault Secrets before upgrading to the removal release.
             properties:
               conditions:
                 description: |-

--- a/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_hcpvaultsecretsapps.yaml
@@ -17,11 +17,19 @@ spec:
     singular: hcpvaultsecretsapp
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: HCPVaultSecretsApp is deprecated and will be removed in a
+      future release of the Vault Secrets Operator. HCP Vault Secrets support is being
+      retired; migrate off HCP Vault Secrets before upgrading to the removal release.
+    name: v1beta1
     schema:
       openAPIV3Schema:
-        description: HCPVaultSecretsApp is the Schema for the hcpvaultsecretsapps
-          API
+        description: |-
+          HCPVaultSecretsApp is the Schema for the hcpvaultsecretsapps API
+
+          Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+          and will be removed in a future release of the Vault Secrets Operator.
+          Migrate off HCP Vault Secrets before upgrading to the removal release.
         properties:
           apiVersion:
             description: |-
@@ -41,7 +49,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: HCPVaultSecretsAppSpec defines the desired state of HCPVaultSecretsApp
+            description: |-
+              HCPVaultSecretsAppSpec defines the desired state of HCPVaultSecretsApp
+
+              Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+              and will be removed in a future release of the Vault Secrets Operator.
+              Migrate off HCP Vault Secrets before upgrading to the removal release.
             properties:
               appName:
                 description: AppName of the Vault Secrets Application that is to be
@@ -264,7 +277,12 @@ spec:
             - destination
             type: object
           status:
-            description: HCPVaultSecretsAppStatus defines the observed state of HCPVaultSecretsApp
+            description: |-
+              HCPVaultSecretsAppStatus defines the observed state of HCPVaultSecretsApp
+
+              Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+              and will be removed in a future release of the Vault Secrets Operator.
+              Migrate off HCP Vault Secrets before upgrading to the removal release.
             properties:
               conditions:
                 description: |-
@@ -333,6 +351,9 @@ spec:
                   description: |-
                     HVSDynamicStatus defines the observed state of a dynamic secret within an HCP
                     Vault Secrets App
+
+                    Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+                    future release of the Vault Secrets Operator.
                   properties:
                     createdAt:
                       description: CreatedAt is the timestamp string of when the dynamic

--- a/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
@@ -83,12 +83,18 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: HCPAuth is the Schema for the hcpauths API
+    - description: "HCPAuth is the Schema for the hcpauths API \n Deprecated: HCPAuth
+        and HCP Vault Secrets support are deprecated and will be removed in a future
+        release of the Vault Secrets Operator. Migrate off HCP Vault Secrets before
+        upgrading to the removal release."
       displayName: HCPAuth
       kind: HCPAuth
       name: hcpauths.secrets.hashicorp.com
       version: v1beta1
-    - description: HCPVaultSecretsApp is the Schema for the hcpvaultsecretsapps API
+    - description: "HCPVaultSecretsApp is the Schema for the hcpvaultsecretsapps API
+        \n Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+        and will be removed in a future release of the Vault Secrets Operator. Migrate
+        off HCP Vault Secrets before upgrading to the removal release."
       displayName: HCPVault Secrets App
       kind: HCPVaultSecretsApp
       name: hcpvaultsecretsapps.secrets.hashicorp.com

--- a/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
@@ -83,22 +83,18 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: |-
-        HCPAuth is the Schema for the hcpauths API
-
-        Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
-        removed in a future release of the Vault Secrets Operator. Migrate off HCP
-        Vault Secrets before upgrading to the removal release.
+    - description: "HCPAuth is the Schema for the hcpauths API \n Deprecated: HCPAuth
+        and HCP Vault Secrets support are deprecated and will be removed in a future
+        release of the Vault Secrets Operator. Migrate off HCP Vault Secrets before
+        upgrading to the removal release."
       displayName: HCPAuth
       kind: HCPAuth
       name: hcpauths.secrets.hashicorp.com
       version: v1beta1
-    - description: |-
-        HCPVaultSecretsApp is the Schema for the hcpvaultsecretsapps API
-
-        Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+    - description: "HCPVaultSecretsApp is the Schema for the hcpvaultsecretsapps API
+        \n Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
         and will be removed in a future release of the Vault Secrets Operator. Migrate
-        off HCP Vault Secrets before upgrading to the removal release.
+        off HCP Vault Secrets before upgrading to the removal release."
       displayName: HCPVault Secrets App
       kind: HCPVaultSecretsApp
       name: hcpvaultsecretsapps.secrets.hashicorp.com

--- a/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/vault-secrets-operator.clusterserviceversion.yaml
@@ -83,18 +83,22 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: "HCPAuth is the Schema for the hcpauths API \n Deprecated: HCPAuth
-        and HCP Vault Secrets support are deprecated and will be removed in a future
-        release of the Vault Secrets Operator. Migrate off HCP Vault Secrets before
-        upgrading to the removal release."
+    - description: |-
+        HCPAuth is the Schema for the hcpauths API
+
+        Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+        removed in a future release of the Vault Secrets Operator. Migrate off HCP
+        Vault Secrets before upgrading to the removal release.
       displayName: HCPAuth
       kind: HCPAuth
       name: hcpauths.secrets.hashicorp.com
       version: v1beta1
-    - description: "HCPVaultSecretsApp is the Schema for the hcpvaultsecretsapps API
-        \n Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+    - description: |-
+        HCPVaultSecretsApp is the Schema for the hcpvaultsecretsapps API
+
+        Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
         and will be removed in a future release of the Vault Secrets Operator. Migrate
-        off HCP Vault Secrets before upgrading to the removal release."
+        off HCP Vault Secrets before upgrading to the removal release.
       displayName: HCPVault Secrets App
       kind: HCPVaultSecretsApp
       name: hcpvaultsecretsapps.secrets.hashicorp.com

--- a/consts/reasons.go
+++ b/consts/reasons.go
@@ -43,4 +43,5 @@ const (
 	ReasonHealthy                       = "Healthy"
 	ReasonUnhealthy                     = "Unhealthy"
 	ReasonReady                         = "Ready"
+	ReasonDeprecated                    = "Deprecated"
 )

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -163,6 +163,16 @@ func RemoveAllFinalizers(ctx context.Context, c client.Client, log logr.Logger) 
 		log.Error(err, "Unable to list VaultPKISecret resources")
 	}
 	removeFinalizers(ctx, c, log, vpkiList)
+
+	// HCPVaultSecretsApp is deprecated. This cleanup is included so that its
+	// finalizer does not go stale and block deletion once the controller is
+	// removed in a future release.
+	hvsaList := &secretsv1beta1.HCPVaultSecretsAppList{}
+	err = c.List(ctx, hvsaList, opts...)
+	if err != nil {
+		log.Error(err, "Unable to list HCPVaultSecretsApp resources")
+	}
+	removeFinalizers(ctx, c, log, hvsaList)
 	return nil
 }
 
@@ -209,6 +219,16 @@ func removeFinalizers(ctx context.Context, c client.Client, log logr.Logger, obj
 				log.Info(fmt.Sprintf("Updating finalizer for DynamicSecret %s", x.Name))
 				if err := c.Update(ctx, &x, &client.UpdateOptions{}); err != nil {
 					log.Error(err, fmt.Sprintf("Unable to update finalizer for %s: %s", vaultDynamicSecretFinalizer, x.Name))
+				}
+			}
+		}
+	case *secretsv1beta1.HCPVaultSecretsAppList:
+		for _, x := range t.Items {
+			cnt++
+			if controllerutil.RemoveFinalizer(&x, hcpVaultSecretsAppFinalizer) {
+				log.Info(fmt.Sprintf("Updating finalizer for HCPVaultSecretsApp %s", x.Name))
+				if err := c.Update(ctx, &x, &client.UpdateOptions{}); err != nil {
+					log.Error(err, fmt.Sprintf("Unable to update finalizer for %s: %s", hcpVaultSecretsAppFinalizer, x.Name))
 				}
 			}
 		}

--- a/controllers/hcpauth_controller.go
+++ b/controllers/hcpauth_controller.go
@@ -11,21 +11,29 @@ import (
 	"time"
 
 	hvsclient "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
+	"github.com/hashicorp/vault-secrets-operator/consts"
 	"github.com/hashicorp/vault-secrets-operator/internal/metrics"
 )
 
 // HCPAuthReconciler reconciles a HCPAuth object
+//
+// Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+// removed in a future release of the Vault Secrets Operator. Migrate off HCP
+// Vault Secrets before upgrading to the removal release.
 type HCPAuthReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=secrets.hashicorp.com,resources=hcpauths,verbs=get;list;watch;create;update;patch;delete
@@ -36,6 +44,9 @@ type HCPAuthReconciler struct {
 
 // Reconcile validates the HCPAuth CR instance, updating the instance's status
 // with the result.
+//
+// Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+// removed in a future release of the Vault Secrets Operator.
 func (r *HCPAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -53,6 +64,16 @@ func (r *HCPAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		logger.Info("Got deletion timestamp", "obj", o)
 		metrics.DeleteResourceStatus("hcpauth", o)
 		return ctrl.Result{}, nil
+	}
+
+	logger.Info("HCPAuth is deprecated and will be removed in a future release of " +
+		"the Vault Secrets Operator; migrate off HCP Vault Secrets before upgrading " +
+		"to the removal release")
+	if r.Recorder != nil {
+		r.Recorder.Event(o, corev1.EventTypeWarning, consts.ReasonDeprecated,
+			"HCPAuth is deprecated and will be removed in a future release of the "+
+				"Vault Secrets Operator; migrate off HCP Vault Secrets before upgrading "+
+				"to the removal release")
 	}
 
 	// perform a rudimentary health check on the HCP host on port 443.
@@ -101,6 +122,9 @@ func (r *HCPAuthReconciler) updateStatus(ctx context.Context, a *secretsv1beta1.
 }
 
 // SetupWithManager sets up the controller with the Manager.
+//
+// Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+// removed in a future release of the Vault Secrets Operator.
 func (r *HCPAuthReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&secretsv1beta1.HCPAuth{}).

--- a/controllers/hcpauth_controller.go
+++ b/controllers/hcpauth_controller.go
@@ -69,12 +69,10 @@ func (r *HCPAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	logger.Info("HCPAuth is deprecated and will be removed in a future release of " +
 		"the Vault Secrets Operator; migrate off HCP Vault Secrets before upgrading " +
 		"to the removal release")
-	if r.Recorder != nil {
-		r.Recorder.Event(o, corev1.EventTypeWarning, consts.ReasonDeprecated,
-			"HCPAuth is deprecated and will be removed in a future release of the "+
-				"Vault Secrets Operator; migrate off HCP Vault Secrets before upgrading "+
-				"to the removal release")
-	}
+	r.Recorder.Event(o, corev1.EventTypeWarning, consts.ReasonDeprecated,
+		"HCPAuth is deprecated and will be removed in a future release of the "+
+			"Vault Secrets Operator; migrate off HCP Vault Secrets before upgrading "+
+			"to the removal release")
 
 	// perform a rudimentary health check on the HCP host on port 443.
 	conn, err := net.DialTimeout("tcp",

--- a/controllers/hcpvaultsecretsapp_controller.go
+++ b/controllers/hcpvaultsecretsapp_controller.go
@@ -75,6 +75,10 @@ var (
 )
 
 // HCPVaultSecretsAppReconciler reconciles a HCPVaultSecretsApp object
+//
+// Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+// and will be removed in a future release of the Vault Secrets Operator.
+// Migrate off HCP Vault Secrets before upgrading to the removal release.
 type HCPVaultSecretsAppReconciler struct {
 	client.Client
 	Scheme                      *runtime.Scheme
@@ -103,6 +107,9 @@ type HCPVaultSecretsAppReconciler struct {
 // Reconcile a secretsv1beta1.HCPVaultSecretsApp Custom Resource instance. Each
 // invocation will ensure that the configured HCP Vault Secrets Application data
 // is synced to the configured K8s Secret.
+//
+// Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+// and will be removed in a future release of the Vault Secrets Operator.
 func (r *HCPVaultSecretsAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -120,6 +127,14 @@ func (r *HCPVaultSecretsAppReconciler) Reconcile(ctx context.Context, req ctrl.R
 		logger.Info("Got deletion timestamp", "obj", o)
 		return ctrl.Result{}, r.handleDeletion(ctx, o)
 	}
+
+	logger.Info("HCPVaultSecretsApp is deprecated and will be removed in a future " +
+		"release of the Vault Secrets Operator; migrate off HCP Vault Secrets before " +
+		"upgrading to the removal release")
+	r.Recorder.Event(o, corev1.EventTypeWarning, consts.ReasonDeprecated,
+		"HCPVaultSecretsApp is deprecated and will be removed in a future release of "+
+			"the Vault Secrets Operator; migrate off HCP Vault Secrets before upgrading "+
+			"to the removal release")
 
 	var requeueAfter time.Duration
 	if o.Spec.RefreshAfter != "" {
@@ -298,6 +313,9 @@ func (r *HCPVaultSecretsAppReconciler) updateStatus(ctx context.Context, o *secr
 }
 
 // SetupWithManager sets up the controller with the Manager.
+//
+// Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+// and will be removed in a future release of the Vault Secrets Operator.
 func (r *HCPVaultSecretsAppReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	r.referenceCache = NewResourceReferenceCache()
 	if r.BackOffRegistry == nil {

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -29,6 +29,9 @@ var ProviderMethodsSupported = []string{
 
 // NewCredentialProvider returns a new provider.CredentialProviderBase instance
 // for the given object. It supports objects of type VaultAuth and HCPAuth.
+//
+// Deprecated: support for HCPAuth objects is deprecated and will be removed in a
+// future release of the Vault Secrets Operator.
 func NewCredentialProvider(ctx context.Context, client client.Client, obj client.Object, providerNamespace string) (provider.CredentialProviderBase, error) {
 	var p provider.CredentialProviderBase
 	switch authObj := obj.(type) {

--- a/credentials/hcp/provider.go
+++ b/credentials/hcp/provider.go
@@ -12,6 +12,10 @@ import (
 	"github.com/hashicorp/vault-secrets-operator/credentials/provider"
 )
 
+// CredentialProviderHCP provides credentials for authenticating to HCP.
+//
+// Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+// future release of the Vault Secrets Operator.
 type CredentialProviderHCP interface {
 	provider.CredentialProviderBase
 	Init(context.Context, client.Client, *v1beta1.HCPAuth, string) error

--- a/credentials/hcp/service_principal.go
+++ b/credentials/hcp/service_principal.go
@@ -28,6 +28,9 @@ var _ CredentialProviderHCP = (*ServicePrincipleCredentialProvider)(nil)
 // ServicePrincipleCredentialProvider provides credentials for authenticating to
 // HCP using a service principal. For security reasons, only project-level
 // service principals should ever be used.
+//
+// Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+// future release of the Vault Secrets Operator.
 type ServicePrincipleCredentialProvider struct {
 	authObj           *secretsv1beta1.HCPAuth
 	providerNamespace string

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -179,6 +179,10 @@ _Appears in:_
 
 HCPAuth is the Schema for the hcpauths API
 
+Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+removed in a future release of the Vault Secrets Operator. Migrate off HCP
+Vault Secrets before upgrading to the removal release.
+
 
 
 _Appears in:_
@@ -197,6 +201,10 @@ _Appears in:_
 
 
 HCPAuthList contains a list of HCPAuth
+
+Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+removed in a future release of the Vault Secrets Operator. Migrate off HCP
+Vault Secrets before upgrading to the removal release.
 
 
 
@@ -217,6 +225,10 @@ HCPAuthList contains a list of HCPAuth
 HCPAuthServicePrincipal provides HCPAuth configuration options needed for
 authenticating to HCP using a service principal configured in SecretRef.
 
+Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+removed in a future release of the Vault Secrets Operator. Migrate off HCP
+Vault Secrets before upgrading to the removal release.
+
 
 
 _Appears in:_
@@ -232,6 +244,10 @@ _Appears in:_
 
 
 HCPAuthSpec defines the desired state of HCPAuth
+
+Deprecated: HCPAuth and HCP Vault Secrets support are deprecated and will be
+removed in a future release of the Vault Secrets Operator. Migrate off HCP
+Vault Secrets before upgrading to the removal release.
 
 
 
@@ -255,6 +271,10 @@ _Appears in:_
 
 HCPVaultSecretsApp is the Schema for the hcpvaultsecretsapps API
 
+Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+and will be removed in a future release of the Vault Secrets Operator.
+Migrate off HCP Vault Secrets before upgrading to the removal release.
+
 
 
 _Appears in:_
@@ -274,6 +294,10 @@ _Appears in:_
 
 HCPVaultSecretsAppList contains a list of HCPVaultSecretsApp
 
+Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+and will be removed in a future release of the Vault Secrets Operator.
+Migrate off HCP Vault Secrets before upgrading to the removal release.
+
 
 
 
@@ -291,6 +315,10 @@ HCPVaultSecretsAppList contains a list of HCPVaultSecretsApp
 
 
 HCPVaultSecretsAppSpec defines the desired state of HCPVaultSecretsApp
+
+Deprecated: HCPVaultSecretsApp and HCP Vault Secrets support are deprecated
+and will be removed in a future release of the Vault Secrets Operator.
+Migrate off HCP Vault Secrets before upgrading to the removal release.
 
 
 
@@ -316,6 +344,9 @@ _Appears in:_
 HVSDynamicStatus defines the observed state of a dynamic secret within an HCP
 Vault Secrets App
 
+Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+future release of the Vault Secrets Operator.
+
 
 
 _Appears in:_
@@ -335,6 +366,9 @@ _Appears in:_
 
 HVSDynamicSyncConfig configures sync behavior for HVS dynamic secrets.
 
+Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+future release of the Vault Secrets Operator.
+
 
 
 _Appears in:_
@@ -350,6 +384,9 @@ _Appears in:_
 
 
 HVSSyncConfig configures sync behavior from HVS to VSO
+
+Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+future release of the Vault Secrets Operator.
 
 
 

--- a/helpers/rollout_restart.go
+++ b/helpers/rollout_restart.go
@@ -25,7 +25,8 @@ import (
 const AnnotationRestartedAt = "vso.secrets.hashicorp.com/restartedAt"
 
 // HandleRolloutRestarts for all v1beta1.RolloutRestartTarget(s) configured for obj.
-// Supported objs are: v1beta1.VaultDynamicSecret, v1beta1.VaultStaticSecret, v1beta1.VaultPKISecret
+// Supported objs are: v1beta1.VaultDynamicSecret, v1beta1.VaultStaticSecret,
+// v1beta1.VaultPKISecret, v1beta1.HCPVaultSecretsApp (deprecated)
 // Please note the following:
 // - a rollout-restart will be triggered for each configured v1beta1.RolloutRestartTarget
 // - the rollout-restart action has no support for roll-back

--- a/helpers/secrets.go
+++ b/helpers/secrets.go
@@ -30,7 +30,13 @@ import (
 )
 
 const (
-	SecretDataKeyRaw      = "_raw"
+	SecretDataKeyRaw = "_raw"
+
+	// HVSSecretTypeKV, HVSSecretTypeRotating, and HVSSecretTypeDynamic are the
+	// HVS secret type identifiers.
+	//
+	// Deprecated: HCP Vault Secrets support is deprecated and will be removed in
+	// a future release of the Vault Secrets Operator.
 	HVSSecretTypeKV       = "kv"
 	HVSSecretTypeRotating = "rotating"
 	HVSSecretTypeDynamic  = "dynamic"
@@ -535,6 +541,9 @@ func marshalJSON(value any) ([]byte, error) {
 
 // WithHVSAppSecrets returns the K8s Secret data from HCP Vault Secrets App. This
 // method must always return a non-nil data map to avoid HMAC calculation issues.
+//
+// Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+// future release of the Vault Secrets Operator.
 func (s *SecretDataBuilder) WithHVSAppSecrets(resp *hvsclient.OpenAppSecretsOK, opt *SecretTransformationOption) (map[string][]byte, error) {
 	if opt == nil {
 		opt = &SecretTransformationOption{}
@@ -711,6 +720,9 @@ func NewSecretsDataBuilder() *SecretDataBuilder {
 
 // MakeHVSShadowSecretData converts a list of HVS OpenSecrets to k8s secret
 // data. Only dynamic secrets are included.
+//
+// Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+// future release of the Vault Secrets Operator.
 func MakeHVSShadowSecretData(secrets []*models.Secrets20231128OpenSecret) (map[string][]byte, error) {
 	data := make(map[string][]byte)
 	for _, v := range secrets {
@@ -728,6 +740,9 @@ func MakeHVSShadowSecretData(secrets []*models.Secrets20231128OpenSecret) (map[s
 }
 
 // FromHVSShadowSecret converts a k8s secret data entry to an HVS OpenSecret.
+//
+// Deprecated: HCP Vault Secrets support is deprecated and will be removed in a
+// future release of the Vault Secrets Operator.
 func FromHVSShadowSecret(data []byte) (*models.Secrets20231128OpenSecret, error) {
 	secret := &models.Secrets20231128OpenSecret{}
 	if err := secret.UnmarshalBinary(data); err != nil {

--- a/main.go
+++ b/main.go
@@ -601,8 +601,9 @@ func main() {
 	}()
 
 	if err = (&controllers.HCPAuthReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("HCPAuth"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HCPAuth")
 		os.Exit(1)


### PR DESCRIPTION
Marking as deprecated all HCPAuth and HCP Vault secrets functions along the CRDs associated with them, since HCP Vault Secrets is being sunset on 1st July, 2026, along with adding a temporary path where users can remove existing finalizers which are using HCPVaultSecretsApp.
Also added deprecation warnings in the documentation and a runtime warning event on every Reconcile in HCPVaultSecretsApp and HCPAuth.

There will be a subsequent release where we remove the functions and the related CRDs themselves .

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
