### PR TITLE
Resolve data races in mount cache and websocket connection.

### DIFF
--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -839,7 +839,7 @@ func (r *VaultDynamicSecretReconciler) SetupWithManager(mgr ctrl.Manager, opts c
 	)
 
 	// TODO: close this channel when the controller is stopped.
-	r.SourceCh = make(chan event.GenericEvent)
+	r.SourceCh = make(chan event.GenericEvent, 4)
 	m := ctrl.NewControllerManagedBy(mgr).
 		For(&secretsv1beta1.VaultDynamicSecret{}).
 		WithOptions(opts).

--- a/controllers/vaultdynamicsecret_controller.go
+++ b/controllers/vaultdynamicsecret_controller.go
@@ -1068,12 +1068,7 @@ func (r *VaultDynamicSecretReconciler) vaultClientCallback(ctx context.Context, 
 				r.SyncRegistry.Add(objKey)
 				logger.V(consts.LogLevelDebug).Info(
 					"Sending GenericEvent to the SourceCh", "evt", evt)
-				select {
-				case r.SourceCh <- evt:
-				default:
-					logger.V(consts.LogLevelWarning).Info(
-						"SourceCh full, dropping client-callback event", "objKey", objKey)
-				}
+				r.SourceCh <- evt
 			}
 		} else if err != nil {
 			logger.V(consts.LogLevelWarning).Info(

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -3052,6 +3052,15 @@ func TestVaultDynamicSecretReconciler_vaultClientCallback_BlocksOnFullSourceCh(t
 		r.vaultClientCallback(ctx, c)
 	}()
 
+	require.Eventually(t, func() bool {
+		return len(sourceCh) == cap(sourceCh)
+	}, time.Second, time.Millisecond, "callback must fill SourceCh before blocking")
+	select {
+	case <-callbackDone:
+		t.Fatal("callback returned while SourceCh was full; events may have been dropped")
+	default:
+	}
+
 	// Consume all instanceCount events from the channel. Each read unblocks the
 	// next blocking send in the callback goroutine.
 	received := 0

--- a/controllers/vaultdynamicsecret_controller_test.go
+++ b/controllers/vaultdynamicsecret_controller_test.go
@@ -2994,3 +2994,83 @@ func Test_VDS_ensureEventWatcher_OnStop_CleansRegistry(t *testing.T) {
 	_, ok = r.eventWatcherRegistry.Get(key)
 	assert.False(t, ok, "registry entry must be deleted after OnStop fires")
 }
+
+// TestVaultDynamicSecretReconciler_vaultClientCallback_BlocksOnFullSourceCh
+// verifies that vaultClientCallback delivers events to ALL matching CRs even
+// when SourceCh has a smaller buffer than the number of matching instances.
+func TestVaultDynamicSecretReconciler_vaultClientCallback_BlocksOnFullSourceCh(t *testing.T) {
+	t.Parallel()
+
+	// Key must match the cacheKeyRe pattern: [provider]-[22 hex chars].
+	cacheKey := vault.ClientCacheKey(fmt.Sprintf("%s-%s", consts.ProviderMethodKubernetes, "aabbccddee1122334455aa"))
+
+	// Create 6 matching VaultDynamicSecret instances — more than any reasonable
+	// small buffer — all sharing the same client cache key.
+	const instanceCount = 6
+	instances := make([]*secretsv1beta1.VaultDynamicSecret, instanceCount)
+	for i := range instances {
+		instances[i] = &secretsv1beta1.VaultDynamicSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      fmt.Sprintf("vds-%d", i),
+			},
+			Status: secretsv1beta1.VaultDynamicSecretStatus{
+				VaultClientMeta: secretsv1beta1.VaultClientMeta{
+					CacheKey: string(cacheKey),
+				},
+			},
+		}
+	}
+
+	// SourceCh is intentionally smaller than instanceCount to force the blocking
+	// send path. A buffer of 1 means only the first send completes immediately;
+	// all subsequent sends must block until the consumer reads.
+	sourceCh := make(chan event.GenericEvent, 1)
+	r := &VaultDynamicSecretReconciler{
+		Client:       testutils.NewFakeClient(),
+		SyncRegistry: NewSyncRegistry(),
+		SourceCh:     sourceCh,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for _, o := range instances {
+		require.NoError(t, r.Create(ctx, o))
+	}
+
+	c := &stubVaultClient{
+		cacheKey:           cacheKey,
+		credentialProvider: &stubCredentialProvider{namespace: "default"},
+	}
+
+	// Run vaultClientCallback in its own goroutine (mirrors production: it is
+	// always spawned by callClientCallbacks, never called on the hot path).
+	callbackDone := make(chan struct{})
+	go func() {
+		defer close(callbackDone)
+		r.vaultClientCallback(ctx, c)
+	}()
+
+	// Consume all instanceCount events from the channel. Each read unblocks the
+	// next blocking send in the callback goroutine.
+	received := 0
+	for received < instanceCount {
+		select {
+		case <-sourceCh:
+			received++
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out after receiving %d/%d events; blocking send did not unblock", received, instanceCount)
+		}
+	}
+
+	// Callback goroutine must finish now that all sends have completed.
+	select {
+	case <-callbackDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("vaultClientCallback goroutine did not finish after all events were consumed")
+	}
+
+	assert.Equal(t, instanceCount, received,
+		"all %d matching CRs must be reconciled even with a small SourceCh buffer", instanceCount)
+}

--- a/controllers/vaultstaticsecret_controller.go
+++ b/controllers/vaultstaticsecret_controller.go
@@ -597,12 +597,7 @@ func (r *VaultStaticSecretReconciler) vaultClientCallback(ctx context.Context, c
 					"objKey", objKey)
 				logger.V(consts.LogLevelDebug).Info(
 					"Sending GenericEvent to the SourceCh", "evt", evt)
-				select {
-				case r.SourceCh <- evt:
-				default:
-					logger.V(consts.LogLevelWarning).Info(
-						"SourceCh full, dropping client-callback event", "objKey", objKey)
-				}
+				r.SourceCh <- evt
 			}
 		} else if err != nil {
 			logger.V(consts.LogLevelWarning).Info(

--- a/controllers/vaultstaticsecret_controller_test.go
+++ b/controllers/vaultstaticsecret_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,7 @@ import (
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
 	vsoconsts "github.com/hashicorp/vault-secrets-operator/consts"
+	"github.com/hashicorp/vault-secrets-operator/credentials/provider"
 	"github.com/hashicorp/vault-secrets-operator/helpers"
 	"github.com/hashicorp/vault-secrets-operator/internal/testutils"
 	"github.com/hashicorp/vault-secrets-operator/vault"
@@ -732,3 +734,102 @@ func Test_VSS_ensureEventWatcher_SubscribeError(t *testing.T) {
 	_, ok := r.eventWatcherRegistry.Get(key)
 	assert.False(t, ok, "registry must not have an entry when subscribe failed")
 }
+
+// TestVaultStaticSecretReconciler_vaultClientCallback_BlocksOnFullSourceCh
+// verifies that vaultClientCallback delivers events to ALL matching CRs even
+// when SourceCh has a smaller buffer than the number of matching instances.
+func TestVaultStaticSecretReconciler_vaultClientCallback_BlocksOnFullSourceCh(t *testing.T) {
+	t.Parallel()
+
+	// Key must match the cacheKeyRe pattern: [provider]-[22 hex chars].
+	cacheKey := fmt.Sprintf("%s-%s", "kubernetes", "aabbccddee1122334455bb")
+
+	// Create 6 matching VaultStaticSecret instances — more than any reasonable
+	// small buffer — all sharing the same client cache key.
+	const instanceCount = 6
+	instances := make([]*secretsv1beta1.VaultStaticSecret, instanceCount)
+	for i := range instances {
+		instances[i] = &secretsv1beta1.VaultStaticSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      fmt.Sprintf("vss-%d", i),
+			},
+			Status: secretsv1beta1.VaultStaticSecretStatus{
+				VaultClientMeta: secretsv1beta1.VaultClientMeta{
+					CacheKey: cacheKey,
+				},
+			},
+		}
+	}
+
+	// SourceCh is intentionally smaller than instanceCount to force the blocking
+	// send path. A buffer of 1 means only the first send completes immediately;
+	// all subsequent sends must block until the consumer reads.
+	sourceCh := make(chan event.GenericEvent, 1)
+	fakeClient := testutils.NewFakeClient()
+	r := &VaultStaticSecretReconciler{
+		Client:   fakeClient,
+		SourceCh: sourceCh,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for _, o := range instances {
+		require.NoError(t, r.Create(ctx, o))
+	}
+
+	c := &stubVSSClient{
+		cacheKey:  vault.ClientCacheKey(cacheKey),
+		namespace: "default",
+	}
+
+	// Run vaultClientCallback in its own goroutine (mirrors production: it is
+	// always spawned by callClientCallbacks, never called on the hot path).
+	callbackDone := make(chan struct{})
+	go func() {
+		defer close(callbackDone)
+		r.vaultClientCallback(ctx, c)
+	}()
+
+	// Consume all instanceCount events from the channel. Each read unblocks the
+	// next blocking send in the callback goroutine.
+	received := 0
+	for received < instanceCount {
+		select {
+		case <-sourceCh:
+			received++
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out after receiving %d/%d events; blocking send did not unblock", received, instanceCount)
+		}
+	}
+
+	// Callback goroutine must finish now that all sends have completed.
+	select {
+	case <-callbackDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("vaultClientCallback goroutine did not finish after all events were consumed")
+	}
+
+	assert.Equal(t, instanceCount, received,
+		"all %d matching CRs must be reconciled even with a small SourceCh buffer", instanceCount)
+}
+
+// stubVSSClient is a minimal vault.Client stub for vaultClientCallback tests.
+type stubVSSClient struct {
+	vault.Client
+	cacheKey  vault.ClientCacheKey
+	namespace string
+}
+
+func (c *stubVSSClient) GetCacheKey() (vault.ClientCacheKey, error) { return c.cacheKey, nil }
+func (c *stubVSSClient) GetCredentialProvider() provider.CredentialProviderBase {
+	return &stubVSSCredentialProvider{namespace: c.namespace}
+}
+
+type stubVSSCredentialProvider struct {
+	provider.CredentialProviderBase
+	namespace string
+}
+
+func (p *stubVSSCredentialProvider) GetNamespace() string { return p.namespace }

--- a/controllers/vaultstaticsecret_controller_test.go
+++ b/controllers/vaultstaticsecret_controller_test.go
@@ -792,6 +792,15 @@ func TestVaultStaticSecretReconciler_vaultClientCallback_BlocksOnFullSourceCh(t 
 		r.vaultClientCallback(ctx, c)
 	}()
 
+	require.Eventually(t, func() bool {
+		return len(sourceCh) == cap(sourceCh)
+	}, time.Second, time.Millisecond, "callback must fill SourceCh before blocking")
+	select {
+	case <-callbackDone:
+		t.Fatal("callback returned while SourceCh was full; events may have been dropped")
+	default:
+	}
+
 	// Consume all instanceCount events from the channel. Each read unblocks the
 	// next blocking send in the callback goroutine.
 	received := 0

--- a/vault/client.go
+++ b/vault/client.go
@@ -544,21 +544,21 @@ func (c *defaultClient) GetMountType(ctx context.Context, mountPath string) (str
 		return "", fmt.Errorf("mount path cannot be empty")
 	}
 
-	// Fast path: cache hit under read lock.
+	// Check closed first, then cache. Holding c.mu.RLock while reading the
+	// cache ensures that Close() (which holds c.mu.Lock before mountTypeMu)
+	// cannot sneak between the closed check and the cache read, so a closed
+	// client never returns a stale cached value.
+	c.mu.RLock()
+	if c.closed {
+		c.mu.RUnlock()
+		return "", fmt.Errorf("client instance is closed")
+	}
 	c.mountTypeMu.RLock()
 	t, ok := c.mountTypeCache[mountPath]
 	c.mountTypeMu.RUnlock()
+	c.mu.RUnlock()
 	if ok {
 		return t, nil
-	}
-
-	// Point-in-time closed check; c.Read will fail independently if the client
-	// is closed between here and the network call.
-	c.mu.RLock()
-	closed := c.closed
-	c.mu.RUnlock()
-	if closed {
-		return "", fmt.Errorf("client instance is closed")
 	}
 
 	// Cache miss — call Vault with no lock held so c.mu users are not blocked.
@@ -572,16 +572,23 @@ func (c *defaultClient) GetMountType(ctx context.Context, mountPath string) (str
 		return "", fmt.Errorf("missing or empty type field in sys/mounts/%s response", mountPath)
 	}
 
-	// Populate cache under write lock with double-check so that two concurrent
-	// misses for the same path store identical results without conflicting.
+	// Populate cache under both locks (c.mu before mountTypeMu, matching the
+	// order Close() uses) so that a slow in-flight call cannot repopulate the
+	// cache after Close() has cleared it.
+	c.mu.RLock()
 	c.mountTypeMu.Lock()
+	defer c.mountTypeMu.Unlock()
+	defer c.mu.RUnlock()
+
+	if c.closed {
+		return "", fmt.Errorf("client instance is closed")
+	}
 	if c.mountTypeCache == nil {
 		c.mountTypeCache = make(map[string]string)
 	}
 	if _, exists := c.mountTypeCache[mountPath]; !exists {
 		c.mountTypeCache[mountPath] = mountType
 	}
-	c.mountTypeMu.Unlock()
 
 	return mountType, nil
 }

--- a/vault/client.go
+++ b/vault/client.go
@@ -236,6 +236,10 @@ type defaultClient struct {
 	mu                 sync.RWMutex
 	id                 string
 	mountTypeCache     map[string]string
+	// mountTypeMu guards mountTypeCache only, keeping cache reads/writes
+	// independent of c.mu so that a slow sys/mounts network call never blocks
+	// token renewal, Close, or other c.mu users.
+	mountTypeMu sync.RWMutex
 	// websockets stores SharedWebSocket instances per event type
 	websockets  map[EventType]*SharedWebSocket
 	websocketMu sync.RWMutex
@@ -517,36 +521,47 @@ func (c *defaultClient) Close(revoke bool) {
 				"Failed to revoke Vault client token", "err", err)
 		}
 	}
