### PR TITLE
Add event-driven drift detection for VSS/VDS destination Secrets

### DIFF
--- a/controllers/eventhandlers.go
+++ b/controllers/eventhandlers.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -204,6 +205,95 @@ func (e *enqueueOnDeletionRequestHandler) Delete(ctx context.Context,
 func (e *enqueueOnDeletionRequestHandler) Generic(ctx context.Context,
 	_ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request],
 ) {
+}
+
+var _ handler.EventHandler = (*enqueueOnDataChangeRequestHandler)(nil)
+
+// enqueueOnDataChangeRequestHandler enqueues the owning syncable-secret custom
+// resource for reconciliation when a destination Secret's .Data changes out
+// of band (e.g. edited or reset by something other than VSO). It does not
+// implement any drift-detection logic itself: it only decides *when* to
+// trigger a reconcile sooner than the next poll/requeue, letting the
+// controller's existing secretMAC/HMAC comparison decide, as it already does
+// on every Reconcile, whether the destination Secret actually needs to be
+// repaired.
+//
+// Update events are expected to already be filtered to Secret.Data changes
+// only (see secretDataChangedPredicate) before reaching this handler, so
+// metadata-only updates (labels/annotations/resourceVersion bumps) never
+// enqueue a request. For every remaining event, the owning CR (matched via
+// OwnerReferences against gvk) is fetched so that optIn can decide whether
+// that CR has enabled watch-driven drift detection at all; CRs that haven't
+// (e.g. VaultStaticSecret with hmacSecretData=false, or VaultDynamicSecret
+// with allowStaticCreds=false) are left untouched, preserving their existing
+// poll/requeue-only behavior.
+type enqueueOnDataChangeRequestHandler struct {
+	// gvk of the owning custom resource, matched against the Secret's
+	// OwnerReferences.
+	gvk schema.GroupVersionKind
+	// client used to fetch the owning custom resource named by a matching
+	// OwnerReference, so that optIn can inspect its Spec.
+	client client.Client
+	// newOwner returns a new, empty instance of the owning CR type, to be
+	// populated by client.Get before optIn is called.
+	newOwner func() client.Object
+	// optIn reports whether the just-fetched owner CR has opted in to
+	// watch-driven drift detection.
+	optIn func(owner client.Object) bool
+}
+
+func (e *enqueueOnDataChangeRequestHandler) Create(_ context.Context,
+	_ event.CreateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+}
+
+func (e *enqueueOnDataChangeRequestHandler) Delete(_ context.Context,
+	_ event.DeleteEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+}
+
+func (e *enqueueOnDataChangeRequestHandler) Generic(_ context.Context,
+	_ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+}
+
+func (e *enqueueOnDataChangeRequestHandler) Update(ctx context.Context,
+	evt event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	logger := log.FromContext(ctx).WithName("enqueueOnDataChangeRequestHandler").
+		WithValues("ownerGVK", e.gvk)
+
+	newSecret, ok := evt.ObjectNew.(*corev1.Secret)
+	if !ok {
+		return
+	}
+
+	for _, ref := range newSecret.GetOwnerReferences() {
+		if ref.APIVersion != e.gvk.GroupVersion().String() || ref.Kind != e.gvk.Kind {
+			continue
+		}
+
+		key := types.NamespacedName{
+			Namespace: newSecret.GetNamespace(),
+			Name:      ref.Name,
+		}
+
+		owner := e.newOwner()
+		if err := e.client.Get(ctx, key, owner); err != nil {
+			logger.V(consts.LogLevelDebug).Info(
+				"Could not get owner for destination Secret update, skipping",
+				"owner", key, "error", err)
+			continue
+		}
+
+		if e.optIn != nil && !e.optIn(owner) {
+			continue
+		}
+
+		logger.V(consts.LogLevelTrace).Info(
+			"Enqueuing owner for destination Secret data change", "owner", key)
+		q.Add(reconcile.Request{NamespacedName: key})
+	}
 }
 
 // enqueueDelayingSyncEventHandler enqueues objects with a delay to avoid

