### PR TITLE
feat: add support for additional annotations in controller ServiceAcc…

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -11,6 +11,10 @@ metadata:
   labels:
     app.kubernetes.io/component: controller-manager
   {{- include "vso.chart.labels" . | nindent 4 }}
+  {{- with .Values.controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{ include "vso.imagePullSecrets" .Values.controller.imagePullSecrets }}
 ---
 apiVersion: apps/v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -185,6 +185,10 @@ controller:
         cpu: 5m
         memory: 64Mi
 
+  # Additional annotations for the controller ServiceAccount. This should be formatted as a YAML object (map).
+  serviceAccount:
+    annotations: {}
+
   # Image pull secret to use for private container registry authentication which will be applied to the controllers
   # service account. Alternatively, the value may be specified as an array of strings.
   # Example:


### PR DESCRIPTION
## Reason and description

Allow users to configure annotations on the controller ServiceAccount through Helm values using `controller.serviceAccount.annotations`. This supports integrations that rely on ServiceAccount annotations, such as cloud workload identity mechanisms.

Closes https://github.com/hashicorp/vault-secrets-operator/issues/1226

## Revert plan

Reverting this pull request restores the previous behavior. No additional rollback steps are required.

## Security controls impact

This change does not modify the operator's RBAC permissions, authentication flow, or logging configuration. It only allows users to add metadata annotations to the controller ServiceAccount. Any security impact depends on the annotations explicitly configured by the chart user, such as cloud identity or IAM role bindings.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

