### PR TITLE
Support Vault auth response data in defaultResponse

### DIFF
--- a/vault/responses.go
+++ b/vault/responses.go
@@ -31,6 +31,25 @@ type defaultResponse struct {
 	secret *api.Secret
 }
 
+// authAsData converts secret.Auth into a map[string]any via JSON roundtrip.
+// Vault endpoints like auth/token/create return data in the "auth" field
+// instead of "data", so this allows those responses to be consumed as
+// standard secret data.
+func (r *defaultResponse) authAsData() map[string]any {
+	if r.secret == nil || r.secret.Auth == nil {
+		return nil
+	}
+	b, err := json.Marshal(r.secret.Auth)
+	if err != nil {
+		return nil
+	}
+	var d map[string]any
+	if err := json.Unmarshal(b, &d); err != nil {
+		return nil
+	}
+	return d
+}
+
 func (r *defaultResponse) WrapInfo() *api.SecretWrapInfo {
 	if r.secret != nil {
 		return r.secret.WrapInfo
@@ -42,6 +61,9 @@ func (r *defaultResponse) SecretK8sData(opt *helpers.SecretTransformationOption)
 	var rawData map[string]interface{}
 	if r.secret != nil {
 		rawData = r.secret.Data
+		if rawData == nil {
+			rawData = r.authAsData()
+		}
 	}
 
 	var wrapData map[string]any
@@ -67,7 +89,11 @@ func (r *defaultResponse) Data() map[string]any {
 		return nil
 	}
 
-	return r.secret.Data
+	if r.secret.Data != nil {
+		return r.secret.Data
+	}
+
+	return r.authAsData()
 }
 
 type kvV1Response struct {

--- a/vault/responses_test.go
+++ b/vault/responses_test.go
@@ -99,6 +99,46 @@ func Test_defaultResponse_Data(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "auth-fallback-nil-data",
+			respFunc: respFunc,
+			secret: &api.Secret{
+				Auth: &api.SecretAuth{
+					ClientToken: "s.abc123",
+					Accessor:    "accessor-xyz",
+					Policies:    []string{"default", "prometheus"},
+					Renewable:   true,
+				},
+			},
+			want: map[string]interface{}{
+				"client_token":      "s.abc123",
+				"accessor":          "accessor-xyz",
+				"policies":          []interface{}{"default", "prometheus"},
+				"renewable":         true,
+				"lease_duration":    float64(0),
+				"token_policies":    interface{}(nil),
+				"identity_policies": interface{}(nil),
+				"metadata":          interface{}(nil),
+				"entity_id":         "",
+				"orphan":            false,
+				"mfa_requirement":   interface{}(nil),
+			},
+		},
+		{
+			name:     "data-takes-precedence-over-auth",
+			respFunc: respFunc,
+			secret: &api.Secret{
+				Data: map[string]interface{}{
+					"key": "from-data",
+				},
+				Auth: &api.SecretAuth{
+					ClientToken: "s.abc123",
+				},
+			},
+			want: map[string]interface{}{
+				"key": "from-data",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -228,6 +268,68 @@ func Test_defaultResponse_SecretK8sData(t *testing.T) {
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.EqualError(t, err, "json: unsupported type: chan int")
 			},
+		},
+		{
+			name:     "auth-fallback-token-create",
+			respFunc: respFunc,
+			secret: &api.Secret{
+				Auth: &api.SecretAuth{
+					ClientToken: "s.abc123",
+					Accessor:    "accessor-xyz",
+					Renewable:   true,
+				},
+			},
+			want: map[string][]byte{
+				"client_token":      []byte("s.abc123"),
+				"accessor":          []byte("accessor-xyz"),
+				"renewable":         []byte("true"),
+				"orphan":            []byte("false"),
+				"lease_duration":    []byte("0"),
+				"entity_id":         []byte(""),
+				"policies":          []byte(`null`),
+				"token_policies":    []byte(`null`),
+				"identity_policies": []byte(`null`),
+				"metadata":          []byte(`null`),
+				"mfa_requirement":   []byte(`null`),
+				helpers.SecretDataKeyRaw: []byte(`{"accessor":"accessor-xyz","client_token":"s.abc123","entity_id":"","identity_policies":null,"lease_duration":0,"metadata":null,"mfa_requirement":null,"orphan":false,"policies":null,"renewable":true,"token_policies":null}`),
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name:     "auth-fallback-with-template",
+			respFunc: respFunc,
+			secret: &api.Secret{
+				Auth: &api.SecretAuth{
+					ClientToken: "s.abc123",
+				},
+			},
+			opt: &helpers.SecretTransformationOption{
+				KeyedTemplates: []*helpers.KeyedTemplate{
+					{
+						Key: "token",
+						Template: secretsv1beta1.Template{
+							Name: "tmpl1",
+							Text: `{{ get .Secrets "client_token" }}`,
+						},
+					},
+				},
+			},
+			want: map[string][]byte{
+				"client_token":      []byte("s.abc123"),
+				"accessor":          []byte(""),
+				"renewable":         []byte("false"),
+				"orphan":            []byte("false"),
+				"lease_duration":    []byte("0"),
+				"entity_id":         []byte(""),
+				"policies":          []byte(`null`),
+				"token_policies":    []byte(`null`),
+				"identity_policies": []byte(`null`),
+				"metadata":          []byte(`null`),
+				"mfa_requirement":   []byte(`null`),
+				"token":             []byte("s.abc123"),
+				helpers.SecretDataKeyRaw: []byte(`{"accessor":"","client_token":"s.abc123","entity_id":"","identity_policies":null,"lease_duration":0,"metadata":null,"mfa_requirement":null,"orphan":false,"policies":null,"renewable":false,"token_policies":null}`),
+			},
+			wantErr: assert.NoError,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**Description**
VaultDynamicSecret produces empty secret data when targeting Vault endpoints that return data in the auth field instead of the data field. This affects endpoints like auth/token/create/<role>, where the Vault API response contains the token and metadata under auth, while data is null.

**Steps to Reproduce**
Create a VaultDynamicSecret resource targeting a token creation endpoint:

```
apiVersion: secrets.hashicorp.com/v1beta1
kind: VaultDynamicSecret
metadata:
  name: vault-prometheus-token-sync
  namespace: openshift-monitoring
spec:
  destination:
    create: true
    name: vault-prometheus-token
  mount: auth/token
  path: create/prometheus-metrics-role
  refreshAfter: 12h
  requestHTTPMethod: POST
  vaultAuthRef: my-auth
```
Observe the resulting Kubernetes secret — all data fields are empty.
Expected Behavior
The operator should populate the Kubernetes secret with data from the Vault response's auth field (including client_token, accessor, policies, etc.), since that is where auth/token/create places its response data.

**Actual Behavior**
The Kubernetes secret is created with empty maps. The _raw field contains null.

The operator logs show the response metadata (annotations, etc.) but the secret data portion is:


`{map[] map[] map[] map[...annotations...] map[]}
`
**Root Cause**
defaultResponse.Data() in [vault/responses.go](https://github.com/hashicorp/vault-secrets-operator/blob/main/vault/responses.go#L65) exclusively returns r.secret.Data:


```
func (r *defaultResponse) Data() map[string]any {
    if r.secret == nil {
        return nil
    }
    return r.secret.Data
}
```
SecretK8sData() similarly only reads from secret.Data for both the _raw field and the template input (.Secrets).

The Vault Go API's api.Secret struct correctly parses the auth JSON field into secret.Auth (*api.SecretAuth), but the operator never accesses it. Vault's auth/token/create endpoint returns:


```
{
  "auth": {
    "client_token": "s.xxxxx",
    "accessor": "...",
    "policies": ["default", "..."],
    "renewable": true,
    ...
  },
  "data": null
}
```
Since data is null, all downstream processing produces empty results.

**Proposed Fix**
When secret.Data is nil, defaultResponse should fall back to converting secret.Auth into a map[string]any (via JSON roundtrip — the same pattern already used for WrapInfo in the same file). This preserves full backward compatibility: when Data is present it takes precedence; the fallback only activates for auth-style responses.


**Files Changed**
vault/responses.go — added authAsData() helper; modified Data() and SecretK8sData() to fall back to auth data
vault/responses_test.go — added test cases for auth fallback, template rendering, and data-precedence