--- a/controllers/eventhandlers_test.go
+++ b/controllers/eventhandlers_test.go
@@ -13,10 +13,15 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -840,5 +845,260 @@ func assertEnqueueOnDeletionRequestHandler(t *testing.T, ctx context.Context,
 				assert.LessOrEqual(t, d.Seconds(), float64(m))
 			}
 		}
+	}
+}
+
+// drainQueue drains and returns every item currently in q without blocking.
+// It is used to assert on items added via q.Add() (as opposed to
+// q.AddAfter(), which DelegatingQueue tracks directly).
+func drainQueue(q workqueue.TypedRateLimitingInterface[reconcile.Request]) []reconcile.Request {
+	var reqs []reconcile.Request
+	for q.Len() > 0 {
+		item, _ := q.Get()
+		reqs = append(reqs, item)
+		q.Done(item)
+	}
+	return reqs
+}
+
+func newEnqueueOnDataChangeTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	require.NoError(t, secretsv1beta1.AddToScheme(s))
+	return s
+}
+
+func Test_enqueueOnDataChangeRequestHandler_Update(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	vssGVK := secretsv1beta1.GroupVersion.WithKind(VaultStaticSecret.String())
+	vdsGVK := secretsv1beta1.GroupVersion.WithKind(VaultDynamicSecret.String())
+
+	vssOwnerRef := func(name string) metav1.OwnerReference {
+		return metav1.OwnerReference{
+			APIVersion: vssGVK.GroupVersion().String(),
+			Kind:       vssGVK.Kind,
+			Name:       name,
+		}
+	}
+	vdsOwnerRef := func(name string) metav1.OwnerReference {
+		return metav1.OwnerReference{
+			APIVersion: vdsGVK.GroupVersion().String(),
+			Kind:       vdsGVK.Kind,
+			Name:       name,
+		}
+	}
+	unsupportedOwnerRef := metav1.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "Unknown",
+		Name:       "other",
+	}
+
+	secretEvent := func(refs ...metav1.OwnerReference) event.UpdateEvent {
+		return event.UpdateEvent{
+			ObjectOld: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "dest"},
+				Data:       map[string][]byte{"foo": []byte("old")},
+			},
+			ObjectNew: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "default",
+					Name:            "dest",
+					OwnerReferences: refs,
+				},
+				Data: map[string][]byte{"foo": []byte("new")},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		gvk         schema.GroupVersionKind
+		newOwner    func() client.Object
+		optIn       func(client.Object) bool
+		objects     []client.Object
+		evt         event.UpdateEvent
+		wantEnqueue []reconcile.Request
+	}{
+		{
+			name: "vss-hmac-enabled-enqueued",
+			gvk:  vssGVK,
+			newOwner: func() client.Object {
+				return &secretsv1beta1.VaultStaticSecret{}
+			},
+			optIn: func(o client.Object) bool {
+				vss := o.(*secretsv1beta1.VaultStaticSecret)
+				return vss.Spec.HMACSecretData != nil && *vss.Spec.HMACSecretData
+			},
+			objects: []client.Object{
+				&secretsv1beta1.VaultStaticSecret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vss1"},
+					Spec:       secretsv1beta1.VaultStaticSecretSpec{HMACSecretData: ptr.To(true)},
+				},
+			},
+			evt: secretEvent(vssOwnerRef("vss1")),
+			wantEnqueue: []reconcile.Request{
+				{NamespacedName: client.ObjectKey{Namespace: "default", Name: "vss1"}},
+			},
+		},
+		{
+			name: "vss-hmac-disabled-not-enqueued",
+			gvk:  vssGVK,
+			newOwner: func() client.Object {
+				return &secretsv1beta1.VaultStaticSecret{}
+			},
+			optIn: func(o client.Object) bool {
+				vss := o.(*secretsv1beta1.VaultStaticSecret)
+				return vss.Spec.HMACSecretData != nil && *vss.Spec.HMACSecretData
+			},
+			objects: []client.Object{
+				&secretsv1beta1.VaultStaticSecret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vss1"},
+					Spec:       secretsv1beta1.VaultStaticSecretSpec{HMACSecretData: ptr.To(false)},
+				},
+			},
+			evt:         secretEvent(vssOwnerRef("vss1")),
+			wantEnqueue: nil,
+		},
+		{
+			name: "vss-hmac-unset-not-enqueued",
+			gvk:  vssGVK,
+			newOwner: func() client.Object {
+				return &secretsv1beta1.VaultStaticSecret{}
+			},
+			optIn: func(o client.Object) bool {
+				vss := o.(*secretsv1beta1.VaultStaticSecret)
+				return vss.Spec.HMACSecretData != nil && *vss.Spec.HMACSecretData
+			},
+			objects: []client.Object{
+				&secretsv1beta1.VaultStaticSecret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vss1"},
+				},
+			},
+			evt:         secretEvent(vssOwnerRef("vss1")),
+			wantEnqueue: nil,
+		},
+		{
+			name: "vds-allow-static-creds-enabled-enqueued",
+			gvk:  vdsGVK,
+			newOwner: func() client.Object {
+				return &secretsv1beta1.VaultDynamicSecret{}
+			},
+			optIn: func(o client.Object) bool {
+				vds := o.(*secretsv1beta1.VaultDynamicSecret)
+				return vds.Spec.AllowStaticCreds
+			},
+			objects: []client.Object{
+				&secretsv1beta1.VaultDynamicSecret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vds1"},
+					Spec:       secretsv1beta1.VaultDynamicSecretSpec{AllowStaticCreds: true},
+				},
+			},
+			evt: secretEvent(vdsOwnerRef("vds1")),
+			wantEnqueue: []reconcile.Request{
+				{NamespacedName: client.ObjectKey{Namespace: "default", Name: "vds1"}},
+			},
+		},
+		{
+			name: "vds-allow-static-creds-disabled-not-enqueued",
+			gvk:  vdsGVK,
+			newOwner: func() client.Object {
+				return &secretsv1beta1.VaultDynamicSecret{}
+			},
+			optIn: func(o client.Object) bool {
+				vds := o.(*secretsv1beta1.VaultDynamicSecret)
+				return vds.Spec.AllowStaticCreds
+			},
+			objects: []client.Object{
+				&secretsv1beta1.VaultDynamicSecret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vds1"},
+					Spec:       secretsv1beta1.VaultDynamicSecretSpec{AllowStaticCreds: false},
+				},
+			},
+			evt:         secretEvent(vdsOwnerRef("vds1")),
+			wantEnqueue: nil,
+		},
+		{
+			name: "unmatched-owner-gvk-not-enqueued",
+			gvk:  vssGVK,
+			newOwner: func() client.Object {
+				return &secretsv1beta1.VaultStaticSecret{}
+			},
+			optIn: func(client.Object) bool {
+				return true
+			},
+			objects:     nil,
+			evt:         secretEvent(unsupportedOwnerRef),
+			wantEnqueue: nil,
+		},
+		{
+			name: "owner-not-found-not-enqueued",
+			gvk:  vssGVK,
+			newOwner: func() client.Object {
+				return &secretsv1beta1.VaultStaticSecret{}
+			},
+			optIn: func(client.Object) bool {
+				return true
+			},
+			objects:     nil,
+			evt:         secretEvent(vssOwnerRef("does-not-exist")),
+			wantEnqueue: nil,
+		},
+		{
+			name: "mixed-owner-refs-only-matching-gvk-enqueued",
+			gvk:  vssGVK,
+			newOwner: func() client.Object {
+				return &secretsv1beta1.VaultStaticSecret{}
+			},
+			optIn: func(o client.Object) bool {
+				vss := o.(*secretsv1beta1.VaultStaticSecret)
+				return vss.Spec.HMACSecretData != nil && *vss.Spec.HMACSecretData
+			},
+			objects: []client.Object{
+				&secretsv1beta1.VaultStaticSecret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vss1"},
+					Spec:       secretsv1beta1.VaultStaticSecretSpec{HMACSecretData: ptr.To(true)},
+				},
+			},
+			evt: secretEvent(unsupportedOwnerRef, vssOwnerRef("vss1")),
+			wantEnqueue: []reconcile.Request{
+				{NamespacedName: client.ObjectKey{Namespace: "default", Name: "vss1"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := fake.NewClientBuilder().
+				WithScheme(newEnqueueOnDataChangeTestScheme(t)).
+				WithObjects(tt.objects...).
+				Build()
+
+			e := &enqueueOnDataChangeRequestHandler{
+				gvk:      tt.gvk,
+				client:   c,
+				newOwner: tt.newOwner,
+				optIn:    tt.optIn,
+			}
+
+			q := &DelegatingQueue{
+				TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueue[reconcile.Request](nil),
+			}
+
+			e.Update(ctx, tt.evt, q)
+
+			assert.ElementsMatch(t, tt.wantEnqueue, drainQueue(q))
+
+			// Create/Delete/Generic are no-ops; assert they never panic or enqueue.
+			e.Create(ctx, event.CreateEvent{}, q)
+			e.Delete(ctx, event.DeleteEvent{}, q)
+			e.Generic(ctx, event.GenericEvent{}, q)
+			assert.Empty(t, drainQueue(q))
+		})
 	}
 }

