### PR TITLE
Refresh VaultPKISecret controller_resource_status outside renewal window

### DIFF
--- a/controllers/vaultpkisecret_controller.go
+++ b/controllers/vaultpkisecret_controller.go
@@ -167,6 +167,12 @@ func (r *VaultPKISecretReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		horizon, inWindow := computePKIRenewalWindow(ctx, o, 0.05)
 		if !inWindow {
 			logger.Info("Not in renewal window", "horizon", horizon)
+			// Refresh the health gauge without writing status. Outside the
+			// renewal window we requeue for a long horizon and never call
+			// updateStatus, so after a process restart long-lived VaultPKISecret
+			// objects would otherwise have no controller_resource_status series
+			// until the next renew/ForceSync.
+			metrics.SetResourceStatus("vaultpkisecret", o, ptr.Deref(o.Status.Valid, false))
 			return ctrl.Result{
 				RequeueAfter: horizon,
 			}, nil


### PR DESCRIPTION
## Summary

`controller_resource_status` for `VaultPKISecret` is only written from `updateStatus`. When a cert is outside the renewal window, `Reconcile` returns early with a long `RequeueAfter` and never calls `updateStatus`.

After a process restart, controller-runtime requeues every CR once. Long-horizon PKI objects take that early exit, so `/metrics` has **no series** for them until the next renew window or ForceSync, even when `.status.valid` is already true. Monitoring that alerts on `== 0` stays silent; the series is simply absent.

## Fix

Call `metrics.SetResourceStatus` on the not-in-renewal-window path using the current `.status.valid`, without a status write or cert re-issue.

## Test plan

- [x] `go test ./controllers/ -run Test_computePKIRenewalWindow`
- [ ] After restart with a long-horizon `VaultPKISecret` outside the renew window, confirm `/metrics` includes `controller_resource_status{controller="vaultpkisecret",name="<cr>",...}` reflecting `.status.valid`

## Context

Seen in production when scraping VSO for Oceanus Traefik PKI health: CR showed `valid: true` via kubectl, but the gauge was missing until ForceSync.


Made with [Cursor](https://cursor.com)