### PR TITLE
Add support for linux/ppc64le (UBI only)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -207,7 +207,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["arm64", "amd64", "s390x", "ppc64le"]
+        arch: ["arm64", "amd64"]
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.get-product-version.outputs.product-version}}
@@ -219,7 +219,6 @@ jobs:
         run: |
           make ci-build-scripts-dir GOARCH="${{ matrix.arch }}"
       - name: Docker Build (Action)
-        if: ${{ matrix.arch != 's390x' && matrix.arch != 'ppc64le' }}
         uses: hashicorp/actions-docker-build@v2
         env:
           VERSION: ${{ needs.get-product-version.outputs.product-version }}
@@ -233,8 +232,39 @@ jobs:
             docker.io/hashicorp/${{env.repo}}:${{env.image_tag}}
             public.ecr.aws/hashicorp/${{env.repo}}:${{env.image_tag}}
             icr.io/cpopen/ibm-vault/${{env.repo}}:${{env.image_tag}}
-      - name: Docker Build (Action) s390x/ppc64le
-        if: ${{ matrix.arch == 's390x' || matrix.arch == 'ppc64le' }}
+      - name: Check binary version in container ${{ matrix.arch }}
+        shell: bash
+        run: |
+          version_output=$(docker run --platform linux/${{matrix.arch}} hashicorp/${{env.repo}}:${{env.image_tag}} --version --output=json)
+          echo $version_output
+          git_version=$(echo $version_output | jq -r .gitVersion)
+
+          if [ "$git_version" != "${{ env.version }}" ]; then
+            echo "$gitVersion expected to be ${{ env.version }}"
+            exit 1
+          fi
+
+  build-docker-ubi-ibm:
+    name: UBI IBM ${{ matrix.arch }} build
+    needs:
+      - get-product-version
+      - build-pre-checks
+      - build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["s390x", "ppc64le"]
+    env:
+      repo: ${{github.event.repository.name}}
+      version: ${{needs.get-product-version.outputs.product-version}}
+      image_tag: ${{needs.get-product-version.outputs.product-version}}-ubi
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup scripts directory
+        shell: bash
+        run: |
+          make ci-build-scripts-dir GOARCH="${{ matrix.arch }}"
+      - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v2
         env:
           VERSION: ${{ needs.get-product-version.outputs.product-version }}
@@ -246,18 +276,6 @@ jobs:
           redhat_tag: quay.io/redhat-isv-containers/64b072322e2773c28d30d988:${{env.image_tag}}
           tags: |
             icr.io/cpopen/ibm-vault/${{env.repo}}:${{env.image_tag}}
-      - name: Check binary version in container ${{ matrix.arch }}
-        if: ${{ matrix.arch != 's390x' && matrix.arch != 'ppc64le' }}
-        shell: bash
-        run: |
-          version_output=$(docker run --platform linux/${{matrix.arch}} hashicorp/${{env.repo}}:${{env.image_tag}} --version --output=json)
-          echo $version_output
-          git_version=$(echo $version_output | jq -r .gitVersion)
-
-          if [ "$git_version" != "${{ env.version }}" ]; then
-            echo "$gitVersion expected to be ${{ env.version }}"
-            exit 1
-          fi
 
   chart-upgrade-tests:
     runs-on: ubuntu-latest
@@ -452,6 +470,7 @@ jobs:
       - build
       - build-docker
       - build-docker-ubi
+      - build-docker-ubi-ibm
       - chart-upgrade-tests
       - unit-tests
       - latest-vault

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -233,21 +233,8 @@ jobs:
             docker.io/hashicorp/${{env.repo}}:${{env.image_tag}}
             public.ecr.aws/hashicorp/${{env.repo}}:${{env.image_tag}}
             icr.io/cpopen/ibm-vault/${{env.repo}}:${{env.image_tag}}
-      - name: Docker Build (Action) s390x
-        if: ${{ matrix.arch == 's390x' }}
-        uses: hashicorp/actions-docker-build@v2
-        env:
-          VERSION: ${{ needs.get-product-version.outputs.product-version }}
-          GO_VERSION: ${{ needs.build-pre-checks.outputs.go-version }}
-        with:
-          version: ${{env.version}}
-          target: release-ubi
-          arch: ${{matrix.arch}}
-          redhat_tag: quay.io/redhat-isv-containers/64b072322e2773c28d30d988:${{env.image_tag}}
-          tags: |
-            icr.io/cpopen/ibm-vault/${{env.repo}}:${{env.image_tag}}
-      - name: Docker Build (Action) ppc64le
-        if: ${{ matrix.arch == 'ppc64le' }}
+      - name: Docker Build (Action) s390x/ppc64le
+        if: ${{ matrix.arch == 's390x' || matrix.arch == 'ppc64le' }}
         uses: hashicorp/actions-docker-build@v2
         env:
           VERSION: ${{ needs.get-product-version.outputs.product-version }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["arm64", "amd64", "s390x"]
+        arch: ["arm64", "amd64", "s390x", "ppc64le"]
       fail-fast: true
     steps:
       - name: Checkout
@@ -207,7 +207,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["arm64", "amd64", "s390x"]
+        arch: ["arm64", "amd64", "s390x", "ppc64le"]
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.get-product-version.outputs.product-version}}
@@ -219,7 +219,7 @@ jobs:
         run: |
           make ci-build-scripts-dir GOARCH="${{ matrix.arch }}"
       - name: Docker Build (Action)
-        if: ${{ matrix.arch != 's390x' }}
+        if: ${{ matrix.arch != 's390x' && matrix.arch != 'ppc64le' }}
         uses: hashicorp/actions-docker-build@v2
         env:
           VERSION: ${{ needs.get-product-version.outputs.product-version }}