--- a/controllers/predicates.go
+++ b/controllers/predicates.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"reflect"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -89,4 +90,42 @@ func (s *secretsPredicate) Update(_ event.UpdateEvent) bool {
 
 func (s *secretsPredicate) Generic(_ event.GenericEvent) bool {
 	return false
+}
+
+// secretDataChangedPredicate lets Update events through only when a Secret's
+// .Data has actually changed, so that metadata-only updates (labels,
+// annotations, status, resourceVersion bumps with unchanged .Data) never
+// reach the event handler and trigger an unnecessary reconcile. Create,
+// Delete, and Generic events are ignored, since those are already covered by
+// the existing deletion/creation watch handling.
+type secretDataChangedPredicate struct{}
+
+func (secretDataChangedPredicate) Create(_ event.CreateEvent) bool {
+	return false
+}
+
+func (secretDataChangedPredicate) Delete(_ event.DeleteEvent) bool {
+	return false
+}
+
+func (secretDataChangedPredicate) Generic(_ event.GenericEvent) bool {
+	return false
+}
+
+func (secretDataChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
+	}
+
+	oldSecret, ok := e.ObjectOld.(*corev1.Secret)
+	if !ok {
+		return false
+	}
+
+	newSecret, ok := e.ObjectNew.(*corev1.Secret)
+	if !ok {
+		return false
+	}
+
+	return !reflect.DeepEqual(oldSecret.Data, newSecret.Data)
 }

