### PR TITLE
Adds a warning note to the version field documentation in VaultStaticSecret

### DIFF
--- a/api/v1beta1/vaultstaticsecret_types.go
+++ b/api/v1beta1/vaultstaticsecret_types.go
@@ -52,6 +52,7 @@ type VaultStaticSecretCommon struct {
 	Path string `json:"path"`
 	// Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:
 	// https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version
+	// This field should normally be omitted, unless you want to lock the sync to a specific version of the secret and ignore updates.
 	// +kubebuilder:validation:Minimum=0
 	Version int `json:"version,omitempty"`
 	// Type of the Vault static secret

--- a/chart/crds/secrets.hashicorp.com_csisecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_csisecrets.yaml
@@ -497,6 +497,7 @@ spec:
                           description: |-
                             Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:
                             https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version
+                            This field should normally be omitted, unless you want to lock the sync to a specific version of the secret and ignore updates.
                           minimum: 0
                           type: integer
                       required:

--- a/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/chart/crds/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -294,6 +294,7 @@ spec:
                 description: |-
                   Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:
                   https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version
+                  This field should normally be omitted, unless you want to lock the sync to a specific version of the secret and ignore updates.
                 minimum: 0
                 type: integer
             required:

--- a/config/crd/bases/secrets.hashicorp.com_csisecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_csisecrets.yaml
@@ -497,6 +497,7 @@ spec:
                           description: |-
                             Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:
                             https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version
+                            This field should normally be omitted, unless you want to lock the sync to a specific version of the secret and ignore updates.
                           minimum: 0
                           type: integer
                       required:

--- a/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
+++ b/config/crd/bases/secrets.hashicorp.com_vaultstaticsecrets.yaml
@@ -294,6 +294,7 @@ spec:
                 description: |-
                   Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:
                   https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version
+                  This field should normally be omitted, unless you want to lock the sync to a specific version of the secret and ignore updates.
                 minimum: 0
                 type: integer
             required:

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -1336,7 +1336,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `mount` _string_ | Mount for the secret in Vault |  |  |
 | `path` _string_ | Path of the secret in Vault, corresponds to the `path` parameter for:<br />kv-v1: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#read-secret<br />kv-v2: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version |  |  |
-| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version |  | Minimum: 0 <br /> |
+| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version<br />This field should normally be omitted, unless you want to lock the sync to a specific version of the secret and ignore updates. |  | Minimum: 0 <br /> |
 | `type` _string_ | Type of the Vault static secret |  | Enum: [kv-v1 kv-v2] <br /> |
 | `transformation` _[Transformation](#transformation)_ | Transformation provides configuration for transforming the secret data before<br />it is stored in the CSI volume. |  |  |
 
@@ -1357,7 +1357,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `mount` _string_ | Mount for the secret in Vault |  |  |
 | `path` _string_ | Path of the secret in Vault, corresponds to the `path` parameter for:<br />kv-v1: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#read-secret<br />kv-v2: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version |  |  |
-| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version |  | Minimum: 0 <br /> |
+| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version<br />This field should normally be omitted, unless you want to lock the sync to a specific version of the secret and ignore updates. |  | Minimum: 0 <br /> |
 | `type` _string_ | Type of the Vault static secret |  | Enum: [kv-v1 kv-v2] <br /> |
 
 
@@ -1401,7 +1401,7 @@ _Appears in:_
 | `syncConfig` _[SyncConfig](#syncconfig)_ | SyncConfig configures sync behavior from Vault to VSO |  |  |
 | `mount` _string_ | Mount for the secret in Vault |  |  |
 | `path` _string_ | Path of the secret in Vault, corresponds to the `path` parameter for:<br />kv-v1: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#read-secret<br />kv-v2: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version |  |  |
-| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version |  | Minimum: 0 <br /> |
+| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version<br />This field should normally be omitted, unless you want to lock the sync to a specific version of the secret and ignore updates. |  | Minimum: 0 <br /> |
 | `type` _string_ | Type of the Vault static secret |  | Enum: [kv-v1 kv-v2] <br /> |
 
 


### PR DESCRIPTION
Description:
Adds a warning note to the `version` field documentation in `VaultStaticSecret`.

By default, omitting the `version` field allows VSO to automatically sync the latest version of a KV-v2 secret as it gets rotated or updated. Setting a static `version` locks secret synchronization to that specific version number and causes subsequent updates to be ignored, which can lead to unexpected behavior if misconfigured.

## Changes

- **`api/v1beta1/vaultstaticsecret_types.go`**: Added a warning to the `Version` field doc comment advising that the field should normally be omitted unless explicitly pinning to a fixed secret version.
- **`docs/api/api-reference.md`**: Updated the API reference markdown documentation with the new warning for `VaultStaticSecretCollectable`, `VaultStaticSecretCommon`, and `VaultStaticSecretSpec`.
- **`config/crd/bases/` & `chart/crds/`**: Synchronized CRD schema descriptions in the base manifests and Helm chart CRDs.

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
