### PR TITLE
fix: Resolve concurrency, websocket leaks, and client optimizations.

### DIFF
--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -441,7 +441,7 @@ func (r *VaultDynamicSecretReconciler) Reconcile(ctx context.Context, req ctrl.R
 			}
 		}
 	} else {
-		r.unWatchEvents(o, vClient)
+		r.unWatchEvents(o, vClient, ctx)
 		r.pendingVaultIndex.Delete(req.NamespacedName)
 	}
 
@@ -544,7 +544,7 @@ func (r *VaultDynamicSecretReconciler) syncSecret(ctx context.Context, c vault.C
 	var data map[string][]byte
 	secretLease := r.getVaultSecretLease(resp.Secret())
 	if !r.isRenewableLease(secretLease, o, true) && o.Spec.AllowStaticCreds {
-		staticCredsMeta, rotatedResponse, err := r.awaitVaultSecretRotation(ctx, o, c, resp)
+		staticCredsMeta, rotatedResponse, err := r.awaitVaultSecretRotation(ctx, o, c, resp, headers)
 		if err != nil {
 			return nil, false, err
 		}
@@ -595,8 +595,13 @@ func (r *VaultDynamicSecretReconciler) syncSecret(ctx context.Context, c vault.C
 // awaitVaultSecretRotation waits for the Vault secret to be rotated. This is
 // necessary for the case where the Vault secret is a static-creds secret and includes
 // a rotation schedule.
+//
+// headers should be the same headers passed to the initial doVault call in
+// syncSecret (e.g. X-Vault-Index on event-triggered reconciles) so that retry
+// reads on Performance Standbys are served from a node that has replicated the
+// write, preserving the freshness guarantee end-to-end.
 func (r *VaultDynamicSecretReconciler) awaitVaultSecretRotation(ctx context.Context, o *secretsv1beta1.VaultDynamicSecret,
-	c vault.ClientBase, lastResponse vault.Response) (*secretsv1beta1.VaultStaticCredsMetaData,
+	c vault.ClientBase, lastResponse vault.Response, headers http.Header) (*secretsv1beta1.VaultStaticCredsMetaData,
 	vault.Response,
 	error,
 ) {
@@ -651,7 +656,7 @@ func (r *VaultDynamicSecretReconciler) awaitVaultSecretRotation(ctx context.Cont
 		backoff.WithMaxInterval(time.Second*2))
 	if err := backoff.Retry(
 		func() error {
-			resp, err = r.doVault(ctx, c, o, nil)
+			resp, err = r.doVault(ctx, c, o, headers)
 			if err != nil {
 				return err
 			}
@@ -791,7 +796,7 @@ func (r *VaultDynamicSecretReconciler) SetupWithManager(mgr ctrl.Manager, opts c
 			Namespace: metrics.Namespace,
 			Subsystem: "vaultdynamicsecret",
 			Name:      "active_event_watchers",
-			Help:      "Number of active VaultDynamicSecret event-subscription websocket connections",
+			Help:      "Number of active VaultDynamicSecret event subscriptions (one per watched resource)",
 		},
 		func() float64 { return float64(r.eventWatcherRegistry.ItemCount()) },
 	))
@@ -866,7 +871,7 @@ func (r *VaultDynamicSecretReconciler) handleDeletion(ctx context.Context, o *se
 				"error", err)
 			r.eventWatcherRegistry.Delete(objKey)
 		} else {
-			r.unWatchEvents(o, c)
+			r.unWatchEvents(o, c, ctx)
 		}
 	}
 	r.pendingVaultIndex.Delete(objKey)
@@ -1036,7 +1041,12 @@ func (r *VaultDynamicSecretReconciler) vaultClientCallback(ctx context.Context, 
 				r.SyncRegistry.Add(objKey)
 				logger.V(consts.LogLevelDebug).Info(
 					"Sending GenericEvent to the SourceCh", "evt", evt)
-				r.SourceCh <- evt
+				select {
+				case r.SourceCh <- evt:
+				default:
+					logger.V(consts.LogLevelWarning).Info(
+						"SourceCh full, dropping client-callback event", "objKey", objKey)
+				}
 			}
 		} else if err != nil {
 			logger.V(consts.LogLevelWarning).Info(
@@ -1212,7 +1222,7 @@ func (r *VaultDynamicSecretReconciler) ensureEventWatcher(
 	if hasMeta {
 		logger.V(consts.LogLevelDebug).Info("Unsubscribing due to metadata, client, or lease change",
 			"namespace", o.Namespace, "name", o.Name)
-		r.unWatchEventsWithLeaseID(o, c, meta.LastLeaseID, meta.LastEventType)
+		r.unWatchEventsWithLeaseID(o, c, meta.LastLeaseID, meta.LastEventType, ctx)
 	}
 
 	// Step 4: subscribe to engine events.
@@ -1265,6 +1275,7 @@ func (r *VaultDynamicSecretReconciler) ensureEventWatcher(
 func (r *VaultDynamicSecretReconciler) unWatchEvents(
 	o *secretsv1beta1.VaultDynamicSecret,
 	c vault.Client,
+	ctx context.Context,
 ) {
 	if r.eventWatcherRegistry == nil {
 		return
@@ -1278,7 +1289,7 @@ func (r *VaultDynamicSecretReconciler) unWatchEvents(
 
 	// Pass LastEventType directly — if it is empty, unWatchEventsWithLeaseID
 	// will skip the engine-event unsubscribe rather than targeting the wrong stream.
-	r.unWatchEventsWithLeaseID(o, c, meta.LastLeaseID, meta.LastEventType)
+	r.unWatchEventsWithLeaseID(o, c, meta.LastLeaseID, meta.LastEventType, ctx)
 }
 
 // unWatchEventsWithLeaseID performs the actual unsubscription using the provided
@@ -1288,6 +1299,7 @@ func (r *VaultDynamicSecretReconciler) unWatchEventsWithLeaseID(
 	c vault.Client,
 	leaseID string,
 	eventType vault.EventType,
+	ctx context.Context,
 ) {
 	if r.eventWatcherRegistry == nil {
 		return
@@ -1304,8 +1316,8 @@ func (r *VaultDynamicSecretReconciler) unWatchEventsWithLeaseID(
 			VaultNamespace: o.Spec.Namespace,
 			VaultPath:      vaultPath,
 		}
-		if err := c.UnsubscribeFromEvents(eventType, pathKey, name.String()); err != nil {
-			log.FromContext(context.Background()).V(consts.LogLevelDebug).Info(
+		if err := c.UnsubscribeFromEvents(ctx, eventType, pathKey, name.String()); err != nil {
+			log.FromContext(ctx).V(consts.LogLevelDebug).Info(
 				"Failed to unsubscribe from events (may already be cleaned up)",
 				"namespace", o.Namespace, "name", o.Name, "error", err)
 		}
@@ -1316,7 +1328,7 @@ func (r *VaultDynamicSecretReconciler) unWatchEventsWithLeaseID(
 		leaseKey := vault.SubscriptionKey{
 			VaultPath: leaseID,
 		}
-		_ = c.UnsubscribeFromEvents(vault.EventTypeLease, leaseKey, name.String())
+		_ = c.UnsubscribeFromEvents(ctx, vault.EventTypeLease, leaseKey, name.String())
 	}
 
 	r.eventWatcherRegistry.Delete(name)
@@ -1328,12 +1340,6 @@ func (r *VaultDynamicSecretReconciler) unWatchEventsWithLeaseID(
 func buildVaultEventKey(o *secretsv1beta1.VaultDynamicSecret) string {
 	roleName := extractRoleName(o.Spec.Path)
 	return o.Spec.Mount + "/" + roleName
-}
-
-// buildLeaseEventKey returns the subscription key for lease lifecycle events.
-// The key is the lease ID from the VDS status.
-func buildLeaseEventKey(o *secretsv1beta1.VaultDynamicSecret) string {
-	return o.Status.SecretLease.ID
 }
 
 // extractRoleName extracts the role name from a VDS spec path.

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -1569,7 +1569,11 @@ func TestVaultDynamicSecretReconciler_vaultClientCallback(t *testing.T) {
 			r := &VaultDynamicSecretReconciler{
 				Client:       testutils.NewFakeClient(),
 				SyncRegistry: syncRegistry,
-				SourceCh:     make(chan event.GenericEvent),
+				// Buffer large enough to hold all events for this test case
+				// without requiring the consumer goroutine to be ready first.
+				// In production, controller-runtime's source.Channel reads
+				// continuously; in tests the goroutine start may race the send.
+				SourceCh: make(chan event.GenericEvent, len(tt.instances)+1),
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -2250,7 +2254,7 @@ func TestVaultDynamicSecretReconciler_awaitRotation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := &VaultDynamicSecretReconciler{}
-			got, got1, err := r.awaitVaultSecretRotation(ctx, tt.o, tt.c, tt.initialResponse)
+			got, got1, err := r.awaitVaultSecretRotation(ctx, tt.o, tt.c, tt.initialResponse, nil)
 			if !tt.wantErr(t, err, fmt.Sprintf("awaitVaultSecretRotation(%v, %v, %v, %v)", ctx, tt.o, tt.c, tt.initialResponse)) {
 				return
 			}
@@ -2356,49 +2360,13 @@ func Test_buildVaultEventKey(t *testing.T) {
 	}
 }
 
-func Test_buildLeaseEventKey(t *testing.T) {
-	tests := []struct {
-		name string
-		o    *secretsv1beta1.VaultDynamicSecret
-		want string
-	}{
-		{
-			name: "with lease ID",
-			o: &secretsv1beta1.VaultDynamicSecret{
-				Status: secretsv1beta1.VaultDynamicSecretStatus{
-					SecretLease: secretsv1beta1.VaultSecretLease{
-						ID: "database/creds/my-role/abc123",
-					},
-				},
-			},
-			want: "database/creds/my-role/abc123",
-		},
-		{
-			name: "empty lease ID",
-			o: &secretsv1beta1.VaultDynamicSecret{
-				Status: secretsv1beta1.VaultDynamicSecretStatus{
-					SecretLease: secretsv1beta1.VaultSecretLease{
-						ID: "",
-					},
-				},
-			},
-			want: "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := buildLeaseEventKey(tt.o)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 type watchUnsubscribeClient struct {
 	vault.Client
 	seen []vault.EventType
 }
 
 func (m *watchUnsubscribeClient) UnsubscribeFromEvents(
+	_ context.Context,
 	eventType vault.EventType,
 	_ vault.SubscriptionKey,
 	_ string,
@@ -2428,7 +2396,7 @@ func Test_unWatchEvents_UsesStoredEventType(t *testing.T) {
 	})
 
 	m := &watchUnsubscribeClient{}
-	r.unWatchEvents(o, m)
+	r.unWatchEvents(o, m, context.Background())
 
 	require.Len(t, m.seen, 2)
 	assert.Equal(t, vault.EventTypeLDAP, m.seen[0])
@@ -2462,7 +2430,7 @@ func (m *mockEnsureClient) SubscribeToEvents(_ context.Context, et vault.EventTy
 	return nil
 }
 
-func (m *mockEnsureClient) UnsubscribeFromEvents(et vault.EventType, _ vault.SubscriptionKey, _ string) error {
+func (m *mockEnsureClient) UnsubscribeFromEvents(_ context.Context, et vault.EventType, _ vault.SubscriptionKey, _ string) error {
 	m.seen = append(m.seen, et)
 	return nil
 }
@@ -2618,7 +2586,7 @@ func Test_unWatchEventsWithLeaseID_EmptyEventType_SkipsEngineUnsubscribe(t *test
 
 	m := &watchUnsubscribeClient{}
 	// Call with empty eventType — only the lease unsubscribe should fire.
-	r.unWatchEventsWithLeaseID(o, m, "database/creds/my-role/abc123", "")
+	r.unWatchEventsWithLeaseID(o, m, "database/creds/my-role/abc123", "", context.Background())
 
 	require.Len(t, m.seen, 1, "only the lease unsubscribe should be called")
 	assert.Equal(t, vault.EventTypeLease, m.seen[0])

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -500,7 +500,7 @@ func (r *VaultStaticSecretReconciler) SetupWithManager(mgr ctrl.Manager, opts co
 		},
 	)
 
-	r.SourceCh = make(chan event.GenericEvent)
+	r.SourceCh = make(chan event.GenericEvent, 4)
 	r.eventWatcherRegistry = newEventWatcherRegistry()
 	ctrlmetrics.Registry.MustRegister(prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -312,7 +312,7 @@ func (r *VaultStaticSecretReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	} else {
 		// ensure event watcher is not running
-		r.unWatchEvents(o, c)
+		r.unWatchEvents(o, c, ctx)
 		r.pendingVaultIndex.Delete(req.NamespacedName)
 	}
 
@@ -352,7 +352,7 @@ func (r *VaultStaticSecretReconciler) handleDeletion(ctx context.Context, o clie
 			"error", err)
 		r.eventWatcherRegistry.Delete(objKey)
 	} else {
-		r.unWatchEvents(vss, c)
+		r.unWatchEvents(vss, c, ctx)
 	}
 	r.pendingVaultIndex.Delete(objKey)
 
@@ -405,7 +405,7 @@ func (r *VaultStaticSecretReconciler) ensureEventWatcher(ctx context.Context, o 
 			// The subscription exists but metadata or vault client has changed, unsubscribe first
 			logger.V(consts.LogLevelDebug).Info("Unsubscribing due to metadata or client change",
 				"namespace", o.Namespace, "name", o.Name)
-			r.unWatchEvents(o, c)
+			r.unWatchEvents(o, c, ctx)
 		} else {
 			// WebSocket is dead or missing - orphaned registry entry detected
 			logger.Info("Detected orphaned registry entry (WebSocket is dead or missing), cleaning up",
@@ -456,7 +456,7 @@ func (r *VaultStaticSecretReconciler) ensureEventWatcher(ctx context.Context, o 
 }
 
 // unWatchEvents unsubscribes the VSS from events and removes it from the registry
-func (r *VaultStaticSecretReconciler) unWatchEvents(o *secretsv1beta1.VaultStaticSecret, c vault.Client) {
+func (r *VaultStaticSecretReconciler) unWatchEvents(o *secretsv1beta1.VaultStaticSecret, c vault.Client, ctx context.Context) {
 	name := client.ObjectKeyFromObject(o)
 	_, ok := r.eventWatcherRegistry.Get(name)
 	if !ok {
@@ -469,8 +469,8 @@ func (r *VaultStaticSecretReconciler) unWatchEvents(o *secretsv1beta1.VaultStati
 		VaultPath:      vaultPath,
 	}
 
-	if err := c.UnsubscribeFromEvents(vault.EventTypeKV, pathKey, name.String()); err != nil {
-		log.FromContext(context.Background()).V(consts.LogLevelDebug).Info(
+	if err := c.UnsubscribeFromEvents(ctx, vault.EventTypeKV, pathKey, name.String()); err != nil {
+		log.FromContext(ctx).V(consts.LogLevelDebug).Info(
 			"Failed to unsubscribe from events (may already be cleaned up)",
 			"namespace", o.Namespace, "name", o.Name, "error", err)
 	}
@@ -507,7 +507,7 @@ func (r *VaultStaticSecretReconciler) SetupWithManager(mgr ctrl.Manager, opts co
 			Namespace: metrics.Namespace,
 			Subsystem: "vaultstaticsecret",
 			Name:      "active_event_watchers",
-			Help:      "Number of active VaultStaticSecret event-subscription websocket connections",
+			Help:      "Number of active VaultStaticSecret event subscriptions (one per watched resource)",
 		},
 		func() float64 { return float64(r.eventWatcherRegistry.ItemCount()) },
 	))
@@ -594,7 +594,12 @@ func (r *VaultStaticSecretReconciler) vaultClientCallback(ctx context.Context, c
 					"objKey", objKey)
 				logger.V(consts.LogLevelDebug).Info(
 					"Sending GenericEvent to the SourceCh", "evt", evt)
-				r.SourceCh <- evt
+				select {
+				case r.SourceCh <- evt:
+				default:
+					logger.V(consts.LogLevelWarning).Info(
+						"SourceCh full, dropping client-callback event", "objKey", objKey)
+				}
 			}
 		} else if err != nil {
 			logger.V(consts.LogLevelWarning).Info(

--- a/controllers/vaultstaticsecret_controller_test.go
+++ b/controllers/vaultstaticsecret_controller_test.go
@@ -254,7 +254,7 @@ func (m *mockVSSClient) SubscribeToEvents(_ context.Context, et vault.EventType,
 	return m.subscribeErr
 }
 
-func (m *mockVSSClient) UnsubscribeFromEvents(et vault.EventType, _ vault.SubscriptionKey, _ string) error {
+func (m *mockVSSClient) UnsubscribeFromEvents(_ context.Context, et vault.EventType, _ vault.SubscriptionKey, _ string) error {
 	m.seen = append(m.seen, et)
 	return m.unsubscribeErr
 }
@@ -414,7 +414,7 @@ func Test_VSS_unWatchEvents_UnsubscribesAndClearsRegistry(t *testing.T) {
 	})
 
 	m := &mockVSSClient{}
-	r.unWatchEvents(o, m)
+	r.unWatchEvents(o, m, context.Background())
 
 	require.Len(t, m.seen, 1, "exactly one unsubscribe call expected (KV only)")
 	assert.Equal(t, vault.EventTypeKV, m.seen[0])
@@ -444,7 +444,7 @@ func Test_VSS_unWatchEvents_NoOpWhenNoRegistryEntry(t *testing.T) {
 
 	m := &mockVSSClient{}
 	// Must not panic and must not call UnsubscribeFromEvents.
-	r.unWatchEvents(o, m)
+	r.unWatchEvents(o, m, context.Background())
 
 	assert.Empty(t, m.seen, "no unsubscribe should be called when object not in registry")
 }
@@ -475,7 +475,7 @@ func Test_VSS_unWatchEvents_UnsubscribeError(t *testing.T) {
 	})
 
 	m := &mockVSSClient{unsubscribeErr: fmt.Errorf("websocket already closed")}
-	r.unWatchEvents(o, m)
+	r.unWatchEvents(o, m, context.Background())
 
 	// UnsubscribeFromEvents was still attempted.
 	require.Len(t, m.seen, 1, "exactly one unsubscribe call expected even on error")

--- a/vault/client.go
+++ b/vault/client.go
@@ -197,7 +197,7 @@ type Client interface {
 	WebsocketClient(string) (*WebsocketClient, error)
 	Renewable() bool
 	SubscribeToEvents(context.Context, EventType, *Subscriber) error
-	UnsubscribeFromEvents(EventType, SubscriptionKey, string) error
+	UnsubscribeFromEvents(context.Context, EventType, SubscriptionKey, string) error
 	// GetWebSocketCount returns the number of real, active WebSocket
 	// connections this client currently holds open to Vault (at most one per
 	// EventType, shared across all subscribers of that event type).
@@ -524,23 +524,29 @@ func (c *defaultClient) Close(revoke bool) {
 
 // GetMountType returns the Vault plugin type for a mount path.
 // Results are cached per-client to avoid repeated sys/mounts lookups.
+//
+// A single write-lock is held for the entire cache-miss path (including the
+// Vault read) so that concurrent reconciles for the same mount only produce one
+// outbound request. c.Read does not acquire c.mu, so there is no self-deadlock.
 func (c *defaultClient) GetMountType(ctx context.Context, mountPath string) (string, error) {
 	mountPath = strings.Trim(mountPath, "/")
 	if mountPath == "" {
 		return "", fmt.Errorf("mount path cannot be empty")
 	}
 
-	c.mu.RLock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.closed {
-		c.mu.RUnlock()
 		return "", fmt.Errorf("client instance is closed")
 	}
 	if t, ok := c.mountTypeCache[mountPath]; ok {
-		c.mu.RUnlock()
 		return t, nil
 	}
-	c.mu.RUnlock()
 
+	// Cache miss — call Vault while holding the lock so that a second goroutine
+	// that also misses the cache waits here and then hits the cache on its next
+	// iteration, rather than issuing a duplicate sys/mounts request.
 	resp, err := c.Read(ctx, NewReadRequest("sys/mounts/"+mountPath, nil, nil))
 	if err != nil {
 		return "", fmt.Errorf("failed to read mount info for %q: %w", mountPath, err)
@@ -551,12 +557,10 @@ func (c *defaultClient) GetMountType(ctx context.Context, mountPath string) (str
 		return "", fmt.Errorf("missing or empty type field in sys/mounts/%s response", mountPath)
 	}
 
-	c.mu.Lock()
 	if c.mountTypeCache == nil {
 		c.mountTypeCache = make(map[string]string)
 	}
 	c.mountTypeCache[mountPath] = mountType
-	c.mu.Unlock()
 
 	return mountType, nil
 }
@@ -1094,11 +1098,12 @@ func (c *defaultClient) SubscribeToEvents(
 // UnsubscribeFromEvents removes a subscription from this client's WebSocket.
 // pathKey identifies the Vault path, resourceKey identifies the specific CR subscriber.
 func (c *defaultClient) UnsubscribeFromEvents(
+	ctx context.Context,
 	eventType EventType,
 	pathKey SubscriptionKey,
 	resourceKey string,
 ) error {
-	logger := log.FromContext(context.TODO()).WithValues(
+	logger := log.FromContext(ctx).WithValues(
 		"clientID", c.id,
 		"eventType", eventType,
 		"pathKey", pathKey.String(),
@@ -1119,7 +1124,7 @@ func (c *defaultClient) UnsubscribeFromEvents(
 
 	// Close WebSocket if no more subscribers
 	if lastSubscriber {
-		c.closeWebSocket(eventType)
+		c.closeWebSocket(ctx, eventType)
 	}
 
 	return nil
@@ -1210,12 +1215,12 @@ func (c *defaultClient) getOrCreateWebSocket(
 }
 
 // closeWebSocket closes a specific WebSocket
-func (c *defaultClient) closeWebSocket(eventType EventType) {
+func (c *defaultClient) closeWebSocket(ctx context.Context, eventType EventType) {
 	c.websocketMu.Lock()
 	defer c.websocketMu.Unlock()
 
 	if ws, exists := c.websockets[eventType]; exists {
-		logger := log.FromContext(context.TODO()).WithValues(
+		logger := log.FromContext(ctx).WithValues(
 			"clientID", c.id,
 			"eventType", eventType,
 		)

--- a/vault/client_test.go
+++ b/vault/client_test.go
@@ -1270,7 +1270,7 @@ func Test_defaultClient_WebSocketManagement(t *testing.T) {
 			VaultNamespace: "",
 			VaultPath:      "kv/data/app/config",
 		}
-		err := c.UnsubscribeFromEvents(EventTypeKV, pathKey, "default/test-secret")
+		err := c.UnsubscribeFromEvents(context.Background(), EventTypeKV, pathKey, "default/test-secret")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "websocket not found")
 	})
@@ -1284,7 +1284,7 @@ func Test_defaultClient_WebSocketManagement(t *testing.T) {
 		c.websockets[EventTypeKV] = ws
 
 		assert.Equal(t, 1, c.GetWebSocketCount())
-		c.closeWebSocket(EventTypeKV)
+		c.closeWebSocket(context.Background(), EventTypeKV)
 		assert.Equal(t, 0, c.GetWebSocketCount())
 	})
 }
@@ -1370,7 +1370,7 @@ func Test_defaultClient_WebSocketLifecycle(t *testing.T) {
 			VaultNamespace: sub.VaultNS,
 			VaultPath:      sub.VaultPath,
 		}
-		err = c.UnsubscribeFromEvents(EventTypeKV, pathKey, sub.ResourceKey.String())
+		err = c.UnsubscribeFromEvents(context.Background(), EventTypeKV, pathKey, sub.ResourceKey.String())
 		require.NoError(t, err)
 		assert.Equal(t, 0, c.GetWebSocketCount())
 		assert.Equal(t, 0, c.GetWebSocketSubscriberCount())

--- a/vault/event_subscription.go
+++ b/vault/event_subscription.go
@@ -38,8 +38,16 @@ const (
 
 // SharedWebSocket manages a single WebSocket connection with multiple subscribers
 type SharedWebSocket struct {
-	// conn is the underlying WebSocket connection
-	conn *websocket.Conn
+	// conn is the underlying WebSocket connection.
+	// Writes (reconnect, Close) and reads from IsHealthy/Close may happen on
+	// different goroutines, so all cross-goroutine accesses must hold connMu.
+	// Accesses inside the event-loop goroutine itself (readAndRoute, eventLoop
+	// done-handler) are inherently sequential with reconnect and do NOT lock,
+	// to avoid a self-deadlock where reconnect holds connMu while calling
+	// wsClient.Connect, and readAndRoute tries to lock connMu on the same
+	// goroutine.
+	conn   *websocket.Conn
+	connMu sync.RWMutex
 	// stopped indicates that the event loop has exited and this websocket should
 	// no longer be considered healthy or reusable. Written by the event-loop
 	// goroutine and read from reconciler goroutines via IsHealthy(), so it must
@@ -87,8 +95,10 @@ func NewSharedWebSocket(
 		return nil, fmt.Errorf("failed to create websocket client: %w", err)
 	}
 
-	// Create cancellable context
-	wsCtx, cancel := context.WithCancel(context.Background())
+	// Create cancellable context derived from the caller's context so that
+	// the event-loop goroutine is cancelled when the parent (manager) context
+	// is cancelled on operator shutdown.
+	wsCtx, cancel := context.WithCancel(ctx)
 
 	ws := &SharedWebSocket{
 		eventType:   eventType,
@@ -357,11 +367,20 @@ func (ws *SharedWebSocket) readAndRoute() error {
 	return nil
 }
 
-// reconnect creates a new WebSocket connection, replacing the old one
+// reconnect creates a new WebSocket connection, replacing the old one.
+// Called exclusively from the event-loop goroutine; connMu is held only around
+// the conn pointer swap so that IsHealthy (which runs on reconciler goroutines)
+// never observes a torn read.
 func (ws *SharedWebSocket) reconnect() error {
-	// Close old connection if still open
-	if ws.conn != nil {
-		ws.conn.Close(websocket.StatusNormalClosure, "reconnecting")
+	// Snapshot and clear the old conn under write lock, then close it without
+	// holding the lock (Close can block briefly).
+	ws.connMu.Lock()
+	old := ws.conn
+	ws.conn = nil
+	ws.connMu.Unlock()
+
+	if old != nil {
+		old.Close(websocket.StatusNormalClosure, "reconnecting")
 	}
 
 	wsClient, err := ws.vaultClient.WebsocketClient(getEventPath(ws.eventType))
@@ -373,7 +392,10 @@ func (ws *SharedWebSocket) reconnect() error {
 	if err != nil {
 		return fmt.Errorf("failed to connect websocket: %w", err)
 	}
+
+	ws.connMu.Lock()
 	ws.conn = conn
+	ws.connMu.Unlock()
 	return nil
 }
 
@@ -498,17 +520,23 @@ func (ws *SharedWebSocket) routeEvent(msg *EventMessage) {
 	}
 }
 
-// Close gracefully shuts down the WebSocket
+// Close gracefully shuts down the WebSocket.
+// May be called from any goroutine (reconciler, manager shutdown).
 func (ws *SharedWebSocket) Close() error {
 	ws.logger.Info("Closing SharedWebSocket", "subscribers", ws.GetSubscriberCount())
 
 	// Cancel context to stop event loop
 	ws.cancel()
 
-	// Close WebSocket connection
-	if ws.conn != nil {
-		err := ws.conn.Close(websocket.StatusNormalClosure, "closing shared websocket")
-		if err != nil {
+	// Snapshot and clear conn under write lock so that a concurrent IsHealthy
+	// call never reads a partially-closed connection.
+	ws.connMu.Lock()
+	conn := ws.conn
+	ws.conn = nil
+	ws.connMu.Unlock()
+
+	if conn != nil {
+		if err := conn.Close(websocket.StatusNormalClosure, "closing shared websocket"); err != nil {
 			ws.logger.Error(err, "Error closing websocket connection")
 			return err
 		}
@@ -518,7 +546,8 @@ func (ws *SharedWebSocket) Close() error {
 	return nil
 }
 
-// IsHealthy checks if the WebSocket is still healthy
+// IsHealthy checks if the WebSocket is still healthy.
+// May be called from any goroutine; uses connMu to safely read ws.conn.
 func (ws *SharedWebSocket) IsHealthy() bool {
 	if ws.stopped.Load() {
 		return false
@@ -527,7 +556,10 @@ func (ws *SharedWebSocket) IsHealthy() bool {
 	case <-ws.ctx.Done():
 		return false
 	default:
-		return ws.conn != nil
+		ws.connMu.RLock()
+		healthy := ws.conn != nil
+		ws.connMu.RUnlock()
+		return healthy
 	}
 }
 

--- a/vault/websocket.go
+++ b/vault/websocket.go
@@ -64,6 +64,11 @@ func (w *WebsocketClient) Connect(ctx context.Context) (*websocket.Conn, error) 
 	var resp *http.Response
 	var err error
 
+	// Track visited URLs to detect redirect cycles (e.g. A→B→A) that would
+	// otherwise silently exhaust all attempts and return a generic error.
+	visited := make(map[string]bool)
+	visited[w.URL] = true
+
 	for attempt := 0; attempt < 10; attempt++ {
 		conn, resp, err = websocket.Dial(ctx, w.URL, &websocket.DialOptions{
 			HTTPClient: w.HTTPClient,
@@ -76,7 +81,12 @@ func (w *WebsocketClient) Connect(ctx context.Context) (*websocket.Conn, error) 
 		if resp == nil {
 			break
 		} else if resp.StatusCode == http.StatusTemporaryRedirect {
-			w.URL = resp.Header.Get("Location")
+			loc := resp.Header.Get("Location")
+			if visited[loc] {
+				return nil, fmt.Errorf("redirect cycle detected when establishing websocket connection: %s has already been visited", loc)
+			}
+			visited[loc] = true
+			w.URL = loc
 			continue
 		} else {
 			break


### PR DESCRIPTION
- Goroutine leak: `NewSharedWebSocket` now derives from the caller's ctx instead of `context.Background()`, so event-loop goroutines exit on operator shutdown
- Data race: added connMu `sync.RWMutex` to protect `ws.conn` across goroutines
- Duplicate Vault calls: `GetMountType` now holds a single write-lock across the cache-miss path, preventing concurrent sys/mounts requests
- Blocking callback: `vaultClientCallback` sends to SourceCh non-blocking (select/default) to match routeEvent's existing pattern
- Stale reads on retry: `awaitVaultSecretRotation` now threads `X-Vault-Index` headers through its backoff retry loop; redirect cycle detection added to WebsocketClient.Connect; context.TODO() replaced with real context in `UnsubscribeFromEvents`; metric Help string corrected; dead `buildLeaseEventKey` function removed

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