--- a/controllers/predicates_test.go
+++ b/controllers/predicates_test.go
@@ -253,6 +253,94 @@ func assertAnnoLabelChangedOnUpdate(t *testing.T, tt testCaseAnnoLabelChanged) {
 	}
 }
 
+func Test_secretDataChangedPredicate_Update(t *testing.T) {
+	t.Parallel()
+
+	secretWithData := func(data map[string][]byte, labels map[string]string) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "dest",
+				Labels:    labels,
+			},
+			Data: data,
+		}
+	}
+
+	tests := []struct {
+		name string
+		evt  event.UpdateEvent
+		want bool
+	}{
+		{
+			name: "data-changed",
+			evt: event.UpdateEvent{
+				ObjectOld: secretWithData(map[string][]byte{"foo": []byte("bar")}, helpers.OwnerLabels),
+				ObjectNew: secretWithData(map[string][]byte{"foo": []byte("baz")}, helpers.OwnerLabels),
+			},
+			want: true,
+		},
+		{
+			name: "data-unchanged-metadata-only",
+			evt: event.UpdateEvent{
+				ObjectOld: secretWithData(map[string][]byte{"foo": []byte("bar")}, helpers.OwnerLabels),
+				ObjectNew: secretWithData(map[string][]byte{"foo": []byte("bar")}, map[string]string{"buz": "baz"}),
+			},
+			want: false,
+		},
+		{
+			name: "data-added-from-nil",
+			evt: event.UpdateEvent{
+				ObjectOld: secretWithData(nil, helpers.OwnerLabels),
+				ObjectNew: secretWithData(map[string][]byte{"foo": []byte("bar")}, helpers.OwnerLabels),
+			},
+			want: true,
+		},
+		{
+			name: "identical-objects",
+			evt: func() event.UpdateEvent {
+				s := secretWithData(map[string][]byte{"foo": []byte("bar")}, helpers.OwnerLabels)
+				return event.UpdateEvent{ObjectOld: s, ObjectNew: s}
+			}(),
+			want: false,
+		},
+		{
+			name: "nil-old-object",
+			evt: event.UpdateEvent{
+				ObjectOld: nil,
+				ObjectNew: secretWithData(map[string][]byte{"foo": []byte("bar")}, helpers.OwnerLabels),
+			},
+			want: false,
+		},
+		{
+			name: "nil-new-object",
+			evt: event.UpdateEvent{
+				ObjectOld: secretWithData(map[string][]byte{"foo": []byte("bar")}, helpers.OwnerLabels),
+				ObjectNew: nil,
+			},
+			want: false,
+		},
+		{
+			name: "not-a-secret",
+			evt: event.UpdateEvent{
+				ObjectOld: &secretsv1beta1.VaultStaticSecret{},
+				ObjectNew: &secretsv1beta1.VaultStaticSecret{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := secretDataChangedPredicate{}
+			assert.Equalf(t, tt.want, p.Update(tt.evt), "Update(%v)", tt.evt)
+			assert.False(t, p.Create(event.CreateEvent{}))
+			assert.False(t, p.Delete(event.DeleteEvent{}))
+			assert.False(t, p.Generic(event.GenericEvent{}))
+		})
+	}
+}
+
 func Test_secretsPredicate_Delete(t *testing.T) {
 	t.Parallel()
 

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -812,6 +812,31 @@ func (r *VaultDynamicSecretReconciler) SetupWithManager(mgr ctrl.Manager, opts c
 			},
 			builder.WithPredicates(&secretsPredicate{}),
 		).
