### PR TITLE
Perf: Optimize Scale testing Infra for VDS.

### DIFF
--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -1519,9 +1519,9 @@ func setupInstantUpdatesInfra(t *testing.T, namePrefix string, dbLeaseTTL int) (
 //
 // Infrastructure is provisioned ONCE in the parent test (one Terraform apply,
 // one postgres pod, one Vault DB mount) and shared across all N parallel
-// subtests — mirroring the VSS events-both scale test pattern. This eliminates
-// the thundering-herd of N concurrent terraform applies that previously
-// saturated the kubectl port-forward (N×9 connections) and the EKS API server.
+// subtests. This eliminates the thundering-herd of N concurrent terraform
+// applies that previously saturated the kubectl port-forward
+// (N×9 connections) and the EKS API server.
 //
 // Each subtest creates its own VaultDynamicSecret CR (uniquely named) inside
 // the shared K8s/Vault namespace, all pointing at the same Vault static role.
@@ -1747,10 +1747,20 @@ func TestVaultDynamicSecret_InstantUpdates(t *testing.T) {
 // near-instant credential rotation when a lease is revoked, driven by WebSocket lease
 // events rather than polling.
 //
-// When VDS_EVENTS_DYNAMIC_CREATE is set (or VDS_CREATE_COUNT as a fallback), N
-// parallel subtests are run — each with its own isolated Terraform stack — to
-// exercise the shared-WebSocket lease subscriber multiplexing under load. When
-// neither env var is set the test behaves exactly as before: a single subtest.
+// Infrastructure is provisioned ONCE in the parent test (one Terraform apply, one
+// postgres pod, one Vault DB mount) and shared across all N parallel subtests.
+// This eliminates the thundering-herd of N concurrent terraform applies that
+// previously saturated the kubectl port-forward and the EKS API server.
+//
+// Each subtest creates its own VaultDynamicSecret CR (uniquely named) pointing at
+// the same shared dynamic DB role. Every VDS gets its own independent lease from
+// Vault; each subtest revokes only its own lease, which triggers a lease* WebSocket
+// event that the SharedWebSocket fans out to all N subscribers — exactly the lease
+// event multiplexing behaviour being tested.
+//
+// The count of parallel subtests is controlled by VDS_EVENTS_DYNAMIC_CREATE
+// (or VDS_CREATE_COUNT as a fallback). When neither is set, a single subtest
+// runs, preserving the original non-scale behaviour.
 func TestVaultDynamicSecret_InstantUpdates_DynamicCreds(t *testing.T) {
 	if testInParallel {
 		t.Parallel()
@@ -1785,6 +1795,41 @@ func TestVaultDynamicSecret_InstantUpdates_DynamicCreds(t *testing.T) {
 		count = v
 	}
 
+	// Provision infrastructure ONCE in the parent — one terraform apply for all
+	// subtests. Cleanup is registered on the parent t so it runs after all
+	// subtests finish (Go t.Cleanup is LIFO within the same *testing.T).
+	tfOptions, outputs := setupInstantUpdatesInfra(t, "vds-events-dynamic", 600)
+
+	ctx := context.Background()
+	crdClient := getCRDClient(t)
+
+	// One shared VaultAuth for all subtests. Registered for cleanup on the
+	// parent t so it is deleted before terraform destroy (LIFO order ensures
+	// subtest CR cleanups run first, then this, then terraform destroy).
+	vaultAuthName := outputs.NamePrefix + "-default"
+	vaultAuth := &secretsv1beta1.VaultAuth{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      vaultAuthName,
+			Namespace: outputs.K8sNamespace,
+		},
+		Spec: secretsv1beta1.VaultAuthSpec{
+			Namespace: outputs.Namespace,
+			Method:    "kubernetes",
+			Mount:     outputs.AuthMount,
+			Kubernetes: &secretsv1beta1.VaultAuthConfigKubernetes{
+				Role:           outputs.AuthRole,
+				ServiceAccount: "default",
+				TokenAudiences: []string{"vault"},
+			},
+		},
+	}
+	require.NoError(t, crdClient.Create(ctx, vaultAuth))
+	t.Cleanup(func() {
+		if os.Getenv("SKIP_CLEANUP") == "" {
+			assert.NoError(t, crdClient.Delete(ctx, vaultAuth))
+		}
+	})
+
 	for i := 0; i < count; i++ {
 		i := i
 		t.Run(fmt.Sprintf("dynamic-%d", i), func(t *testing.T) {
@@ -1793,32 +1838,10 @@ func TestVaultDynamicSecret_InstantUpdates_DynamicCreds(t *testing.T) {
 			ctx := context.Background()
 			crdClient := getCRDClient(t)
 
-			tfOptions, outputs := setupInstantUpdatesInfra(t, fmt.Sprintf("vds-events-dynamic-%d", i), 600)
-
-			vaultAuthName := outputs.NamePrefix + "-default"
-			vaultAuth := &secretsv1beta1.VaultAuth{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      vaultAuthName,
-					Namespace: outputs.K8sNamespace,
-				},
-				Spec: secretsv1beta1.VaultAuthSpec{
-					Namespace: outputs.Namespace,
-					Method:    "kubernetes",
-					Mount:     outputs.AuthMount,
-					Kubernetes: &secretsv1beta1.VaultAuthConfigKubernetes{
-						Role:           outputs.AuthRole,
-						ServiceAccount: "default",
-						TokenAudiences: []string{"vault"},
-					},
-				},
-			}
-			require.NoError(t, crdClient.Create(ctx, vaultAuth))
-			t.Cleanup(func() {
-				if os.Getenv("SKIP_CLEANUP") == "" {
-					assert.NoError(t, crdClient.Delete(ctx, vaultAuth))
-				}
-			})
-
+			// Each subtest gets a uniquely named VDS CR pointing at the same
+			// shared dynamic DB role. Vault issues a distinct lease per CR;
+			// each subtest revokes only its own lease, which emits a lease*
+			// event that the SharedWebSocket fans out to all N subscribers.
 			destName := fmt.Sprintf("vds-instant-updates-dynamic-%d", i)
 			vdsObj := &secretsv1beta1.VaultDynamicSecret{
 				ObjectMeta: v1.ObjectMeta{
@@ -1891,8 +1914,9 @@ func TestVaultDynamicSecret_InstantUpdates_DynamicCreds(t *testing.T) {
 				return nil
 			}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 60)))
 
-			// Revoke the active lease. Vault emits a lease* event, which the WebSocket
-			// subscription should pick up and trigger an immediate reconciliation.
+			// Revoke this VDS's own lease. Vault emits a lease* event for that
+			// specific lease ID, which the WebSocket subscription picks up and
+			// triggers an immediate reconciliation for this CR only.
 			vClient := getVaultClient(t, outputs.Namespace)
 			require.NoError(t, vClient.Sys().Revoke(vdsBefore.Status.SecretLease.ID),
 				"failed to revoke lease %s", vdsBefore.Status.SecretLease.ID)

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -1699,8 +1699,15 @@ func TestVaultDynamicSecret_InstantUpdates(t *testing.T) {
 				"ttl",
 			)
 
-			// Capture the VDS status before rotation so we can detect changes.
+			// Confirm the WebSocket subscription is active before snapshotting
+			// vdsBefore, so the baseline is taken as close to our own
+			// rotate-role call as possible.
 			objKey := ctrlclient.ObjectKeyFromObject(vdsObj)
+			awaitEventWatcherStarted(t, ctx, crdClient, vdsObj)
+
+			// Snapshot immediately before rotation to minimise the window where
+			// a concurrent subtest's rotate-role could have already updated
+			// LastVaultRotation and staled this baseline.
 			var vdsBefore secretsv1beta1.VaultDynamicSecret
 			require.NoError(t, backoff.Retry(func() error {
 				if err := crdClient.Get(ctx, objKey, &vdsBefore); err != nil {
@@ -1714,10 +1721,6 @@ func TestVaultDynamicSecret_InstantUpdates(t *testing.T) {
 				}
 				return nil
 			}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 60)))
-
-			// Wait for the EventWatcherStarted event, confirming the WebSocket
-			// subscription is active before triggering the rotation.
-			awaitEventWatcherStarted(t, ctx, crdClient, vdsObj)
 
 			// Force-rotate the static database role in Vault. This emits a
 			// database* event that the SharedWebSocket fans out to all N

--- a/test/integration/vaultdynamicsecret_integration_test.go
+++ b/test/integration/vaultdynamicsecret_integration_test.go
@@ -1517,10 +1517,20 @@ func setupInstantUpdatesInfra(t *testing.T, namePrefix string, dbLeaseTTL int) (
 // by WebSocket events rather than polling. It covers static role credentials
 // (database* events).
 //
-// When VDS_EVENTS_STATIC_CREATE is set (or VDS_CREATE_COUNT as a fallback), N
-// parallel subtests are run — each with its own isolated Terraform stack — to
-// exercise the shared-WebSocket subscriber multiplexing under load. When neither
-// env var is set the test behaves exactly as before: a single subtest.
+// Infrastructure is provisioned ONCE in the parent test (one Terraform apply,
+// one postgres pod, one Vault DB mount) and shared across all N parallel
+// subtests — mirroring the VSS events-both scale test pattern. This eliminates
+// the thundering-herd of N concurrent terraform applies that previously
+// saturated the kubectl port-forward (N×9 connections) and the EKS API server.
+//
+// Each subtest creates its own VaultDynamicSecret CR (uniquely named) inside
+// the shared K8s/Vault namespace, all pointing at the same Vault static role.
+// A single rotate-role call therefore fans out via the SharedWebSocket to all N
+// subscribers simultaneously — exactly the multiplexing behaviour being tested.
+//
+// The count of parallel subtests is controlled by VDS_EVENTS_STATIC_CREATE
+// (or VDS_CREATE_COUNT as a fallback). When neither is set, a single subtest
+// runs, preserving the original non-scale behaviour.
 func TestVaultDynamicSecret_InstantUpdates(t *testing.T) {
 	if testInParallel {
 		t.Parallel()
@@ -1550,6 +1560,41 @@ func TestVaultDynamicSecret_InstantUpdates(t *testing.T) {
 		count = v
 	}
 
+	// Provision infrastructure ONCE in the parent — one terraform apply for all
+	// subtests. Cleanup is registered on the parent t so it runs after all
+	// subtests finish (Go t.Cleanup is LIFO within the same *testing.T).
+	tfOptions, outputs := setupInstantUpdatesInfra(t, "vds-events", 600)
+
+	ctx := context.Background()
+	crdClient := getCRDClient(t)
+
+	// One shared VaultAuth for all subtests. Registered for cleanup on the
+	// parent t so it is deleted before terraform destroy (LIFO order ensures
+	// subtest CR cleanups run first, then this, then terraform destroy).
+	vaultAuthName := outputs.NamePrefix + "-default"
+	vaultAuth := &secretsv1beta1.VaultAuth{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      vaultAuthName,
+			Namespace: outputs.K8sNamespace,
+		},
+		Spec: secretsv1beta1.VaultAuthSpec{
+			Namespace: outputs.Namespace,
+			Method:    "kubernetes",
+			Mount:     outputs.AuthMount,
+			Kubernetes: &secretsv1beta1.VaultAuthConfigKubernetes{
+				Role:           outputs.AuthRole,
+				ServiceAccount: "default",
+				TokenAudiences: []string{"vault"},
+			},
+		},
+	}
+	require.NoError(t, crdClient.Create(ctx, vaultAuth))
+	t.Cleanup(func() {
+		if os.Getenv("SKIP_CLEANUP") == "" {
+			assert.NoError(t, crdClient.Delete(ctx, vaultAuth))
+		}
+	})
+
 	for i := 0; i < count; i++ {
 		i := i
 		t.Run(fmt.Sprintf("static-%d", i), func(t *testing.T) {
@@ -1558,32 +1603,9 @@ func TestVaultDynamicSecret_InstantUpdates(t *testing.T) {
 			ctx := context.Background()
 			crdClient := getCRDClient(t)
 
-			tfOptions, outputs := setupInstantUpdatesInfra(t, fmt.Sprintf("vds-events-%d", i), 600)
-
-			vaultAuthName := outputs.NamePrefix + "-default"
-			vaultAuth := &secretsv1beta1.VaultAuth{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      vaultAuthName,
-					Namespace: outputs.K8sNamespace,
-				},
-				Spec: secretsv1beta1.VaultAuthSpec{
-					Namespace: outputs.Namespace,
-					Method:    "kubernetes",
-					Mount:     outputs.AuthMount,
-					Kubernetes: &secretsv1beta1.VaultAuthConfigKubernetes{
-						Role:           outputs.AuthRole,
-						ServiceAccount: "default",
-						TokenAudiences: []string{"vault"},
-					},
-				},
-			}
-			require.NoError(t, crdClient.Create(ctx, vaultAuth))
-			t.Cleanup(func() {
-				if os.Getenv("SKIP_CLEANUP") == "" {
-					assert.NoError(t, crdClient.Delete(ctx, vaultAuth))
-				}
-			})
-
+			// Each subtest gets a uniquely named VDS CR pointing at the same
+			// shared Vault static role. A single rotate-role call fans the
+			// database* event out to all N subscribers via SharedWebSocket.
 			destName := fmt.Sprintf("vds-instant-updates-static-%d", i)
 			vdsObj := &secretsv1beta1.VaultDynamicSecret{
 				ObjectMeta: v1.ObjectMeta{
@@ -1663,15 +1685,16 @@ func TestVaultDynamicSecret_InstantUpdates(t *testing.T) {
 				return nil
 			}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 60)))
 
-			// Force-rotate the static database role in Vault. This emits a database*
-			// event that the WebSocket subscription should pick up immediately.
+			// Force-rotate the static database role in Vault. This emits a
+			// database* event that the SharedWebSocket fans out to all N
+			// subscribed VDS CRs simultaneously.
 			vClient := getVaultClient(t, outputs.Namespace)
 			rotatePath := fmt.Sprintf("%s/rotate-role/%s", outputs.DBPath, outputs.DBRoleStatic)
 			_, err := vClient.Logical().WriteWithContext(ctx, rotatePath, nil)
 			require.NoError(t, err, "failed to force-rotate static role %s", outputs.DBRoleStatic)
 
-			// Assert the K8s secret is updated quickly (within ~30s) via the event-driven
-			// path, NOT the 1h RefreshAfter polling cadence.
+			// Assert the K8s secret is updated quickly (within ~30s) via the
+			// event-driven path, NOT the 1h RefreshAfter polling cadence.
 			require.NoError(t, backoff.Retry(func() error {
 				var vdsAfter secretsv1beta1.VaultDynamicSecret
 				if err := crdClient.Get(ctx, objKey, &vdsAfter); err != nil {


### PR DESCRIPTION
Eliminates the thundering-herd of N concurrent Terraform applies that previously saturated kubectl port-forward and the EKS API server during scale runs of the VDS instant-update tests. Infrastructure is now provisioned once per parent test and shared across all N parallel subtests.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