@@ -246,8 +246,21 @@ jobs:
           redhat_tag: quay.io/redhat-isv-containers/64b072322e2773c28d30d988:${{env.image_tag}}
           tags: |
             icr.io/cpopen/ibm-vault/${{env.repo}}:${{env.image_tag}}
+      - name: Docker Build (Action) ppc64le
+        if: ${{ matrix.arch == 'ppc64le' }}
+        uses: hashicorp/actions-docker-build@v2
+        env:
+          VERSION: ${{ needs.get-product-version.outputs.product-version }}
+          GO_VERSION: ${{ needs.build-pre-checks.outputs.go-version }}
+        with:
+          version: ${{env.version}}
+          target: release-ubi
+          arch: ${{matrix.arch}}
+          redhat_tag: quay.io/redhat-isv-containers/64b072322e2773c28d30d988:${{env.image_tag}}
+          tags: |
+            icr.io/cpopen/ibm-vault/${{env.repo}}:${{env.image_tag}}
       - name: Check binary version in container ${{ matrix.arch }}
-        if: ${{ matrix.arch != 's390x' }}
+        if: ${{ matrix.arch != 's390x' && matrix.arch != 'ppc64le' }}
         shell: bash
         run: |
           version_output=$(docker run --platform linux/${{matrix.arch}} hashicorp/${{env.repo}}:${{env.image_tag}} --version --output=json)

--- a/.release/vault-secrets-operator-artifacts.hcl
+++ b/.release/vault-secrets-operator-artifacts.hcl
@@ -7,6 +7,7 @@ artifacts {
     "vault-secrets-operator_${version}_linux_amd64.zip",
     "vault-secrets-operator_${version}_linux_arm64.zip",
     "vault-secrets-operator_${version}_linux_s390x.zip",
+    "vault-secrets-operator_${version}_linux_ppc64le.zip",
   ]
   container = [
     "vault-secrets-operator_release-default_linux_amd64_${version}_${commit_sha}.docker.tar",
@@ -14,8 +15,10 @@ artifacts {
     "vault-secrets-operator_release-ubi_linux_amd64_${version}_${commit_sha}.docker.redhat.tar",
     "vault-secrets-operator_release-ubi_linux_arm64_${version}_${commit_sha}.docker.redhat.tar",
     "vault-secrets-operator_release-ubi_linux_s390x_${version}_${commit_sha}.docker.redhat.tar",
+    "vault-secrets-operator_release-ubi_linux_ppc64le_${version}_${commit_sha}.docker.redhat.tar",
     "vault-secrets-operator_release-ubi_linux_amd64_${version}_${commit_sha}.docker.tar",
     "vault-secrets-operator_release-ubi_linux_arm64_${version}_${commit_sha}.docker.tar",
     "vault-secrets-operator_release-ubi_linux_s390x_${version}_${commit_sha}.docker.tar",
+    "vault-secrets-operator_release-ubi_linux_ppc64le_${version}_${commit_sha}.docker.tar",
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+Build:
+* Add `ppc64le` (IBM Power) architecture support: build and publish UBI-based images to `icr.io/cpopen/ibm-vault` and `quay.io/redhat-isv-containers` ([#1325](https://github.com/hashicorp/vault-secrets-operator/pull/1325))
+
 ## 1.5.0 (July 23rd, 2026)
 
 BREAKING CHANGES:


### PR DESCRIPTION
## Description

Adds `ppc64le` (IBM Power) architecture support to the Vault Secrets Operator
build and release pipeline. This enables VSO images to be built, pushed, and
distributed for `ppc64le` environments alongside the existing `amd64`, `arm64`,
and `s390x` architectures.

## Changes

### `.github/workflows/build.yaml`
- Added `ppc64le` to the binary build matrix (`build` job).
- Refactored UBI image building for IBM architectures into a dedicated
  `build-docker-ubi-ibm` job (matrix: `["s390x", "ppc64le"]`), separate from
  the existing `build-docker-ubi` job (matrix: `["arm64", "amd64"]`). This
  removes the need for per-step `if:` conditionals in the shared job.
- `build-docker-ubi` now runs unconditionally for `arm64`/`amd64`, including
  the binary version verification step.
- `build-docker-ubi-ibm` publishes images only to
  `icr.io/cpopen/ibm-vault/` and `quay.io/redhat-isv-containers` (no Docker
  Hub / ECR), with no binary version check (cross-arch execution is not
  supported on the GitHub Actions runner).
- Added `build-docker-ubi-ibm` to the `build-done` gate job's `needs:` list.

### `.release/vault-secrets-operator-artifacts.hcl`
- Registered the `ppc64le` binary zip artifact:
  `vault-secrets-operator_${version}_linux_ppc64le.zip`.
- Registered the `ppc64le` UBI-based Docker tarballs:
  - `vault-secrets-operator_release-ubi_linux_ppc64le_${version}_${commit_sha}.docker.redhat.tar`
  - `vault-secrets-operator_release-ubi_linux_ppc64le_${version}_${commit_sha}.docker.tar`

## Why

IBM Power (`ppc64le`) is a platform used in enterprise and regulated
environments, including OpenShift on IBM Power. This change extends VSO's
multi-arch support to include `ppc64le` so it can be deployed natively on those
platforms without emulation.

## Testing

- `ppc64le` UBI image is manually tested in an OCP cluster and all integration
  tests passed.
- Binary version verification is intentionally skipped for `ppc64le` (consistent
  with `s390x` treatment) as the GitHub Actions runner cannot execute
  cross-architecture Docker containers natively.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