-	c.mountTypeCache = nil
 	c.id = ""
 	c.closed = true
+
+	// Clear the mount-type cache under its own lock (not c.mu) because
+	// mountTypeMu is the sole owner of mountTypeCache after M2 fix.
+	c.mountTypeMu.Lock()
+	c.mountTypeCache = nil
+	c.mountTypeMu.Unlock()
 }
 
 // GetMountType returns the Vault plugin type for a mount path.
 // Results are cached per-client to avoid repeated sys/mounts lookups.
 //
-// A single write-lock is held for the entire cache-miss path (including the
-// Vault read) so that concurrent reconciles for the same mount only produce one
-// outbound request. c.Read does not acquire c.mu, so there is no self-deadlock.
+// mountTypeMu (not c.mu) guards the cache so that a slow sys/mounts network
+// call on a cache miss never blocks token renewal, Close, or other c.mu users.
+// A double-check after the write-lock handles concurrent cache misses: both
+// goroutines issue a Vault read, but only one stores the result.
 func (c *defaultClient) GetMountType(ctx context.Context, mountPath string) (string, error) {
 	mountPath = strings.Trim(mountPath, "/")
 	if mountPath == "" {
 		return "", fmt.Errorf("mount path cannot be empty")
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.closed {
-		return "", fmt.Errorf("client instance is closed")
-	}
-	if t, ok := c.mountTypeCache[mountPath]; ok {
+	// Fast path: cache hit under read lock.
+	c.mountTypeMu.RLock()
+	t, ok := c.mountTypeCache[mountPath]
+	c.mountTypeMu.RUnlock()
+	if ok {
 		return t, nil
 	}
 
-	// Cache miss — call Vault while holding the lock so that a second goroutine
-	// that also misses the cache waits here and then hits the cache on its next
-	// iteration, rather than issuing a duplicate sys/mounts request.
+	// Point-in-time closed check; c.Read will fail independently if the client
+	// is closed between here and the network call.
+	c.mu.RLock()
+	closed := c.closed
+	c.mu.RUnlock()
+	if closed {
+		return "", fmt.Errorf("client instance is closed")
+	}
+
+	// Cache miss — call Vault with no lock held so c.mu users are not blocked.
 	resp, err := c.Read(ctx, NewReadRequest("sys/mounts/"+mountPath, nil, nil))
 	if err != nil {
 		return "", fmt.Errorf("failed to read mount info for %q: %w", mountPath, err)
@@ -557,10 +572,16 @@ func (c *defaultClient) GetMountType(ctx context.Context, mountPath string) (str
 		return "", fmt.Errorf("missing or empty type field in sys/mounts/%s response", mountPath)
 	}
 
+	// Populate cache under write lock with double-check so that two concurrent
+	// misses for the same path store identical results without conflicting.
+	c.mountTypeMu.Lock()
 	if c.mountTypeCache == nil {
 		c.mountTypeCache = make(map[string]string)
 	}
-	c.mountTypeCache[mountPath] = mountType
+	if _, exists := c.mountTypeCache[mountPath]; !exists {
+		c.mountTypeCache[mountPath] = mountType
+	}
+	c.mountTypeMu.Unlock()
 
 	return mountType, nil
 }

--- a/vault/client_test.go
+++ b/vault/client_test.go
@@ -1739,3 +1739,81 @@ func TestClient_UserAgentHeader(t *testing.T) {
 		})
 	}
 }