+		// Watch destination Secrets for out-of-band .Data changes so that
+		// static-creds drift (allowStaticCreds=true) can be repaired within
+		// seconds instead of waiting for the next poll/requeue. This is a
+		// full-object watch (unlike the metadata-only watch above) since we
+		// need to see .Data, but it is bounded to VSO-owned Secrets by the
+		// manager's Cache.ByObject label selector (see main.go), so it does
+		// not reintroduce the cluster-wide Secret caching that
+		// Client.Cache.DisableFor was added to avoid. Normal leased dynamic
+		// secrets (allowStaticCreds=false) are unaffected: optIn below only
+		// enqueues static-creds VaultDynamicSecrets.
+		Watches(
+			&corev1.Secret{},
+			&enqueueOnDataChangeRequestHandler{
+				gvk:    secretsv1beta1.GroupVersion.WithKind(VaultDynamicSecret.String()),
+				client: mgr.GetClient(),
+				newOwner: func() client.Object {
+					return &secretsv1beta1.VaultDynamicSecret{}
+				},
+				optIn: func(owner client.Object) bool {
+					vds, ok := owner.(*secretsv1beta1.VaultDynamicSecret)
+					return ok && vds.Spec.AllowStaticCreds
+				},
+			},
+			builder.WithPredicates(&secretDataChangedPredicate{}),
+		).
 		WatchesRawSource(
 			source.Channel(r.SourceCh,
 				&enqueueDelayingSyncEventHandler{

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -639,6 +639,28 @@ func (r *VaultStaticSecretReconciler) SetupWithManager(mgr ctrl.Manager, opts co
 			},
 			builder.WithPredicates(&secretsPredicate{}),
 		).
+		// Watch destination Secrets for out-of-band .Data changes so that
+		// hmacSecretData drift can be repaired within seconds instead of
+		// waiting for the next poll/requeue. This is a full-object watch
+		// (unlike the metadata-only watch above) since we need to see
+		// .Data, but it is bounded to VSO-owned Secrets by the manager's
+		// Cache.ByObject label selector (see main.go), so it does not
+		// reintroduce cluster-wide Secret caching.
+		Watches(
+			&corev1.Secret{},
+			&enqueueOnDataChangeRequestHandler{
+				gvk:    secretsv1beta1.GroupVersion.WithKind(VaultStaticSecret.String()),
+				client: mgr.GetClient(),
+				newOwner: func() client.Object {
+					return &secretsv1beta1.VaultStaticSecret{}
+				},
+				optIn: func(owner client.Object) bool {
+					vss, ok := owner.(*secretsv1beta1.VaultStaticSecret)
+					return ok && vss.Spec.HMACSecretData != nil && *vss.Spec.HMACSecretData
+				},
+			},
+			builder.WithPredicates(&secretDataChangedPredicate{}),
+		).
 		WatchesRawSource(
 			source.Channel(r.SourceCh,
 				&enqueueDelayingSyncEventHandler{

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -436,6 +437,22 @@ func main() {
 				// the operator.
 				DisableFor: []client.Object{
 					&corev1.Secret{},
+				},
+			},
+		},
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				// The VaultStaticSecret/VaultDynamicSecret controllers watch
+				// destination Secrets for out-of-band data changes, to repair
+				// drift faster than the next poll/requeue. That watch requires
+				// a full-object (not metadata-only) informer for Secrets, which
+				// would otherwise cache every Secret in the cluster. Scope it
+				// down to only the Secrets VSO manages, identified by the
+				// owner labels it always sets on them (see helpers.OwnerLabels),
+				// so this does not reintroduce the OOM risk that DisableFor
+				// above was added to avoid.
+				&corev1.Secret{}: {
+					Label: labels.SelectorFromSet(helpers.OwnerLabels),
 				},
 			},
 		},


### PR DESCRIPTION
Watch destination Secrets owned by VaultStaticSecret (hmacSecretData=true) and VaultDynamicSecret (allowStaticCreds=true) for out-of-band .Data changes, and enqueue the owning CR for reconciliation immediately instead of waiting on the next poll/requeue. Repair logic is unchanged: the existing secretMAC/HMAC comparison already re-validates the live destination Secret on every Reconcile, so this only changes when that check runs, not how drift is detected or repaired.

- enqueueOnDataChangeRequestHandler (controllers/eventhandlers.go) maps a Secret Update event to its owning CR via OwnerReferences, fetches that CR, and only enqueues it if the CR has opted in (HMACSecretData for VSS, AllowStaticCreds for VDS). CRs that haven't opted in see no behavior change.
- secretDataChangedPredicate (controllers/predicates.go) filters Update events to only those where .Data actually changed, so metadata-only Secret writes (labels/annotations/resourceVersion bumps) never reach the handler.
- Both controllers register an additional Watches(&corev1.Secret{}, ...) alongside the existing metadata-only deletion watch.
- main.go scopes the manager's default cache for Secrets to VSO-owned Secrets only (via the same owner-label selector already applied to every destination Secret), so the new full-object watch does not reintroduce cluster-wide Secret caching.



## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