+
+// Test_defaultClient_GetMountType_ErrorAfterClose verifies two closed-client
+// cache regression scenarios fixed by the c.mu-before-mountTypeMu ordering:
+//
+//  1. A cached entry must not be served after Close() — the closed check now
+//     runs first (under c.mu.RLock) so the fast-path cache read is skipped.
+//
+//  2. A slow in-flight call that completes its network round-trip after Close()
+//     must not repopulate the cache — the write-path re-checks c.closed while
+//     holding both c.mu.RLock and mountTypeMu.Lock before storing.
+func Test_defaultClient_GetMountType_ErrorAfterClose(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cached entry returns error after Close", func(t *testing.T) {
+		t.Parallel()
+
+		// Construct a client that is already closed and already has a warm cache.
+		c := &defaultClient{
+			mountTypeCache: map[string]string{"database": "database"},
+			closed:         true,
+		}
+
+		_, err := c.GetMountType(context.Background(), "database")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client instance is closed",
+			"GetMountType must fail when client is closed even if mount type is cached")
+	})
+
+	t.Run("slow in-flight call cannot repopulate cache after Close", func(t *testing.T) {
+		t.Parallel()
+
+		// Set up a server that hangs until we release it, simulating the window
+		// between "network call dispatched" and "write lock acquired".
+		release := make(chan struct{})
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			<-release // block until the test closes the client
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"type":"database"}}`))
+		}))
+		defer server.Close()
+
+		cfg := api.DefaultConfig()
+		cfg.Address = server.URL
+		apiClient, err := api.NewClient(cfg)
+		require.NoError(t, err)
+
+		c := &defaultClient{client: apiClient}
+
+		// Start the GetMountType call in a goroutine; it will block in the HTTP
+		// server handler until we release it.
+		done := make(chan error, 1)
+		go func() {
+			_, err := c.GetMountType(context.Background(), "database")
+			done <- err
+		}()
+
+		// Close the client while the network call is in-flight.
+		// Small sleep gives the goroutine time to reach the HTTP handler.
+		time.Sleep(20 * time.Millisecond)
+		c.Close(false)
+
+		// Unblock the server so the goroutine can attempt to write to the cache.
+		close(release)
+
+		// The in-flight call must return either a network/context error (if the
+		// http client is torn down) or "client instance is closed" (if it managed
+		// to get a response but was rejected at the write-lock closed recheck).
+		// Either way, the cache must not be repopulated.
+		<-done
+		c.mu.RLock()
+		c.mountTypeMu.RLock()
+		cacheNil := c.mountTypeCache == nil
+		c.mountTypeMu.RUnlock()
+		c.mu.RUnlock()
+		assert.True(t, cacheNil,
+			"mountTypeCache must remain nil after Close even if an in-flight call returned a result")
+	})
+}

--- a/vault/client_test.go
+++ b/vault/client_test.go
@@ -1772,8 +1772,10 @@ func Test_defaultClient_GetMountType_ErrorAfterClose(t *testing.T) {
 
 		// Set up a server that hangs until we release it, simulating the window
 		// between "network call dispatched" and "write lock acquired".
+		started := make(chan struct{})
 		release := make(chan struct{})
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			close(started)
 			<-release // block until the test closes the client
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"data":{"type":"database"}}`))
@@ -1795,9 +1797,8 @@ func Test_defaultClient_GetMountType_ErrorAfterClose(t *testing.T) {
 			done <- err
 		}()
 
-		// Close the client while the network call is in-flight.
-		// Small sleep gives the goroutine time to reach the HTTP handler.
-		time.Sleep(20 * time.Millisecond)
+		// Close the client after the network call is in-flight.
+		<-started
 		c.Close(false)
 
 		// Unblock the server so the goroutine can attempt to write to the cache.

--- a/vault/event_subscription.go
+++ b/vault/event_subscription.go
@@ -39,13 +39,10 @@ const (
 // SharedWebSocket manages a single WebSocket connection with multiple subscribers
 type SharedWebSocket struct {
 	// conn is the underlying WebSocket connection.
-	// Writes (reconnect, Close) and reads from IsHealthy/Close may happen on
-	// different goroutines, so all cross-goroutine accesses must hold connMu.
-	// Accesses inside the event-loop goroutine itself (readAndRoute, eventLoop
-	// done-handler) are inherently sequential with reconnect and do NOT lock,
-	// to avoid a self-deadlock where reconnect holds connMu while calling
-	// wsClient.Connect, and readAndRoute tries to lock connMu on the same
-	// goroutine.
+	// All cross-goroutine accesses snapshot the pointer under connMu.RLock for
+	// just the load, then release before calling any method on the connection.
+	// This protects the pointer against a concurrent Close() zeroing it while
+	// never holding connMu across a blocking network call.
 	conn   *websocket.Conn
 	connMu sync.RWMutex
 	// stopped indicates that the event loop has exited and this websocket should
@@ -219,8 +216,11 @@ func (ws *SharedWebSocket) eventLoop() {
 		select {
 		case <-ws.ctx.Done():
 			ws.logger.V(consts.LogLevelDebug).Info("Context cancelled, stopping event loop")
-			if ws.conn != nil {
-				ws.conn.Close(websocket.StatusNormalClosure, "context cancelled")
+			ws.connMu.RLock()
+			conn := ws.conn
+			ws.connMu.RUnlock()
+			if conn != nil {
+				conn.Close(websocket.StatusNormalClosure, "context cancelled")
 			}
 			return
 		default:
@@ -251,8 +251,11 @@ func (ws *SharedWebSocket) eventLoop() {
 						ws.logger.Error(reconnErr, "Too many reconnect failures, stopping event loop",
 							"errorCount", errorCount, "threshold", maxReconnectErrorThreshold)
 						ws.notifyOnStop = true
-						if ws.conn != nil {
-							ws.conn.Close(websocket.StatusNormalClosure, "reconnect threshold reached")
+						ws.connMu.RLock()
+						conn := ws.conn
+						ws.connMu.RUnlock()
+						if conn != nil {
+							conn.Close(websocket.StatusNormalClosure, "reconnect threshold reached")
 						}
 						ws.cancel()
 						return
@@ -318,7 +321,13 @@ func (ws *SharedWebSocket) notifySubscribersOfStop() {
 				// resync. Spawn a goroutine to block-send so delivery is
 				// guaranteed without holding the subscriber lock.
 				ch := sub.ReconcileCh
-				go func() { ch <- evt }()
+				ctx := ws.ctx
+				go func() {
+					select {
+					case ch <- evt:
+					case <-ctx.Done():
+					}
+				}()
 				ws.logger.V(consts.LogLevelDebug).Info("ReconcileCh full, scheduled async requeue",
 					"subscriber", subKey)
 			}
@@ -329,7 +338,13 @@ func (ws *SharedWebSocket) notifySubscribersOfStop() {
 // readAndRoute reads a single message from the WebSocket and routes it.
 // Uses sync.Pool to reduce GC pressure for unmatched events.
 func (ws *SharedWebSocket) readAndRoute() error {
-	msgType, message, err := ws.conn.Read(ws.ctx)
+	ws.connMu.RLock()
+	conn := ws.conn
+	ws.connMu.RUnlock()
+	if conn == nil {
+		return fmt.Errorf("connection is nil")
+	}
+	msgType, message, err := conn.Read(ws.ctx)
 	if err != nil {
 		return fmt.Errorf("failed to read from websocket: %w", err)
 	}

--- a/vault/event_subscription.go
+++ b/vault/event_subscription.go
@@ -257,6 +257,11 @@ func (ws *SharedWebSocket) eventLoop() {
 						if conn != nil {
 							conn.Close(websocket.StatusNormalClosure, "reconnect threshold reached")
 						}
+						// Notify subscribers before canceling the context so that the
+						// async fallback goroutine in notifySubscribersOfStop can still
+						// send on ReconcileCh without racing against ctx.Done().
+						ws.notifySubscribersOfStop()
+						ws.notifyOnStop = false // already notified; skip the deferred call
 						ws.cancel()
 						return
 					}

--- a/vault/event_subscription_test.go
+++ b/vault/event_subscription_test.go
@@ -1609,3 +1609,69 @@ func TestSharedWebSocket_RouteEvent_KV_StillWorksWithBranching(t *testing.T) {
 	evt := <-ch
 	assert.Equal(t, "my-vss", evt.Object.GetName())
 }
+
+// TestSharedWebSocket_EventLoop_ThresholdHit_FullReconcileChDelivered verifies
+// that when the reconnect-failure threshold is reached AND the subscriber's
+// ReconcileCh is already full, the requeue event is still eventually delivered.
+//
+// This tests the fix for review issue #2: notifySubscribersOfStop() is now
+// called BEFORE ws.cancel(), so the async fallback goroutine's ctx.Done() select
+// arm is not immediately ready, and the blocking channel send can complete.
+func TestSharedWebSocket_EventLoop_ThresholdHit_FullReconcileChDelivered(t *testing.T) {
+	// Use a buffered channel of capacity 1 and pre-fill it so the fast-path
+	// send inside notifySubscribersOfStop falls through to the async goroutine.
+	reconcileCh := make(chan event.GenericEvent, 1)
+	reconcileCh <- event.GenericEvent{} // pre-fill → channel is full
+
+	resourceKey := types.NamespacedName{Namespace: "default", Name: "vss-instant"}
+	onStopCalled := false
+	sub := &Subscriber{
+		ResourceKey:  resourceKey,
+		VaultPath:    "kv/data/app/config",
+		ResourceType: ResourceTypeVaultStaticSecret,
+		ReconcileCh:  reconcileCh,
+		OnStop:       func() { onStopCalled = true },
+		NewObject: func() client.Object {
+			return &secretsv1beta1.VaultStaticSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: resourceKey.Namespace,
+					Name:      resourceKey.Name,
+				},
+			}
+		},
+	}
+
+	ws := newTestSharedWebSocket(EventTypeKV)
+	require.NoError(t, ws.Subscribe(sub))
+
+	// Simulate the reconnect-threshold path: call notifySubscribersOfStop
+	// BEFORE canceling the context — exactly what the fixed eventLoop code does
+	// at the threshold.
+	ws.notifyOnStop = true
+	ws.notifySubscribersOfStop()
+	ws.notifyOnStop = false // already notified; deferred call is a no-op
+
+	// OnStop must have fired synchronously.
+	assert.True(t, onStopCalled, "OnStop must fire even when ReconcileCh is full")
+
+	// Drain the pre-filled dummy event BEFORE canceling ws.ctx. This mirrors
+	// production where the controller-runtime consumer is always reading the
+	// channel: the async goroutine sees the channel become writable and sends.
+	// Draining here unblocks the goroutine's blocking channel send so it can
+	// complete while ws.ctx is still live.
+	<-reconcileCh
+
+	// The async goroutine must deliver the requeue event within a short
+	// deadline. ws.ctx has not been canceled yet, so the goroutine can send.
+	select {
+	case evt := <-reconcileCh:
+		assert.NotNil(t, evt.Object,
+			"requeue event must carry a non-nil object")
+		assert.Equal(t, resourceKey.Name, evt.Object.GetName())
+	case <-time.After(time.Second):
+		t.Fatal("timed out: requeue event was not delivered after threshold-hit with full ReconcileCh")
+	}
+
+	// Now cancel — after the event has been delivered.
+	ws.cancel()
+}


### PR DESCRIPTION
- Fixes a data race on `ws.conn` in the WebSocket event loop where `Close()` could zero the pointer concurrently with bare reads in `readAndRoute` and `eventLoop`. 
- Removes a goroutine leak in `notifySubscribersOfStop` and decouples `GetMountType` from the global client lock so a slow `sys/mounts` call can no longer block token renewal. 
- Buffers the VDS SourceCh to 4 to match VSS and prevent silent event drops on client rotation.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
